### PR TITLE
lib/util.js typo

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -12,7 +12,7 @@
 'use strict';
 
 if (!global.COM_RS_COMMON_LOGGER) {
-  const loggerFile = require('../../zlux-shared/src/logging/logger.js');
+  const loggerFile = require('../../zlux-shared/src/logging/logger.ts');
   global.COM_RS_COMMON_LOGGER = new loggerFile.Logger();
   global.COM_RS_COMMON_LOGGER.addDestination(global.COM_RS_COMMON_LOGGER.makeDefaultDestination(true,true,true));
 }

--- a/lib/util.js
+++ b/lib/util.js
@@ -12,7 +12,7 @@
 'use strict';
 
 if (!global.COM_RS_COMMON_LOGGER) {
-  const loggerFile = require('../../zlux-shared/src/logging/logger.ts');
+  const loggerFile = require('../../zlux-shared/src/logging/logger.js');
   global.COM_RS_COMMON_LOGGER = new loggerFile.Logger();
   global.COM_RS_COMMON_LOGGER.addDestination(global.COM_RS_COMMON_LOGGER.makeDefaultDestination(true,true,true));
 }


### PR DESCRIPTION
I was trying to run zlux-app-server/bin/nodeServer.sh when I noticed this. This one-char typo in zlux-server-framework/lib/util.js was making Node complain that the logger did not exist: it was looking for a JS file but found a TS file.

Best,
Michael Roffo