### PR TITLE
Proxy fixes

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -84,17 +84,26 @@ function makeSimpleProxy(host, port, options, pluginID, serviceName) {
       const headers = res2.headers;
       for (const header of Object.keys(headers)) {
         if (header == 'location') {
-          var pattern = /^http.+\/ZLUX\/plugins\/.+/;
+          const location = headers[header];
+          let pattern = /^http.+\/ZLUX\/plugins\/.+/;
           if (!pattern.test(headers[header])) {
-            /* Find :{port} and take all that is after */
-            var x = headers[header];
-            var y = x.split(":");
-            var z = y[2];
-            var t = z.indexOf('/');
-            var newEnd = z.substring(t);
-            var newRedirect = req1.protocol + '://' + req1.get('host') + "/ZLUX/plugins/" + pluginID + "/services/" + serviceName + newEnd; 
-            proxyLog.debug('Redirecting to: ' + newRedirect);
-            res1.set(header, newRedirect);
+            if (location.startsWith('/')) {
+	      res1.set(header, `${req1.protocol}://${req1.get('host')}/ZLUX/plugins/${pluginID}/services/${serviceName}/_current${location}`);
+            }
+            else if (location.startsWith('http')) {
+	      const locationParts = location.split(":");
+              let part;
+	      if (locationParts.length > 2) {
+	        part = locationParts[2];
+              } else {
+                part = locationParts[1]
+              }
+              const t = part.indexOf('/');
+              const newEnd = part.substring(t);
+              const newRedirect = req1.protocol + '://' + req1.get('host') + "/ZLUX/plugins/" + pluginID + "/services/_current" + serviceName + newEnd; 
+              proxyLog.debug('Redirecting to: ' + newRedirect);
+              res1.set(header, newRedirect);
+            }            
           }
         }
         else {

--- a/lib/webapp.js
+++ b/lib/webapp.js
@@ -1002,20 +1002,22 @@ WebApp.prototype = {
   installErrorHanders() {
     this.expressApp.use((req, res, next) => {
       const headers = req.headers
+      let referrerPresent = false;
       for (const header of Object.keys(headers)) {
         /* Try to find a referer header and try to
          * redirect to our server,
          */
         if (header == 'referer') {
+          referrerPresent = true;
           let referrer = headers[header];
           var pattern = new RegExp('^http.+\/'+this.options.productCode+'\/plugins\/.+');
           if (pattern.test(referrer)) {
-            var parts = headers[header].split("/");
-            var zluxIndex = parts.indexOf(this.options.productCode);
-            var pluginID = parts[zluxIndex + 2];
-            var serviceName = parts[zluxIndex + 4];
-            var myProxy = proxyMap.get(pluginID + ":" + serviceName);
-            var fullUrl = req.originalUrl;
+            const parts = headers[header].split("/");
+            const zluxIndex = parts.indexOf(this.options.productCode);
+            const pluginID = parts[zluxIndex + 2];
+            const serviceName = parts[zluxIndex + 4];
+            const myProxy = proxyMap.get(pluginID + ":" + serviceName);
+            const fullUrl = req.originalUrl;
             req.url = fullUrl;
             if (myProxy != undefined) {
               utilLog.debug("About to call myProxy");
@@ -1032,10 +1034,12 @@ WebApp.prototype = {
                   + ` 404 because referrer (${referrer}) didn't match a plugin pattern`);               
             return do404(req.url, res, this.options.productCode + ": unknown resource requested");
           }
-        } else {
-          return do404(req.url, res, this.options.productCode
-               + ": unknown resource requested");
+          break;
         }
+      }
+      if (!referrerPresent) {
+        return do404(req.url, res, this.options.productCode
+                     + ": unknown resource requested");
       }
     });
   }


### PR DESCRIPTION
Fixes for proxy hitting 404 when it shouldnt, and for when location header is not what was expected
Proxy redirect logic due to sniffing referrer trick did not loop correctly, going right to 404.
And location header logic only worked in a very specific case.