### PR TITLE
Temp workaround for callservice of auth handlers throwing exception

### DIFF
--- a/lib/webapp.js
+++ b/lib/webapp.js
@@ -346,7 +346,12 @@ const commonMiddleware = {
         try {
           const allHandles = this.services[name];
           let version = '_current';
-          if (appData.service.def.versionRequirements 
+          if (appData.service.def
+              /* 
+                 TODO this does not cover the case in which an auth plugin wanted to do callService. See: zosmf-auth
+                 In that case, appData.service = {} because it isn't a service itself.
+              */
+              && appData.service.def.versionRequirements 
               && appData.service.def.versionRequirements[name]) {
             version = appData.service.def.versionRequirements[name];
           }


### PR DESCRIPTION
Farther out: need a design for this... can auth handlers have similar attributes to service? If so, then it could be appData.service or appData.auth.

See https://github.com/zowe/zlux-server-framework/pull/106 for a PR that can be used to test behavior.
Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>