### PR TITLE
Compatibility with auth handlers without refresh

### DIFF
--- a/lib/webauth.js
+++ b/lib/webauth.js
@@ -159,18 +159,26 @@ module.exports = function(authManager) {
         const authPluginSession = getAuthPluginSession(req, pluginID, {});
         req[`${UNP.APP_NAME}Data`].plugin.services = 
           authServiceHandleMaps[pluginID];
-        const wasAuthenticated = handler.getStatus(authPluginSession).authenticated;
-        const handlerResult = yield handler[functionName](req,
-                                                          authPluginSession);
-        if (handlerResult.success) {
-          authLogger.info(`${req.session.id}: Session security call ${functionName} succesful for auth ` 
-                          + `handler ${pluginID}. Plugin response: ` + JSON.stringify(handlerResult));
-        }          
-        //do not modify session if not authenticated or deauthenticated
-        if (wasAuthenticated || handlerResult.success) {
-          setAuthPluginSession(req, pluginID, authPluginSession);
+        const status = handler.getStatus(authPluginSession);
+        const wasAuthenticated = status.authenticated;
+        let handlerResult;
+        if (handler[functionName]) {
+          handlerResult = yield handler[functionName](req,
+                                                      authPluginSession);
+          if (handlerResult.success) {
+            authLogger.info(`${req.session.id}: Session security call ${functionName} succesful for auth `
+                            + `handler ${pluginID}. Plugin response: ` + JSON.stringify(handlerResult));
+          }
+        } else if (type == SESSION_ACTION_TYPE_REFRESH) { //compatibility for auth that dont refresh
+          handlerResult = {success: wasAuthenticated, username: status.username};
         }
-        result.addHandlerResult(handlerResult, handler);
+        //do not modify session if not authenticated or deauthenticated
+        if (handlerResult) {
+          if (wasAuthenticated || handlerResult.success) {
+            setAuthPluginSession(req, pluginID, authPluginSession);
+          }
+          result.addHandlerResult(handlerResult, handler);
+        }
       }
       result.updateStatus();
       res.status(result.success? 200 : 401).json(result);


### PR DESCRIPTION
Bugfix: old auth handlers were throwing an exception due to missing refresh function, which was just added between 1.0.1 and 1.10. Not all auth handlers will support refresh, so expecting the function to exist is perhaps wrong. If the function doesnt exist, the success/fail of the call is now just on if getStatus's authentication status is good. /auth-refresh is best-effort, so that if it doesn't refresh, you'll still just timeout later. But for things that dont actually support refresh at all, we don't want the return to be a 400 or 500 if a subset of handlers supported & succeeded, but others simply didnt support refresh.

Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>