### PR TITLE
Updating old proxy and example paths to app server and framework

### DIFF
--- a/js/plugin-loader.js
+++ b/js/plugin-loader.js
@@ -192,7 +192,7 @@ Plugin.prototype = {
   },
   
   init(context) {
-    //Nothing here anymore: startup checks for validity will be superceeded by https://github.com/zowe/zlux-proxy-server/pull/18 and initialization concept has not manifested for many plugin types, so a warning is not needed.
+    //Nothing here anymore: startup checks for validity will be superceeded by https://github.com/zowe/zlux-server-framework/pull/18 and initialization concept has not manifested for many plugin types, so a warning is not needed.
   },
   
   exportDef() {
@@ -434,7 +434,7 @@ NodeAuthenticationPlugIn.prototype = {
   
   init(context) {
     let filepath = path.join(this.location, 'lib', this.filename);
-	// Make the relative path clear. process.cwd() is zlux-example-server/bin/
+	// Make the relative path clear. process.cwd() is zlux-app-server/bin/
     if (!path.isAbsolute(filepath)) {
       filepath = path.join(process.cwd(),filepath);
     }

--- a/test/plugin-loader/depgraph.js
+++ b/test/plugin-loader/depgraph.js
@@ -1,7 +1,7 @@
 const assert = require('assert')
 const Depgraph = require('depgraph')
 const depTestData = require('./depgraph-test-data')
-const pd = "..\..\..\\zlux-example-server\\deploy\\product"
+const pd = "..\..\..\\zlux-app-server\\deploy\\product"
   
 describe('degpraph', function() {
   it('should correctly install plugins with valid deps', function() {

--- a/test/webserver/multibind.js
+++ b/test/webserver/multibind.js
@@ -1,6 +1,6 @@
 const assert = require('assert')
 const zluxUtil = require('../../js/util.js')
-const pd = "..\..\..\\zlux-example-server\\deploy\\product"
+const pd = "..\..\..\\zlux-app-server\\deploy\\product"
   
 global.COM_RS_COMMON_LOGGER.setLogLevelForComponentPattern("_unp.network", 5);
 


### PR DESCRIPTION
zlux-proxy-server was renamed to zlux-server-framework, and zlux-example-server was renamed to zlux-app-server. There was some hardcoding so this should remedy it.
Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>