### PR TITLE
make extra unused auth plugins not throw errors

### DIFF
--- a/lib/plugin-loader.js
+++ b/lib/plugin-loader.js
@@ -427,6 +427,16 @@ NodeAuthenticationPlugIn.prototype = {
     }
     return true;
   },
+
+  isRequestedAuthPlugin(context) {
+    //we should not load authentication types that are 
+    //not requested by the administrator
+    if (!context.authManager.authPluginRequested(this.identifier,
+      this.authenticationCategory)) {
+      return false;
+    }
+    return true;
+  },
   
   exportDef() {
     return Object.assign(super.exportDef(), {
@@ -503,9 +513,14 @@ function makePlugin(def, pluginConfiguration, pluginContext, dynamicallyCreated)
   const self = new pluginConstr(def, pluginConfiguration);
   self.dynamicallyCreated = dynamicallyCreated;
   if (!self.isValid(pluginContext)) {
-    bootstrapLogger.warn(`${def.location} points to an`
+    if (def.pluginType == 'nodeAuthentication' && !self.isRequestedAuthPlugin(pluginContext)) {
+      bootstrapLogger.info(`Plugin ${self.identifier} is not requested skipping without error`);
+      return null;
+    } else {
+      bootstrapLogger.warn(`${def.location} points to an`
         + " invalid plugin definition, skipping");
-    throw new Error(`Plugin ${def.identifier} invalid`)
+      throw new Error(`Plugin ${def.identifier} invalid`);
+    }
   }
   self.initDataServices(pluginContext);
   if (!dynamicallyCreated) {
@@ -622,12 +637,17 @@ PluginLoader.prototype = {
         bootstrapLogger.debug(`For plugin with id=${pluginDef.identifier}, internal config` 
                                 + ` found=\n${JSON.stringify(pluginConfiguration)}`);
         const plugin = makePlugin(pluginDef, pluginConfiguration, pluginContext);
-        bootstrapLogger.log(bootstrapLogger.INFO,
+        if (plugin) {
+          bootstrapLogger.log(bootstrapLogger.INFO,
             `Plugin ${plugin.identifier} at path=${plugin.location} loaded.\n`);
-        bootstrapLogger.debug(' Content:\n' + plugin.toString());
-        this.plugins.push(zluxUtil.deepFreeze(plugin));
-        this.pluginMap[plugin.identifier] = plugin;
-        successCount++;
+          bootstrapLogger.debug(' Content:\n' + plugin.toString());
+          this.plugins.push(zluxUtil.deepFreeze(plugin));
+          this.pluginMap[plugin.identifier] = plugin;
+          successCount++;
+        } else {
+          bootstrapLogger.log(bootstrapLogger.INFO,
+            `Plugin ${pluginDef.identifier} not loaded`);
+        }
       } catch (e) {
         console.log(e);
         //bootstrapLogger.warn(e)

--- a/lib/plugin-loader.js
+++ b/lib/plugin-loader.js
@@ -427,16 +427,6 @@ NodeAuthenticationPlugIn.prototype = {
     }
     return true;
   },
-
-  isRequestedAuthPlugin(context) {
-    //we should not load authentication types that are 
-    //not requested by the administrator
-    if (!context.authManager.authPluginRequested(this.identifier,
-      this.authenticationCategory)) {
-      return false;
-    }
-    return true;
-  },
   
   exportDef() {
     return Object.assign(super.exportDef(), {
@@ -513,7 +503,8 @@ function makePlugin(def, pluginConfiguration, pluginContext, dynamicallyCreated)
   const self = new pluginConstr(def, pluginConfiguration);
   self.dynamicallyCreated = dynamicallyCreated;
   if (!self.isValid(pluginContext)) {
-    if (def.pluginType == 'nodeAuthentication' && !self.isRequestedAuthPlugin(pluginContext)) {
+    if (def.pluginType == 'nodeAuthentication' && pluginContext.authManager.authPluginRequested(self.identifier,
+      self.authenticationCategory)) {
       bootstrapLogger.info(`Plugin ${self.identifier} is not requested skipping without error`);
       return null;
     } else {

--- a/lib/plugin-loader.js
+++ b/lib/plugin-loader.js
@@ -503,7 +503,7 @@ function makePlugin(def, pluginConfiguration, pluginContext, dynamicallyCreated)
   const self = new pluginConstr(def, pluginConfiguration);
   self.dynamicallyCreated = dynamicallyCreated;
   if (!self.isValid(pluginContext)) {
-    if (def.pluginType == 'nodeAuthentication' && pluginContext.authManager.authPluginRequested(self.identifier,
+    if (def.pluginType == 'nodeAuthentication' && !pluginContext.authManager.authPluginRequested(self.identifier,
       self.authenticationCategory)) {
       bootstrapLogger.info(`Plugin ${self.identifier} is not requested skipping without error`);
       return null;


### PR DESCRIPTION
Signed-off-by: toddwellman <twellman@rocketsoftware.com>