### PR TITLE
Add gzip and brotli support for static files

### DIFF
--- a/lib/webapp.js
+++ b/lib/webapp.js
@@ -28,6 +28,7 @@ const proxy = require('./proxy');
 const zLuxUrl = require('./url');
 const UNP = require('./unp-constants');
 const translationUtils = require('./translation-utils');
+const expressStaticGzip = require("express-static-gzip");
 
 /**
  * Sets up an Express application to serve plugin data files and services  
@@ -956,7 +957,8 @@ WebApp.prototype = {
     if (plugin.webContent && plugin.location) {
       let url = `${urlBase}/web`;
       installLog.info(`${plugin.identifier}: serving static files at ${url}`);
-      this.pluginRouter.use(url, express.static(path.join(plugin.location, '/web')));
+      this.pluginRouter.use(url, expressStaticGzip(path.join(plugin.location, '/web'),
+                                                   {enableBrotli: true, orderPreference: ['br', 'gzip']}));
     }
     if (plugin.pluginType === "library") {
       let url = `/lib/${plugin.identifier}/${plugin.libraryVersion}`;

--- a/package-lock.json
+++ b/package-lock.json
@@ -415,6 +415,14 @@
         "utils-merge": "1.0.1"
       }
     },
+    "express-static-gzip": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/express-static-gzip/-/express-static-gzip-1.1.3.tgz",
+      "integrity": "sha512-k8Q4Dx4PDpzEb8kth4uiPWrBeJWJYSgnWMzNdjQUOsEyXfYKbsyZDkU/uXYKcorRwOie5Vzp4RMEVrJLMfB6rA==",
+      "requires": {
+        "serve-static": "^1.12.3"
+      }
+    },
     "express-ws": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/express-ws/-/express-ws-4.0.0.tgz",
@@ -621,9 +629,9 @@
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
     "js-yaml": {
-      "version": "3.12.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.2.tgz",
-      "integrity": "sha512-QHn/Lh/7HhZ/Twc7vJYQTkjuCa0kaCcDcjK5Zlk2rvnUpy7DxMJ23+Jc2dcyvltwQVg1nygAVlB2oRDFHoRS5Q==",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "eureka-js-client": "~4.4.1",
     "express": "~4.16.3",
     "express-session": "~1.15.6",
+    "express-static-gzip": "~1.1.3",
     "express-ws": "~4.0.0",
     "glob": "~7.1.3",
     "ipaddr.js": "~1.8.0",


### PR DESCRIPTION
gzip compression is supported by pretty much everything, and brotli is supported by all browsers Zowe Desktop already supports: https://caniuse.com/#search=brotli
This change makes the server serve static files with a preference for brotli, when present and the browser states it is supported via the accepts headers.