### PR TITLE
Bugfix for ZSS Dataservice authentication

### DIFF
--- a/lib/webapp.js
+++ b/lib/webapp.js
@@ -812,7 +812,7 @@ WebApp.prototype = {
       //installLog.info(`${plugin.identifier}: installing proxy at ${subUrl}`);
       router = this.makeProxy(zLuxUrl.makePluginURL(this.options.productCode, 
                                                     plugin.identifier) +
-                              zLuxUrl.makeServiceSubURL(service, false, true),
+                              zLuxUrl.makeServiceSubURL(service, false, true), false,
                               getAgentProxyOptions(this.options, this.options.serverConfig.agent));
       break;
     case "nodeService":


### PR DESCRIPTION
Parameter count mismatch resulted in a missing boolean that controlled setting cookie for proxied zss calls, so rest apis that were zss code would fail. In particular, tn3270 discovery api.