### PR TITLE
Support passphrase in https options

### DIFF
--- a/js/webserver.js
+++ b/js/webserver.js
@@ -63,6 +63,9 @@ WebServer.prototype = {
     if (this.config.https.certificateRevocationLists) {
       this.httpsOptions.crl = util.readFilesToArray(this.config.https.certificateRevocationLists);
     };
+    if (this.config.https.passphrase) {
+      this.httpsOptions.passphrase = this.config.https.passphrase
+    }
   },
 
   isConfigValid(config) {


### PR DESCRIPTION
This PR adds a new field to the https options named `passphrase` 
to allow PKCS12 key store (provided in pfx option) with a password.

The certificates generated by Zowe APIML can use passwords.

Resolves zowe/api-layer#92