### PR TITLE
Feature/auth refresh

### DIFF
--- a/lib/webapp.js
+++ b/lib/webapp.js
@@ -670,7 +670,9 @@ WebApp.prototype = {
     this._installRootService('/auth', 'post', this.auth.doLogin, 
         {needJson: true, needAuth: false, isPseudoSso: true});
     this._installRootService('/auth', 'get', this.auth.getStatus, 
-      {needJson: true, needAuth: false, isPseudoSso: true});
+        {needJson: true, needAuth: false, isPseudoSso: true});
+    this._installRootService('/auth-refresh', 'get', this.auth.refreshStatus, 
+        {needJson: true, needAuth: false, isPseudoSso: true});    
     this._installRootService('/auth-logout', 'post', this.auth.doLogout, 
         {needJson: true, needAuth: false, isPseudoSso: true});
     this._installRootService('/auth-logout', 'get', this.auth.doLogout, 

--- a/lib/webauth.js
+++ b/lib/webauth.js
@@ -81,8 +81,9 @@ AuthResponse.prototype = {
       authCategoryResult[this.keyField] = true;
     }
     //alert client of when this session expires one way or another
-    if (!handlerResult.expms) {
-      //handler may only know expiration time due to login process, as a response, or may know ahead of time due to set value or retrievable server config.
+    if (handlerResult.authenticated && !handlerResult.expms) {
+      //handler may only know expiration time due to login process, as a response,
+      //or may know ahead of time due to set value or retrievable server config.
       handlerResult.expms = handler.sessionExpirationMS;
     }
     authCategoryResult.plugins[pluginID] = handlerResult;
@@ -145,7 +146,7 @@ module.exports = function(authManager) {
       handler.addProxyAuthorizations(req1, req2Options, authPluginSession);     
     },
     
-    getStatus(req, res) {
+    getStatus: Promise.coroutine(function*(req, res) {
       const handlers = authManager.getAllHandlers();
       const result = new StatusResponse();
       for (const handler of handlers) {
@@ -153,7 +154,7 @@ module.exports = function(authManager) {
         const authPluginSession = util.getOrInit(req.session, pluginID, {});
         let status;
         try {
-          status = handler.getStatus(authPluginSession); 
+          status = yield handler.getStatus(req, authPluginSession); 
         } catch (error) {
           status = {
             error
@@ -162,7 +163,7 @@ module.exports = function(authManager) {
         result.addHandlerResult(status, handler);
       }
       res.status(200).json(result);
-    },
+    }),
 
     refreshStatus: Promise.coroutine(function*(req, res) {
       try {
@@ -178,6 +179,10 @@ module.exports = function(authManager) {
           const wasAuthenticate = authPluginSession.authenticated;
           const handlerResult = yield handler.refreshStatus(req, 
               authPluginSession);
+          if (handlerResult.success) {
+            authLogger.info(`${req.session.id}: Successful session renewal to auth ` 
+            + `handler ${pluginID}. Plugin response: ` + JSON.stringify(handlerResult));
+          }          
           //do not modify session if not authenticated or deauthenticated
           if (wasAuthenticate || authPluginSession.authenticated) {
             setAuthPluginSession(req, pluginID, authPluginSession);

--- a/lib/webauth.js
+++ b/lib/webauth.js
@@ -131,10 +131,60 @@ StatusResponse.prototype = {
   keyField: "authenticated"
 }
 
+const SESSION_ACTION_TYPE_AUTHENTICATE = 1;
+const SESSION_ACTION_TYPE_REFRESH = 2;
+
 /*
  * Assumes req.session is there and behaves as it should
  */
 module.exports = function(authManager) {
+  const _authenticateOrRefresh = Promise.coroutine(function*(req, res, type) {
+    let functionName;
+    if (type == SESSION_ACTION_TYPE_AUTHENTICATE) {
+      functionName = 'authenticate';
+    } else if (type == SESSION_ACTION_TYPE_REFRESH) {
+      functionName = 'refreshStatus';
+    } else {
+      res.status(500).json({error: "Invalid session action type attempted"});
+      return;
+    }
+    
+    try {
+      const result = new LoginResult();
+      const handlers = getRelevantHandlers(authManager, req.body);
+      const authServiceHandleMaps = 
+            req[`${UNP.APP_NAME}Data`].webApp.authServiceHandleMaps;
+      for (const handler of handlers) {
+        const pluginID = handler.pluginID;
+        const authPluginSession = getAuthPluginSession(req, pluginID, {});
+        req[`${UNP.APP_NAME}Data`].plugin.services = 
+          authServiceHandleMaps[pluginID];
+        // FIXME This is a bug: in webauth.js we shouldn't make assumptions
+        // about the contents of the session. We only can look at the return 
+        // values of the method.          
+        const wasAuthenticate = authPluginSession.authenticated;
+        const handlerResult = yield handler[functionName](req,
+                                                          authPluginSession);
+        if (handlerResult.success) {
+          authLogger.info(`${req.session.id}: Session security call ${functionName} succesful for auth ` 
+                          + `handler ${pluginID}. Plugin response: ` + JSON.stringify(handlerResult));
+        }          
+        //do not modify session if not authenticated or deauthenticated
+        if (wasAuthenticate || authPluginSession.authenticated) {
+          setAuthPluginSession(req, pluginID, authPluginSession);
+        }
+        result.addHandlerResult(handlerResult, handler);
+      }
+      result.updateStatus();
+      res.status(result.success? 200 : 401).json(result);
+    } catch (e) {
+      console.warn(e)
+      res.status(500).send(e.message);
+      return;
+    }
+  });
+
+  
   return {
     
     addProxyAuthorizations(req1, req2Options) {
@@ -154,7 +204,7 @@ module.exports = function(authManager) {
         const authPluginSession = util.getOrInit(req.session, pluginID, {});
         let status;
         try {
-          status = yield handler.getStatus(req, authPluginSession); 
+         status = handler.getStatus(authPluginSession); 
         } catch (error) {
           status = {
             error
@@ -165,74 +215,13 @@ module.exports = function(authManager) {
       res.status(200).json(result);
     }),
 
-    refreshStatus: Promise.coroutine(function*(req, res) {
-      try {
-        const result = new LoginResult();
-        const handlers = getRelevantHandlers(authManager, req.body);
-        const authServiceHandleMaps = 
-          req[`${UNP.APP_NAME}Data`].webApp.authServiceHandleMaps;
-        for (const handler of handlers) {
-          const pluginID = handler.pluginID;
-          const authPluginSession = getAuthPluginSession(req, pluginID, {});
-          req[`${UNP.APP_NAME}Data`].plugin.services = 
-            authServiceHandleMaps[pluginID];
-          const wasAuthenticate = authPluginSession.authenticated;
-          const handlerResult = yield handler.refreshStatus(req, 
-              authPluginSession);
-          if (handlerResult.success) {
-            authLogger.info(`${req.session.id}: Successful session renewal to auth ` 
-            + `handler ${pluginID}. Plugin response: ` + JSON.stringify(handlerResult));
-          }          
-          //do not modify session if not authenticated or deauthenticated
-          if (wasAuthenticate || authPluginSession.authenticated) {
-            setAuthPluginSession(req, pluginID, authPluginSession);
-          }
-          result.addHandlerResult(handlerResult, handler);
-        }
-        result.updateStatus();
-        res.status(result.success? 200 : 401).json(result);
-      } catch (e) {
-        console.warn(e)
-        res.status(500).send(e.message);
-        return;
-      }
-    }),
+    refreshStatus(req, res) {
+      return _authenticateOrRefresh(req,res,SESSION_ACTION_TYPE_REFRESH);
+    },
     
-    doLogin: Promise.coroutine(function*(req, res) {
-      try {
-        const result = new LoginResult();
-        const handlers = getRelevantHandlers(authManager, req.body);
-        const authServiceHandleMaps = 
-          req[`${UNP.APP_NAME}Data`].webApp.authServiceHandleMaps;
-        for (const handler of handlers) {
-          const pluginID = handler.pluginID;
-          const authPluginSession = getAuthPluginSession(req, pluginID, {});
-          req[`${UNP.APP_NAME}Data`].plugin.services = 
-            authServiceHandleMaps[pluginID];
-          // FIXME This is a bug: in webauth.js we shouldn't make assumptions
-          // about the contents of the session. We only can look at the return 
-          // values of the method.
-          const wasAuthenticated = authPluginSession.authenticated;
-          const handlerResult = yield handler.authenticate(req, 
-              authPluginSession);
-          if (handlerResult.success) {
-            authLogger.debug(`${req.session.id}: Successful authenticate to auth ` 
-            + `handler ${pluginID}. Plugin response: ` + JSON.stringify(handlerResult));
-          }
-          //do not modify session if not authenticated or deauthenticated
-          if (wasAuthenticated || handlerResult.success) {
-            setAuthPluginSession(req, pluginID, authPluginSession);
-          }
-          result.addHandlerResult(handlerResult, handler);
-        }
-        result.updateStatus();
-        res.status(result.success? 200 : 401).json(result);
-      } catch (e) {
-        console.warn(e)
-        res.status(500).send(e.message);
-        return;
-      }
-    }),
+    doLogin(req, res) {
+      return _authenticateOrRefresh(req,res,SESSION_ACTION_TYPE_AUTHENTICATE);
+    },
     
     doLogout(req, res) {
       //FIXME XSRF

--- a/lib/webauth.js
+++ b/lib/webauth.js
@@ -159,10 +159,7 @@ module.exports = function(authManager) {
         const authPluginSession = getAuthPluginSession(req, pluginID, {});
         req[`${UNP.APP_NAME}Data`].plugin.services = 
           authServiceHandleMaps[pluginID];
-        // FIXME This is a bug: in webauth.js we shouldn't make assumptions
-        // about the contents of the session. We only can look at the return 
-        // values of the method.          
-        const wasAuthenticate = authPluginSession.authenticated;
+        const wasAuthenticated = handler.getStatus(authPluginSession).authenticated;
         const handlerResult = yield handler[functionName](req,
                                                           authPluginSession);
         if (handlerResult.success) {
@@ -170,7 +167,7 @@ module.exports = function(authManager) {
                           + `handler ${pluginID}. Plugin response: ` + JSON.stringify(handlerResult));
         }          
         //do not modify session if not authenticated or deauthenticated
-        if (wasAuthenticate || authPluginSession.authenticated) {
+        if (wasAuthenticated || handlerResult.success) {
           setAuthPluginSession(req, pluginID, authPluginSession);
         }
         result.addHandlerResult(handlerResult, handler);
@@ -204,7 +201,7 @@ module.exports = function(authManager) {
         const authPluginSession = util.getOrInit(req.session, pluginID, {});
         let status;
         try {
-         status = handler.getStatus(authPluginSession); 
+          status = handler.getStatus(authPluginSession);
         } catch (error) {
           status = {
             error

--- a/lib/webauth.js
+++ b/lib/webauth.js
@@ -193,7 +193,7 @@ module.exports = function(authManager) {
       handler.addProxyAuthorizations(req1, req2Options, authPluginSession);     
     },
     
-    getStatus: Promise.coroutine(function*(req, res) {
+    getStatus(req, res) {
       const handlers = authManager.getAllHandlers();
       const result = new StatusResponse();
       for (const handler of handlers) {
@@ -210,7 +210,7 @@ module.exports = function(authManager) {
         result.addHandlerResult(status, handler);
       }
       res.status(200).json(result);
-    }),
+    },
 
     refreshStatus(req, res) {
       return _authenticateOrRefresh(req,res,SESSION_ACTION_TYPE_REFRESH);

--- a/lib/webauth.js
+++ b/lib/webauth.js
@@ -79,7 +79,12 @@ AuthResponse.prototype = {
     });
     if (handlerResult[this.keyField]) {
       authCategoryResult[this.keyField] = true;
-    } 
+    }
+    //alert client of when this session expires one way or another
+    if (!handlerResult.expms) {
+      //handler may only know expiration time due to login process, as a response, or may know ahead of time due to set value or retrievable server config.
+      handlerResult.expms = handler.sessionExpirationMS;
+    }
     authCategoryResult.plugins[pluginID] = handlerResult;
   },
   
@@ -158,6 +163,35 @@ module.exports = function(authManager) {
       }
       res.status(200).json(result);
     },
+
+    refreshStatus: Promise.coroutine(function*(req, res) {
+      try {
+        const result = new LoginResult();
+        const handlers = getRelevantHandlers(authManager, req.body);
+        const authServiceHandleMaps = 
+          req[`${UNP.APP_NAME}Data`].webApp.authServiceHandleMaps;
+        for (const handler of handlers) {
+          const pluginID = handler.pluginID;
+          const authPluginSession = getAuthPluginSession(req, pluginID, {});
+          req[`${UNP.APP_NAME}Data`].plugin.services = 
+            authServiceHandleMaps[pluginID];
+          const wasAuthenticate = authPluginSession.authenticated;
+          const handlerResult = yield handler.refreshStatus(req, 
+              authPluginSession);
+          //do not modify session if not authenticated or deauthenticated
+          if (wasAuthenticate || authPluginSession.authenticated) {
+            setAuthPluginSession(req, pluginID, authPluginSession);
+          }
+          result.addHandlerResult(handlerResult, handler);
+        }
+        result.updateStatus();
+        res.status(result.success? 200 : 401).json(result);
+      } catch (e) {
+        console.warn(e)
+        res.status(500).send(e.message);
+        return;
+      }
+    }),
     
     doLogin: Promise.coroutine(function*(req, res) {
       try {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,27 +5,27 @@
   "requires": true,
   "dependencies": {
     "@types/chai": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.1.6.tgz",
-      "integrity": "sha512-CBk7KTZt3FhPsEkYioG6kuCIpWISw+YI8o+3op4+NXwTpvAPxE1ES8+PY8zfaK2L98b1z5oq03UHa4VYpeUxnw==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.1.7.tgz",
+      "integrity": "sha512-2Y8uPt0/jwjhQ6EiluT0XCri1Dbplr0ZxfFXUz+ye13gaqE8u5gL5ppao1JrUYr9cIip5S6MvQzBS7Kke7U9VA==",
       "dev": true
     },
     "@types/cookiejar": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.0.tgz",
-      "integrity": "sha512-EIjmpvnHj+T4nMcKwHwxZKUfDmphIKJc2qnEMhSoOvr1lYEQpuRKRz8orWr//krYIIArS/KGGLfL2YGVUYXmIA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.1.tgz",
+      "integrity": "sha512-aRnpPa7ysx3aNW60hTiCtLHlQaIFsXFCgQlpakNgDNVFzbtusSY8PwjAQgRWfSk0ekNoBjO51eQRB6upA9uuyw==",
       "dev": true
     },
     "@types/node": {
-      "version": "10.11.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.11.4.tgz",
-      "integrity": "sha512-ojnbBiKkZFYRfQpmtnnWTMw+rzGp/JiystjluW9jgN3VzRwilXddJ6aGQ9V/7iuDG06SBgn7ozW9k3zcAnYjYQ==",
+      "version": "11.11.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-11.11.3.tgz",
+      "integrity": "sha512-wp6IOGu1lxsfnrD+5mX6qwSwWuqsdkKKxTN4aQc4wByHAKZJf9/D4KXPQ1POUjEbnCP5LMggB0OEFNY9OTsMqg==",
       "dev": true
     },
     "@types/superagent": {
-      "version": "3.8.4",
-      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-3.8.4.tgz",
-      "integrity": "sha512-Dnh0Iw6NO55z1beXvlsvUrfk4cd9eL2nuTmUk+rAhSVCk10PGGFbqCCTwbau9D0d2W3DITiXl4z8VCqppGkMPQ==",
+      "version": "3.8.7",
+      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-3.8.7.tgz",
+      "integrity": "sha512-9KhCkyXv268A2nZ1Wvu7rQWM+BmdYUVkycFeNnYrUL5Zwu7o8wPQ3wBfW59dDP+wuoxw0ww8YKgTNv8j/cgscA==",
       "dev": true,
       "requires": {
         "@types/cookiejar": "*",
@@ -47,9 +47,9 @@
       }
     },
     "ajv": {
-      "version": "6.5.5",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.5.tgz",
-      "integrity": "sha512-7q7gtRQDJSyuEHjuVgHoUa2VuemFiCMrfQc9Tc08XTAc4Zj/5U1buQJ0HU6i7fKjXU09SVgSmxa4sLvuvS8Iyg==",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
+      "integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
       "requires": {
         "fast-deep-equal": "^2.0.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -90,11 +90,11 @@
       "dev": true
     },
     "async": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
-      "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
+      "integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
       "requires": {
-        "lodash": "^4.17.10"
+        "lodash": "^4.17.11"
       }
     },
     "async-limiter": {
@@ -131,9 +131,9 @@
       }
     },
     "bluebird": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.2.tgz",
-      "integrity": "sha512-dhHTWMI7kMx5whMQntl7Vr9C6BvV10lFXDAasnqnrMYhXVCzzk6IO9Fo2L75jXHT07WrOngL1WDXOp+yYS91Yg=="
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
+      "integrity": "sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw=="
     },
     "body-parser": {
       "version": "1.18.3",
@@ -186,9 +186,9 @@
       }
     },
     "chai-http": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/chai-http/-/chai-http-4.2.0.tgz",
-      "integrity": "sha512-5j9LC1pl9jaPanux+wDm9D/V6R2xLfpixsRQhoJHxCR0E5KaiT0aL4544pVtYXN/wTUVSDTmwye5mCXkO/8b3w==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/chai-http/-/chai-http-4.2.1.tgz",
+      "integrity": "sha512-S2Ezy5uSVuOYleeXppfUKtTU/xbHCZyKkwjheNJ/76SGFTUPDpDkkpVdPNgC3sAO1Ap5J5LJ+/rXdLG8EGhCDA==",
       "dev": true,
       "requires": {
         "@types/chai": "4",
@@ -241,9 +241,9 @@
       "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
     },
     "cookie-parser": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.3.tgz",
-      "integrity": "sha1-D+MfoZ0AC5X0qt8fU/3CuKIDuqU=",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.4.tgz",
+      "integrity": "sha512-lo13tqF3JEtFO7FyA49CqbhaFkskRJ0u/UAiINgrIXeRCY41c88/zxtrECl8AKH3B0hj9q10+h3Kt8I7KlW4tw==",
       "requires": {
         "cookie": "0.3.1",
         "cookie-signature": "1.0.6"
@@ -470,23 +470,13 @@
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
     },
     "form-data": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
-      "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
       "requires": {
         "asynckit": "^0.4.0",
-        "combined-stream": "1.0.6",
+        "combined-stream": "^1.0.6",
         "mime-types": "^2.1.12"
-      },
-      "dependencies": {
-        "combined-stream": {
-          "version": "1.0.6",
-          "resolved": "http://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
-          "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
-          "requires": {
-            "delayed-stream": "~1.0.0"
-          }
-        }
       }
     },
     "formidable": {
@@ -631,9 +621,9 @@
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
     "js-yaml": {
-      "version": "3.12.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.1.tgz",
-      "integrity": "sha512-um46hB9wNOKlwkHgiuyEVAybXBjwFUV0Z/RaHJblRd9DXltue9FTYvzCr9ErQrK9Adz5MU4gHWVaNUfdmrC8qA==",
+      "version": "3.12.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.2.tgz",
+      "integrity": "sha512-QHn/Lh/7HhZ/Twc7vJYQTkjuCa0kaCcDcjK5Zlk2rvnUpy7DxMJ23+Jc2dcyvltwQVg1nygAVlB2oRDFHoRS5Q==",
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -696,16 +686,16 @@
       "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
     },
     "mime-db": {
-      "version": "1.36.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.36.0.tgz",
-      "integrity": "sha512-L+xvyD9MkoYMXb1jAmzI/lWYAxAMCPvIBSWur0PZ5nOf5euahRLVqH//FKW9mWp2lkqUgYiXPgkzfMUFi4zVDw=="
+      "version": "1.38.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.38.0.tgz",
+      "integrity": "sha512-bqVioMFFzc2awcdJZIzR3HjZFX20QhilVS7hytkKrv7xFAn8bM1gzc/FOX2awLISvWe0PV8ptFKcon+wZ5qYkg=="
     },
     "mime-types": {
-      "version": "2.1.20",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.20.tgz",
-      "integrity": "sha512-HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==",
+      "version": "2.1.22",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.22.tgz",
+      "integrity": "sha512-aGl6TZGnhm/li6F7yx82bJiBZwgiEa4Hf6CNr8YO+r5UHr53tSTYZb102zyU50DOWWKeOv0uQLRL0/9EiKWCog==",
       "requires": {
-        "mime-db": "~1.36.0"
+        "mime-db": "~1.38.0"
       }
     },
     "minimatch": {
@@ -740,9 +730,9 @@
       }
     },
     "on-headers": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz",
-      "integrity": "sha1-ko9dD0cNSTQmUepnlLCFfBAGk/c="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
+      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA=="
     },
     "once": {
       "version": "1.4.0",
@@ -759,7 +749,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-to-regexp": {
@@ -838,7 +828,7 @@
     },
     "readable-stream": {
       "version": "2.3.6",
-      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "dev": true,
       "requires": {
@@ -947,9 +937,9 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "sshpk": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.0.tgz",
-      "integrity": "sha512-Zhev35/y7hRMcID/upReIvRse+I9SVhyVre/KTJSJQWMz3C3+G+HpO7m1wK/yckEtujKZ7dS4hkVxAnmHaIGVQ==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
       "requires": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
@@ -969,7 +959,7 @@
     },
     "string_decoder": {
       "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "requires": {
@@ -995,9 +985,9 @@
       },
       "dependencies": {
         "debug": {
-          "version": "3.2.5",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.5.tgz",
-          "integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "dev": true,
           "requires": {
             "ms": "^2.1.1"

--- a/plugins/trivial-auth/lib/trivialAuth.js
+++ b/plugins/trivial-auth/lib/trivialAuth.js
@@ -17,7 +17,7 @@ TrivialAuthenticator.prototype = {
   getStatus(sessionState) {
     return {
       username: sessionState.username,
-      authenticated: sessionState.authenticated
+      authenticated: !!sessionState.username
     };
   },
     
@@ -34,10 +34,20 @@ TrivialAuthenticator.prototype = {
    * { success: true }. Should not reject the promise.
    */ 
   authenticate(request, sessionState) {
-    sessionState.username = request.body.username;
-    sessionState.authenticated = true;
-    return Promise.resolve({ success: true });
+    if (request.body && request.body.username) {
+      sessionState.username = request.body.username;
+      sessionState.authenticated = true;
+      return Promise.resolve({ success: true });
+    } else {
+      return Promise.resolve({ success: false });
+    }
   },
+  
+  refreshStatus(request, sessionState) {
+    const result = sessionState.username;
+    sessionState.authenticated = result;
+    return Promise.resolve({ success: true });
+  },  
 
   /**
    * Invoked for every service call by the middleware.

--- a/test/webapp/config.js
+++ b/test/webapp/config.js
@@ -32,6 +32,7 @@ exports.webAppOptions = {
       doLogin() {},
       getStatus() {},
       doLogout() {},
+      refreshStatus() {},
       middleware(r, re, next) { next() }
     }
 };


### PR DESCRIPTION
Adds the explicit ability for client to request that a session be renewed in order to not expire.
This may be an implicit feature of doing a status check ( GET to /auth), and therefore may not need its own URL... will change if needed.

Made getStatus async because it was not checking with the auth server, so it's possible that on doing getStatus that a session had expired in the past.