### PR TITLE
Try-catch around java manager loading

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -22,7 +22,6 @@ const unp = require('./unp-constants');
 const http = require('http');
 const ApimlConnector = require('./apiml');
 const checkProxiedHost = require('./proxy').checkProxiedHost;
-const javaManager = require('./javaManager');
 const bootstrapLogger = util.loggers.bootstrapLogger;
 const installLogger = util.loggers.installLogger;
 const ipaddr = require('ipaddr.js');
@@ -62,7 +61,15 @@ function Server(appConfig, userConfig, startUpConfig, options) {
   let langManagers = [];
   this.langManagers = langManagers;
   if (userConfig.languages && userConfig.languages.java) {
-    langManagers.push(new javaManager.JavaManager(userConfig.languages.java, userConfig.instanceDir, serverUrl));
+    try {
+      const javaManager = require('./javaManager');
+      let instance = new javaManager.JavaManager(userConfig.languages.java, userConfig.instanceDir, serverUrl);
+      langManagers.push(instance);
+    } catch (e) {
+      bootstrapLogger.warn(`Could not initialize Java manager. Java services from Apps will not be able to load\n`,
+                           e.stack);
+    }
+    
   }
 
   this.processManager = new ProcessManager(true, langManagers);


### PR DESCRIPTION
Do not require or create an instance of java manger without a try-catch and only when config requests it

Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>