### PR TITLE
Fix for node 6

### DIFF
--- a/lib/swagger-catalog.js
+++ b/lib/swagger-catalog.js
@@ -11,6 +11,7 @@
 
 
 const express = require('express');
+const Promise = require('bluebird');
 const zLuxUrl = require('./url')
 const path = require('path');
 const fs = require('fs');
@@ -87,7 +88,7 @@ function makeCatalogForPlugin(plugin, productCode, nodeContext) {
   })
 }
 
-async function getSwaggerDocs(plugin, productCode, nodeContext) {
+var getSwaggerDocs = Promise.coroutine(function* (plugin, productCode, nodeContext) {
   var allServiceDocs = [];
   if (plugin.dataServices){
     for (let i = 0; i < plugin.dataServices.length; i++) {
@@ -98,16 +99,19 @@ async function getSwaggerDocs(plugin, productCode, nodeContext) {
         continue; //resolve never... API enhancement needed if this is desired
       }
       installLog.debug(`Reading swagger for ${plugin.identifier}:${service.name}`);
-      let fileContent = await readSingleSwaggerFile(path.join(plugin.location, "doc/swagger"),
-                                                    service.name,
-                                                    service.version).catch((err) => {
-            if (err.code === 'ENOENT') {
-              installLog.warn(`Swagger file for service (${plugin.identifier}:${service.name}) not found`);
-            } else {
-              installLog.warn(`Invalid Swagger from file for service (${plugin.identifier}:${service.name})`);
-              installLog.warn(err);
-            }
-          })
+      let fileContent;
+      try {
+        fileContent = yield readSingleSwaggerFile(path.join(plugin.location, "doc/swagger"),
+                                                  service.name,
+                                                  service.version);
+      } catch (err) {
+        if (err.code === 'ENOENT') {
+          installLog.warn(`Swagger file for service (${plugin.identifier}:${service.name}) not found`);
+        } else {
+          installLog.warn(`Invalid Swagger from file for service (${plugin.identifier}:${service.name})`);
+          installLog.warn(err);
+        }
+      }
       if (fileContent) {
         fileContent = overwriteSwaggerFieldsForServer(fileContent, 
                                                       zLuxUrl.makePluginURL(productCode, plugin.identifier),
@@ -121,7 +125,7 @@ async function getSwaggerDocs(plugin, productCode, nodeContext) {
     }
   }
   return allServiceDocs;
-}
+})
 
 function readSingleSwaggerFile (dirName, serviceName, serviceVersion) {
   // read one swagger file and validate the json that is returned


### PR DESCRIPTION
Fixes that https://github.com/zowe/zlux-server-framework/pull/99 required node8+ due to the keyword "async". Making use of bluebird to support 6 instead.