### PR TITLE
Adding no cache headers to root services that had been missed

### DIFF
--- a/lib/webapp.js
+++ b/lib/webapp.js
@@ -607,7 +607,7 @@ WebApp.prototype = {
   },
 
   _installRootService(url, method, handler, {needJson, needAuth, isPseudoSso}) {
-    const handlers = [commonMiddleware.logRootServiceCall(false, url)];
+    const handlers = [commonMiddleware.logRootServiceCall(false, url), commonMiddleware.httpNoCacheHeaders()];
     if (needJson) {
       handlers.push(jsonParser);
     }


### PR DESCRIPTION
Related to https://github.com/zowe/zss/issues/11, just filling in headers for some services that were missed during the last round of header fixes.
This just instructs the browser not to cache these responses, and the effected services don't really gain anything by being cached, so it should be a change without adverse effects.
Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>