### PR TITLE
Encode URI to prevent HTML insertion into 404 handler

### DIFF
--- a/lib/webapp.js
+++ b/lib/webapp.js
@@ -80,6 +80,11 @@ DataserviceContext.prototype = {
 
 function do404(URL, res, message) {
   contentLogger.debug("404: "+message+", url="+URL);
+  if (URL.indexOf('<')!=-1) {
+    //sender didn't URI encode (browsers generally do)
+    //Not a catch-all for missed encoding - specifically to prevent HTML tag insertion
+    URL = encodeURI(URL);
+  }
   res.statusMessage = message;
   res.status(404).send("<h1>Resource not found, URL: "+URL+"</h1></br><h2>Additional info: "+message+"</h2>");
 }


### PR DESCRIPTION
Test case that this addresses:
GET /plugins/<script>alert(1)</script>
You don't want to see:
<h1>Resource not found, URL: <script>alert(1)</script></h1></br><h2>Additional info: ZLUX: unknown resource requested</h2>
Just in case the browser tries to load a malicious script through this.

Chrome and Postman both do not actually trigger this, because they URI encode <
However, curl doesn't. So, this is a fix for curl or things that don't URI encode.

Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>