### PR TITLE
Restore removed call to load translations of plugin names

### DIFF
--- a/lib/plugin-loader.js
+++ b/lib/plugin-loader.js
@@ -512,6 +512,7 @@ function makePlugin(def, pluginConfiguration, pluginContext, dynamicallyCreated)
     self.verifyStaticWebContent();
   }
   self.init(pluginContext);
+  self.loadTranslations();
   return self;
 };
 


### PR DESCRIPTION
loadTranslations is used to set up a map of translations for UI strings about application names. It was added in #15 but was removed accidentally within #14. This restores it in what seems to be the correct, modern location.
Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>