### PR TITLE
Remove cookie exp & add server exp

### DIFF
--- a/lib/auth-manager.js
+++ b/lib/auth-manager.js
@@ -88,10 +88,11 @@ AuthManager.prototype = {
     let plugin;
     while ((plugin = this.pendingPlugins.pop()) !== undefined) {
       try {
-        const authenticationHandler = yield plugin.authenticationModule(plugin,
-                                                                        this.configuration,
-                                                                        config,
-                                                                        new AuthPluginContext(plugin));
+        const authenticationHandler = yield plugin.authenticationModule(
+                                              plugin,
+                                              this.configuration,
+                                              config,
+                                              new AuthPluginContext(plugin));
         // at this time we should have resolved plugin configuration to have a 
         // nice list of info about what we are using to authenticate against
         if ((typeof authenticationHandler.authenticate) !== 'function') {

--- a/lib/auth-manager.js
+++ b/lib/auth-manager.js
@@ -19,9 +19,17 @@ const zluxUtil = require('./util');
 const bootstrapLogger = zluxUtil.loggers.bootstrapLogger;
 const authLog = zluxUtil.loggers.authLogger;
 
+const DEFAULT_SESSION_TIMEOUT_MS = 60 /* min */ * 60 * 1000;
+
 const acceptAllHandler = {
   authorized() {
     return Promise.resolve({ authorized: true });
+  }
+}
+
+class AuthPluginContext {
+  constructor(plugin) {
+    this.logger = global.COM_RS_COMMON_LOGGER.makeComponentLogger(plugin.identifier);
   }
 }
 
@@ -42,6 +50,9 @@ function AuthManager(options) {
     pendingPlugins: [],
     rbacEnabled: !!options.config.rbac
   });
+  if (!this.sessionTimeoutMs) {
+    this.sessionTimeoutMs = DEFAULT_SESSION_TIMEOUT_MS;
+  }
   if (!this.rbacEnabled) {
     bootstrapLogger.warn('RBAC is disabled in the configuration. All authenticated'
         + ' users will have access to all servces. Enable RBAC in the configuration'
@@ -78,7 +89,9 @@ AuthManager.prototype = {
     while ((plugin = this.pendingPlugins.pop()) !== undefined) {
       try {
         const authenticationHandler = yield plugin.authenticationModule(plugin,
-                this.configuration, config);
+                                                                        this.configuration,
+                                                                        config,
+                                                                        new AuthPluginContext(plugin));
         // at this time we should have resolved plugin configuration to have a 
         // nice list of info about what we are using to authenticate against
         if ((typeof authenticationHandler.authenticate) !== 'function') {

--- a/lib/index.js
+++ b/lib/index.js
@@ -41,9 +41,20 @@ function Server(appConfig, userConfig, startUpConfig, options) {
   this.startUpConfig = startUpConfig;
   util.deepFreeze(startUpConfig);
   this.processManager = new ProcessManager(true);
+  let sessionTimeoutMs = undefined;
+  try { 
+    //TODO a better configuration infrastructure that supports 
+    //deeply nested structures and default values on all levels 
+    sessionTimeoutMs = userConfig.node.session.timeoutMS
+      ? userConfig.node.session.timeoutMS
+    //deprecating due to cookie not having the expiration info
+      : userConfig.node.session.cookie.timeoutMS;
+  } catch (nullReferenceError) { /* ignore */ }
+
   this.authManager = new AuthManager({
     config: userConfig.dataserviceAuthentication,
-    productCode:  appConfig.productCode
+    productCode:  appConfig.productCode,
+    sessionTimeoutMs: sessionTimeoutMs
   });
   this.pluginLoader = new PluginLoader({
     productCode: appConfig.productCode,
@@ -127,12 +138,6 @@ Server.prototype = {
     util.deepFreeze(this.userConfig);
     this.webServer.setConfig(wsConfig);
     const webauth = WebAuth(this.authManager);
-    let sessionTimeoutMs = null;
-    try { 
-      //TODO a better configuration infrastructure that supports 
-      //deeply nested structures and default values on all levels 
-      sessionTimeoutMs = wsConfig.session.cookie.timeoutMS;
-    } catch (nullReferenceError) { /* ignore */ }
     /*
       if either proxiedHost or proxiedPort were specified, then there is intent to connect to an agent.
       However, zlux may be run without one, so if both are undefined then don't check for connection.
@@ -144,7 +149,6 @@ Server.prototype = {
       yield checkProxiedHost(host, port);
     }
     const webAppOptions = {
-      sessionTimeoutMs: sessionTimeoutMs,
       httpPort: wsConfig.http ? wsConfig.http.port : undefined,
       httpsPort: wsConfig.https ? wsConfig.https.port : undefined,
       productCode: this.appConfig.productCode,

--- a/lib/sessionStore.js
+++ b/lib/sessionStore.js
@@ -74,7 +74,7 @@ SessionStore.prototype.addSession = function(sid, session) {
 
 SessionStore.prototype.removeSid = function(sid) {
   if (this.sessions.delete(sid)) {
-    this.sessionsQueue.splice(array.indexOf(sid), 1);
+    this.sessionsQueue.splice(this.sessionsQueue.indexOf(sid), 1);
   }
 }
 
@@ -136,7 +136,7 @@ SessionStore.prototype.destroy = function(sid, callback) {
     try {
         //console.log('SessionStore.destroy ' + sid);
         this.removeSid(sid);
-        callback(null);
+        callback && callback(null);
     } catch (error) {
         if (callback) {
             callback(error);

--- a/lib/sessionStore.js
+++ b/lib/sessionStore.js
@@ -144,7 +144,9 @@ SessionStore.prototype.destroy = function(sid, callback) {
     }
   } else {
     this.clusterRemoteCall("destroy", [sid], function(result) {
+      if (callback) {
         callback(result[0]);
+      }
     });
   }
 }
@@ -156,7 +158,9 @@ SessionStore.prototype.clear = function(callback) {
       //console.log('SessionStore.clear');
       this.sessions.clear();
       this.sessionsQueue.splice(0,this.sessionsQueue.length);
-      callback(null);
+      if (callback) {
+        callback(null);
+      }
     } catch (error) {
       if (callback) {
         callback(error);
@@ -164,7 +168,9 @@ SessionStore.prototype.clear = function(callback) {
     }
   } else {
     this.clusterRemoteCall("clear", [], function(result) {
+      if (callback) {
         callback(result[0]);
+      }
     });
   }
 }

--- a/lib/sessionStore.js
+++ b/lib/sessionStore.js
@@ -130,6 +130,7 @@ SessionStore.prototype.all = function(callback) {
   }
 }
 
+//Callback is optional
 SessionStore.prototype.destroy = function(sid, callback) {
   //Required, callback(error) once the session is destroyed
   if (this.isLocalStorage()) {
@@ -151,6 +152,7 @@ SessionStore.prototype.destroy = function(sid, callback) {
   }
 }
 
+//Callback is optional
 SessionStore.prototype.clear = function(callback) {
   //Optional, callback(error) once the store is cleared
   if (this.isLocalStorage()) {

--- a/lib/webapp.js
+++ b/lib/webapp.js
@@ -34,7 +34,6 @@ const expressStaticGzip = require("express-static-gzip");
  * Sets up an Express application to serve plugin data files and services  
  */
 
-const DEFAULT_SESSION_TIMEOUT_MS = 60 /* min */ * 60 * 1000;
 
 const SERVICE_TYPE_NODE = 0;
 const SERVICE_TYPE_PROXY = 1;
@@ -526,10 +525,6 @@ function getAgentProxyOptions(serverConfig, agentConfig) {
 
 function WebApp(options){
   this.expressApp = express();
-  let sessionTimeoutMs = DEFAULT_SESSION_TIMEOUT_MS;
-  if (options.sessionTimeoutMs) {
-    sessionTimeoutMs = options.sessionTimeoutMs;
-  }
   this.expressApp.use(cookieParser());
   this.expressApp.use(session({
     //TODO properly generate this secret
@@ -541,7 +536,6 @@ function WebApp(options){
     store: require("./sessionStore").sessionStore,
     resave: true, saveUninitialized: false,
     cookie: {
-      maxAge: sessionTimeoutMs,
       secure: 'auto'
     }
   }));

--- a/lib/webauth.js
+++ b/lib/webauth.js
@@ -14,6 +14,9 @@ const UNP = require('./unp-constants');
 
 const authLogger = util.loggers.authLogger;
 
+const sessionExpirationMap = {};
+const REASON_ZLUX_SESSION_EXPIRE = 'ZLUXSessionExp';
+
 function getAuthHandler(req, authManager) {
   const appData = req[`${UNP.APP_NAME}Data`];
   if (appData.service && appData.service.def) {
@@ -28,8 +31,8 @@ function getAuthHandler(req, authManager) {
 }
 
 function getAuthPluginSession(req, pluginID, dflt) {
-  if (req.session) {
-    let value = req.session[pluginID];
+  if (req.session && req.session.authPlugins) {
+    let value = req.session.authPlugins[pluginID];
     if (value) {
       return value;
     }
@@ -39,10 +42,15 @@ function getAuthPluginSession(req, pluginID, dflt) {
 
 function setAuthPluginSession(req, pluginID, authPluginSession) {
   if (req.session) {
-    // FIXME Note that it does something only when req.session[pluginID] is 
+    // FIXME Note that it does something only when req.session.authPlugins[pluginID] is 
     // undefined. Otherwise it does nothing (see getAuthPluginSession()) 
     // -- don't get confused
-    req.session[pluginID] = authPluginSession;
+
+    if (!req.session.authPlugins) {
+      req.session.authPlugins = {};
+    }
+
+    req.session.authPlugins[pluginID] = authPluginSession;
   }
 }
 
@@ -86,6 +94,11 @@ AuthResponse.prototype = {
       //or may know ahead of time due to set value or retrievable server config.
       handlerResult.expms = handler.sessionExpirationMS;
     }
+    //overall expiration when last auth expires
+    if (!this.expms
+        || (handlerResult.expms && handlerResult.expms > this.expms)) {
+      this.expms = handlerResult.expms;
+    }
     authCategoryResult.plugins[pluginID] = handlerResult;
   },
   
@@ -93,7 +106,7 @@ AuthResponse.prototype = {
    * Checks if all auth types are successful (have at least one succesful plugin)
    * and updates the summary field on this object
    */
-  updateStatus() {
+  updateStatus(defaultExpiration) {
     let result = false;
     for (const type of Object.keys(this.categories)) {
       const authCategoryResult = this.categories[type];
@@ -106,6 +119,10 @@ AuthResponse.prototype = {
       } else {
         result = true;
       }
+    }
+    //default expiration if none found
+    if (!this.expms) {
+      this.expms = defaultExpiration;
     }
     this[this.keyField] = result;
   }
@@ -154,14 +171,27 @@ module.exports = function(authManager) {
       const handlers = getRelevantHandlers(authManager, req.body);
       const authServiceHandleMaps = 
             req[`${UNP.APP_NAME}Data`].webApp.authServiceHandleMaps;
+      
       for (const handler of handlers) {
         const pluginID = handler.pluginID;
         const authPluginSession = getAuthPluginSession(req, pluginID, {});
         req[`${UNP.APP_NAME}Data`].plugin.services = 
           authServiceHandleMaps[pluginID];
         const wasAuthenticated = handler.getStatus(authPluginSession).authenticated;
-        const handlerResult = yield handler[functionName](req,
-                                                          authPluginSession);
+        let handlerResult;
+
+        //dont allow refresh if zlux cant find id or overall session expired
+        const timeout = sessionExpirationMap[req.session.id];
+        if (type === SESSION_ACTION_TYPE_REFRESH
+            && authManager.sessionTimeoutMs !== -1
+            && (!timeout || timeout < Date.now())) {
+          delete sessionExpirationMap[req.session.id];
+          handlerResult = {success:false, reason:REASON_ZLUX_SESSION_EXPIRE};
+        } else {
+          handlerResult = yield handler[functionName](req,
+                                                      authPluginSession);
+        }
+        
         if (handlerResult.success) {
           authLogger.info(`${req.session.id}: Session security call ${functionName} succesful for auth ` 
                           + `handler ${pluginID}. Plugin response: ` + JSON.stringify(handlerResult));
@@ -172,10 +202,15 @@ module.exports = function(authManager) {
         }
         result.addHandlerResult(handlerResult, handler);
       }
-      result.updateStatus();
+      
+      result.updateStatus(authManager.sessionTimeoutMs);
+      if (result.expms !== -1) {
+        sessionExpirationMap[req.session.id] = Date.now() + result.expms;
+      }
+      
       res.status(result.success? 200 : 401).json(result);
     } catch (e) {
-      console.warn(e)
+      authLogger.warn(e);
       res.status(500).send(e.message);
       return;
     }
@@ -222,11 +257,16 @@ module.exports = function(authManager) {
     
     doLogout(req, res) {
       //FIXME XSRF
+      if (req.session.id) {
+        delete sessionExpirationMap[req.session.id];
+      }
       const handlers = getRelevantHandlers(authManager, req.body);
       for (const handler of handlers) {
         const pluginID = handler.pluginID;
         authLogger.debug(`${req.session.id}: User logout for auth handler ${pluginID}`);
-        delete req.session[pluginID];
+        if (req.session.authPlugins) {
+          delete req.session.authPlugins[pluginID];
+        }
       }
       res.status(200).send('');
     },
@@ -248,11 +288,19 @@ module.exports = function(authManager) {
           return;
         }
         const authPluginID = handler.pluginID;
-        const authPluginSession = getAuthPluginSession(req, authPluginID, {});
-        const result = yield handler.authorized(req, authPluginSession, {
-          syncOnly: isWebsocket,
-          bypassAuthorizatonCheck: !authManager.isRbacEnabled()
-        });
+        let result;
+        const timeout = sessionExpirationMap[req.session.id];
+        if (authManager.sessionTimeoutMs !== -1 && (!timeout || timeout < Date.now())) {
+          delete sessionExpirationMap[req.session.id];
+          result = {authenticated:false, authorized: false};
+        }
+        else {
+          const authPluginSession = getAuthPluginSession(req, authPluginID, {});
+          result = yield handler.authorized(req, authPluginSession, {
+            syncOnly: isWebsocket,
+            bypassAuthorizatonCheck: !authManager.isRbacEnabled()
+          });
+        }
         //we only care if its authorized
         if (!result.authorized) {
           const errorResponse = {

--- a/lib/webauth.js
+++ b/lib/webauth.js
@@ -292,7 +292,6 @@ module.exports = function(authManager) {
         const authPluginID = handler.pluginID;
         let result;
         const timeout = req.session.zluxExp;
-        console.log(`timeout for id=${req.session.id} is`,timeout);
         if (authManager.sessionTimeoutMs !== -1 && (!timeout || timeout < Date.now())) {
           req.session.zluxExp = undefined;
           result = {authenticated:false, authorized: false};

--- a/lib/webauth.js
+++ b/lib/webauth.js
@@ -15,6 +15,15 @@ const UNP = require('./unp-constants');
 const authLogger = util.loggers.authLogger;
 const REASON_ZLUX_SESSION_EXPIRE = 'ZLUXSessionExp';
 
+//It is not enough for an auth to not return an expiration value, or 0. It must be explicit
+const TIMEOUT_VALUE_NO_EXPIRE = -1;
+
+function initZLUXSession(req) {
+  if (!req.session.zlux) {
+    req.session.zlux = {};
+  }
+}
+
 function getAuthHandler(req, authManager) {
   const appData = req[`${UNP.APP_NAME}Data`];
   if (appData.service && appData.service.def) {
@@ -169,7 +178,8 @@ module.exports = function(authManager) {
       const handlers = getRelevantHandlers(authManager, req.body);
       const authServiceHandleMaps = 
             req[`${UNP.APP_NAME}Data`].webApp.authServiceHandleMaps;
-      
+
+      const timeout = req.session.zlux ? req.session.zlux.expirationTime : 0;
       for (const handler of handlers) {
         const pluginID = handler.pluginID;
         const authPluginSession = getAuthPluginSession(req, pluginID, {});
@@ -177,13 +187,12 @@ module.exports = function(authManager) {
           authServiceHandleMaps[pluginID];
         const wasAuthenticated = handler.getStatus(authPluginSession).authenticated;
         let handlerResult;
-
+        
         //dont allow refresh if zlux cant find id or overall session expired
-        const timeout = req.session.zluxExp
         if (type === SESSION_ACTION_TYPE_REFRESH
-            && authManager.sessionTimeoutMs !== -1
+            && authManager.sessionTimeoutMs !== TIMEOUT_VALUE_NO_EXPIRE
             && (!timeout || timeout < Date.now())) {
-          req.session.zluxExp = undefined;
+          req.session.zlux = undefined;
           handlerResult = {success:false, reason:REASON_ZLUX_SESSION_EXPIRE};
         } else {
           handlerResult = yield handler[functionName](req,
@@ -202,8 +211,9 @@ module.exports = function(authManager) {
       }
       
       result.updateStatus(authManager.sessionTimeoutMs);
-      if (result.expms !== -1) {
-        req.session.zluxExp = Date.now() + result.expms;
+      if (result.expms !== TIMEOUT_VALUE_NO_EXPIRE) {
+        initZLUXSession(req);
+        req.session.zlux.expirationTime = Date.now() + result.expms;
       }
       
       res.status(result.success? 200 : 401).json(result);
@@ -265,7 +275,7 @@ module.exports = function(authManager) {
       }
       if (Object.keys(req.session.authPlugins).length == 0) {
         if (req.session.id) {
-          req.session.zluxExp = undefined;
+          req.session.zlux = undefined;
         }
         req.sessionStore.destroy(req.session.id);
         req.session.id = null;
@@ -291,9 +301,10 @@ module.exports = function(authManager) {
         }
         const authPluginID = handler.pluginID;
         let result;
-        const timeout = req.session.zluxExp;
-        if (authManager.sessionTimeoutMs !== -1 && (!timeout || timeout < Date.now())) {
-          req.session.zluxExp = undefined;
+        const timeout = req.session.zlux ? req.session.zlux.expirationTime : 0;
+        if (authManager.sessionTimeoutMs !== TIMEOUT_VALUE_NO_EXPIRE
+            && (!timeout || timeout < Date.now())) {
+          req.session.zlux = undefined;
           result = {authenticated:false, authorized: false};
         }
         else {

--- a/lib/webauth.js
+++ b/lib/webauth.js
@@ -257,9 +257,6 @@ module.exports = function(authManager) {
     
     doLogout(req, res) {
       //FIXME XSRF
-      if (req.session.id) {
-        delete sessionExpirationMap[req.session.id];
-      }
       const handlers = getRelevantHandlers(authManager, req.body);
       for (const handler of handlers) {
         const pluginID = handler.pluginID;
@@ -267,6 +264,13 @@ module.exports = function(authManager) {
         if (req.session.authPlugins) {
           delete req.session.authPlugins[pluginID];
         }
+      }
+      if (Object.keys(req.session.authPlugins).length == 0) {
+        if (req.session.id) {
+          delete sessionExpirationMap[req.session.id];
+        }
+        req.sessionStore.destroy(req.session.id);
+        req.session.id = null;
       }
       res.status(200).send('');
     },

--- a/lib/webauth.js
+++ b/lib/webauth.js
@@ -13,8 +13,6 @@ const util = require('./util');
 const UNP = require('./unp-constants');
 
 const authLogger = util.loggers.authLogger;
-
-const sessionExpirationMap = {};
 const REASON_ZLUX_SESSION_EXPIRE = 'ZLUXSessionExp';
 
 function getAuthHandler(req, authManager) {
@@ -181,11 +179,11 @@ module.exports = function(authManager) {
         let handlerResult;
 
         //dont allow refresh if zlux cant find id or overall session expired
-        const timeout = sessionExpirationMap[req.session.id];
+        const timeout = req.session.zluxExp
         if (type === SESSION_ACTION_TYPE_REFRESH
             && authManager.sessionTimeoutMs !== -1
             && (!timeout || timeout < Date.now())) {
-          delete sessionExpirationMap[req.session.id];
+          req.session.zluxExp = undefined;
           handlerResult = {success:false, reason:REASON_ZLUX_SESSION_EXPIRE};
         } else {
           handlerResult = yield handler[functionName](req,
@@ -205,7 +203,7 @@ module.exports = function(authManager) {
       
       result.updateStatus(authManager.sessionTimeoutMs);
       if (result.expms !== -1) {
-        sessionExpirationMap[req.session.id] = Date.now() + result.expms;
+        req.session.zluxExp = Date.now() + result.expms;
       }
       
       res.status(result.success? 200 : 401).json(result);
@@ -267,7 +265,7 @@ module.exports = function(authManager) {
       }
       if (Object.keys(req.session.authPlugins).length == 0) {
         if (req.session.id) {
-          delete sessionExpirationMap[req.session.id];
+          req.session.zluxExp = undefined;
         }
         req.sessionStore.destroy(req.session.id);
         req.session.id = null;
@@ -293,9 +291,10 @@ module.exports = function(authManager) {
         }
         const authPluginID = handler.pluginID;
         let result;
-        const timeout = sessionExpirationMap[req.session.id];
+        const timeout = req.session.zluxExp;
+        console.log(`timeout for id=${req.session.id} is`,timeout);
         if (authManager.sessionTimeoutMs !== -1 && (!timeout || timeout < Date.now())) {
-          delete sessionExpirationMap[req.session.id];
+          req.session.zluxExp = undefined;
           result = {authenticated:false, authorized: false};
         }
         else {


### PR DESCRIPTION
The zlux cookie used to have a timeout on it, but it didn't make too much sense versus the individual auth timeouts.
Now, this has been removed in favor of server-side tracking, and the server counts an expiration based on the latest timeout for all auths related to a session.
This makes use of the session object that comes from the cluster, so this works both in single process mode and in cluster mode.