### PR TITLE
Fix config service for trivial auth

### DIFF
--- a/plugins/trivial-auth/lib/trivialAuth.js
+++ b/plugins/trivial-auth/lib/trivialAuth.js
@@ -44,9 +44,9 @@ TrivialAuthenticator.prototype = {
   },
   
   refreshStatus(request, sessionState) {
-    const result = sessionState.username;
+    const result = !!sessionState.username;
     sessionState.authenticated = result;
-    return Promise.resolve({ success: true });
+    return Promise.resolve({ success: result });
   },  
 
   /**


### PR DESCRIPTION
Config service needs username to get user config
Latest auth code uses auth refresh to do the initial login check
It unconditionally succeeded on trivial auth, even when username wasnt present, so although you were able to login, the config service could not function.
It makes more sense to gate by if a username has been given or not. This is how it was before this bug was introduced.
Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>