### PR TITLE
Add ability to use host/port used in node deploy (console command arguments or zluxServer.json propeties) if there are no values in pluginDefinition.json (for external services)

### DIFF
--- a/lib/webapp.js
+++ b/lib/webapp.js
@@ -845,7 +845,11 @@ WebApp.prototype = {
       break;
     case "external":
 //      installLog.info(`${plugin.identifier}: installing external proxy at ${subUrl}`);
-      router = this.makeExternalProxy(service.host, service.port,
+
+      const host  = service.host ? service.host : this.options.proxiedHost;
+      const port  = service.port ? service.port : this.options.proxiedPort;
+
+      router = this.makeExternalProxy(host, port,
           service.urlPrefix, service.isHttps,
           undefined, plugin.identifier, service.name);
       break;


### PR DESCRIPTION
Add ability to set host/port for external services from _options_ object if there are no _host_ , _port_ values in pluginDefinition.json for that services.

_proxiedHost_ and _proxiedPort_ firstly set in zluxArgs.js in _startupConfig_ object (https://github.com/zowe/zlux-app-server/blob/de4a96fc20dbeaf7e1c0efd03d39f8f42878305c/lib/zluxArgs.js#L183). So that fix use this values if _host_ , _port_ are missed in pluginDefinition.json.