### PR TITLE
Compatibility for auth handlers without refresh (Revisited)

### DIFF
--- a/lib/webauth.js
+++ b/lib/webauth.js
@@ -155,15 +155,6 @@ StatusResponse.prototype = {
   keyField: "authenticated"
 }
 
-function getCapabilities(handler){
-  const handlerFuncs = ['getStatus', 'authenticate', 'refreshStatus', 'authorized', 'addProxyAuthorizations'];
-  let capabilities = {};
-  for(let func of handlerFuncs){
-    capabilities[func] = (typeof handler[func] === 'function');
-  }
-  return capabilities;
-}
-
 const SESSION_ACTION_TYPE_AUTHENTICATE = 1;
 const SESSION_ACTION_TYPE_REFRESH = 2;
 

--- a/lib/webauth.js
+++ b/lib/webauth.js
@@ -208,13 +208,16 @@ module.exports = function(authManager) {
           }
         } else {
           authLogger.warn(`${pluginID} does not have getCapabilities() function defined`);
-          handlerReuslt = (functionName == 'refreshStatus') ? { success: true } : yield handler[functionName](req, authPluginSession);
+          handlerResult = (functionName == 'refreshStatus') ? { success: true } : yield handler[functionName](req, authPluginSession);
         }
           
         if (handlerResult.success) {
           authLogger.info(`${req.session.id}: Session security call ${functionName} succesful for auth ` 
                           + `handler ${pluginID}. Plugin response: ` + JSON.stringify(handlerResult));
-        }          
+        } else {
+          authLogger.info(`${req.session.id}: Session security call ${functionName} failed for auth ` 
+                          + `handler ${pluginID}. Plugin response: ` + JSON.stringify(handlerResult));
+        }
         //do not modify session if not authenticated or deauthenticated
         if (wasAuthenticated || handlerResult.success) {
           setAuthPluginSession(req, pluginID, authPluginSession);

--- a/lib/webauth.js
+++ b/lib/webauth.js
@@ -180,23 +180,37 @@ module.exports = function(authManager) {
             req[`${UNP.APP_NAME}Data`].webApp.authServiceHandleMaps;
 
       const timeout = req.session.zlux ? req.session.zlux.expirationTime : 0;
+      //let refreshHandlers = [];
       for (const handler of handlers) {
         const pluginID = handler.pluginID;
         const authPluginSession = getAuthPluginSession(req, pluginID, {});
         req[`${UNP.APP_NAME}Data`].plugin.services = 
           authServiceHandleMaps[pluginID];
-        const wasAuthenticated = handler.getStatus(authPluginSession).authenticated;
-        let handlerResult;
         
-        //dont allow refresh if zlux cant find id or overall session expired
-        if (type === SESSION_ACTION_TYPE_REFRESH
+        const authHandlerStatus = handler.getStatus(authPluginSession);
+        const wasAuthenticated = authHandlerStatus.authenticated;
+        if((typeof handler.getCapabilities) !== 'function'){
+          authLogger.warn(`${pluginID} does not have getCapabilities() function defined`);
+        }
+        let handlerResult;
+
+        if(handler.getCapabilities().canRefresh === true){
+          //refreshHandlers.push(handler);
+          authLogger.info(`${pluginID} can refresh`);
+          //dont allow refresh if zlux cant find id or overall session expired
+          if (type === SESSION_ACTION_TYPE_REFRESH
             && authManager.sessionTimeoutMs !== TIMEOUT_VALUE_NO_EXPIRE
             && (!timeout || timeout < Date.now())) {
           req.session.zlux = undefined;
           handlerResult = {success:false, reason:REASON_ZLUX_SESSION_EXPIRE};
+          } else {
+            handlerResult = yield handler[functionName](req,
+                                                        authPluginSession);
+          }
         } else {
-          handlerResult = yield handler[functionName](req,
-                                                      authPluginSession);
+          authLogger.info(`${pluginID} cannot refresh session, attempting to authenticate`);
+          handlerResult = yield handler['authenticate'](req,
+            authPluginSession);
         }
         
         if (handlerResult.success) {

--- a/lib/webauth.js
+++ b/lib/webauth.js
@@ -155,6 +155,15 @@ StatusResponse.prototype = {
   keyField: "authenticated"
 }
 
+function getCapabilities(handler){
+  const handlerFuncs = ['getStatus', 'authenticate', 'refreshStatus', 'authorized', 'addProxyAuthorizations'];
+  let capabilities = {};
+  for(let func of handlerFuncs){
+    capabilities[func] = (typeof handler[func] === 'function');
+  }
+  return capabilities;
+}
+
 const SESSION_ACTION_TYPE_AUTHENTICATE = 1;
 const SESSION_ACTION_TYPE_REFRESH = 2;
 
@@ -180,7 +189,6 @@ module.exports = function(authManager) {
             req[`${UNP.APP_NAME}Data`].webApp.authServiceHandleMaps;
 
       const timeout = req.session.zlux ? req.session.zlux.expirationTime : 0;
-      //let refreshHandlers = [];
       for (const handler of handlers) {
         const pluginID = handler.pluginID;
         const authPluginSession = getAuthPluginSession(req, pluginID, {});
@@ -189,30 +197,29 @@ module.exports = function(authManager) {
         
         const authHandlerStatus = handler.getStatus(authPluginSession);
         const wasAuthenticated = authHandlerStatus.authenticated;
-        if((typeof handler.getCapabilities) !== 'function'){
-          authLogger.warn(`${pluginID} does not have getCapabilities() function defined`);
-        }
+        const hasGetCapabilities = !!((typeof handler.getCapabilities) === 'function');
         let handlerResult;
 
-        if(handler.getCapabilities().canRefresh === true){
-          //refreshHandlers.push(handler);
-          authLogger.info(`${pluginID} can refresh`);
-          //dont allow refresh if zlux cant find id or overall session expired
+        /*
+          The logic for performing refreshStatus()/authenticate() calls has been wrapped in a check for the presence of
+          the getCapabilities() function because functions that do not include getCapabilities() likely dont support refreshing (or haven't been maintained).  
+          If a service calls refreshStatus on an auth handler that does not support it,
+          { success: true } is returned so that the session may expire naturally and users are not forced to log in every time they refresh.
+        */
+        if(hasGetCapabilities){
           if (type === SESSION_ACTION_TYPE_REFRESH
-            && authManager.sessionTimeoutMs !== TIMEOUT_VALUE_NO_EXPIRE
-            && (!timeout || timeout < Date.now())) {
-          req.session.zlux = undefined;
-          handlerResult = {success:false, reason:REASON_ZLUX_SESSION_EXPIRE};
+              && authManager.sessionTimeoutMs !== TIMEOUT_VALUE_NO_EXPIRE
+              && (!timeout || timeout < Date.now())) {
+            req.session.zlux = undefined;
+            handlerResult = {success:false, reason:REASON_ZLUX_SESSION_EXPIRE};
           } else {
-            handlerResult = yield handler[functionName](req,
-                                                        authPluginSession);
+            handlerResult = (functionName == 'refreshStatus' && !handler.getCapabilities().canRefresh === true) ? { success: true } : yield handler[functionName](req, authPluginSession);
           }
         } else {
-          authLogger.info(`${pluginID} cannot refresh session, attempting to authenticate`);
-          handlerResult = yield handler['authenticate'](req,
-            authPluginSession);
+          authLogger.warn(`${pluginID} does not have getCapabilities() function defined`);
+          handlerReuslt = (functionName == 'refreshStatus') ? { success: true } : yield handler[functionName](req, authPluginSession);
         }
-        
+          
         if (handlerResult.success) {
           authLogger.info(`${req.session.id}: Session security call ${functionName} succesful for auth ` 
                           + `handler ${pluginID}. Plugin response: ` + JSON.stringify(handlerResult));

--- a/lib/webauth.js
+++ b/lib/webauth.js
@@ -195,19 +195,18 @@ module.exports = function(authManager) {
          authLogger.warn(`${pluginID}: getCapabilities() is not a function`);
        }
 
-       if (type === SESSION_ACTION_TYPE_REFRESH
-            && authManager.sessionTimeoutMs !== TIMEOUT_VALUE_NO_EXPIRE
-            && (!timeout || timeout < Date.now())) {
-          req.session.zlux = undefined;
-          handlerResult = {success:false, reason:REASON_ZLUX_SESSION_EXPIRE};
-        } else {
-          if((hasGetCapabilities
-              && handler.getCapabilities().canRefresh
-              && functionName == 'refreshStatus') || functionName == 'authenticate'){
-            handlerResult = yield handler[functionName](req, authPluginSession);
+        if(type === SESSION_ACTION_TYPE_REFRESH){
+          if(authManager.sessionTimeoutMs !== TIMEOUT_VALUE_NO_EXPIRE
+              && (!timeout || timeout < Date.now())){
+            req.session.zlux = undefined;
+            handlerResult = {success:false, reason:REASON_ZLUX_SESSION_EXPIRE};
+          } else if (hasGetCapabilities && handler.getCapabilities().canRefresh){
+            handlerResult = yield handler.refreshStatus(req, authPluginSession);
           } else {
             handlerResult = { success: true };
           }
+        } else if(type == SESSION_ACTION_TYPE_AUTHENTICATE){
+          handlerResult = yield handler.authenticate(req, authPluginSession);
         }
           
         if (handlerResult.success) {

--- a/lib/webauth.js
+++ b/lib/webauth.js
@@ -191,25 +191,23 @@ module.exports = function(authManager) {
         const hasGetCapabilities = !!((typeof handler.getCapabilities) === 'function');
         let handlerResult;
 
-        /*
-          The logic for performing refreshStatus()/authenticate() calls has been wrapped in a check for the presence of
-          the getCapabilities() function because functions that do not include getCapabilities() likely dont support refreshing (or haven't been maintained).  
-          If a service calls refreshStatus on an auth handler that does not support it,
-          { success: true } is returned so that the session may expire naturally and users are not forced to log in every time they refresh.
-        */
        if(!hasGetCapabilities){
          authLogger.warn(`${pluginID}: getCapabilities() is not a function`);
        }
-       
+
        if (type === SESSION_ACTION_TYPE_REFRESH
             && authManager.sessionTimeoutMs !== TIMEOUT_VALUE_NO_EXPIRE
             && (!timeout || timeout < Date.now())) {
           req.session.zlux = undefined;
           handlerResult = {success:false, reason:REASON_ZLUX_SESSION_EXPIRE};
-        } else if(hasGetCapabilities && handler.getCapabilities().canRefresh === true && functionName == 'refreshStatus'){
-          handlerResult = yield handler[functionName](req, authPluginSession);
         } else {
-          handlerResult = (functionName == 'refreshStatus') ? { success: true } : yield handler[functionName](req, authPluginSession);
+          if((hasGetCapabilities
+              && handler.getCapabilities().canRefresh
+              && functionName == 'refreshStatus') || functionName == 'authenticate'){
+            handlerResult = yield handler[functionName](req, authPluginSession);
+          } else {
+            handlerResult = { success: true };
+          }
         }
           
         if (handlerResult.success) {

--- a/lib/webauth.js
+++ b/lib/webauth.js
@@ -197,17 +197,18 @@ module.exports = function(authManager) {
           If a service calls refreshStatus on an auth handler that does not support it,
           { success: true } is returned so that the session may expire naturally and users are not forced to log in every time they refresh.
         */
-        if(hasGetCapabilities){
-          if (type === SESSION_ACTION_TYPE_REFRESH
-              && authManager.sessionTimeoutMs !== TIMEOUT_VALUE_NO_EXPIRE
-              && (!timeout || timeout < Date.now())) {
-            req.session.zlux = undefined;
-            handlerResult = {success:false, reason:REASON_ZLUX_SESSION_EXPIRE};
-          } else {
-            handlerResult = (functionName == 'refreshStatus' && !handler.getCapabilities().canRefresh === true) ? { success: true } : yield handler[functionName](req, authPluginSession);
-          }
+       if(!hasGetCapabilities){
+         authLogger.warn(`${pluginID}: getCapabilities() is not a function`);
+       }
+       
+       if (type === SESSION_ACTION_TYPE_REFRESH
+            && authManager.sessionTimeoutMs !== TIMEOUT_VALUE_NO_EXPIRE
+            && (!timeout || timeout < Date.now())) {
+          req.session.zlux = undefined;
+          handlerResult = {success:false, reason:REASON_ZLUX_SESSION_EXPIRE};
+        } else if(hasGetCapabilities && handler.getCapabilities().canRefresh === true && functionName == 'refreshStatus'){
+          handlerResult = yield handler[functionName](req, authPluginSession);
         } else {
-          authLogger.warn(`${pluginID} does not have getCapabilities() function defined`);
           handlerResult = (functionName == 'refreshStatus') ? { success: true } : yield handler[functionName](req, authPluginSession);
         }
           

--- a/plugins/internal-auth/lib/internalAuth.js
+++ b/plugins/internal-auth/lib/internalAuth.js
@@ -44,7 +44,16 @@ function internalAuthenticator(pluginDef, pluginConf, serverConf) {
       resources: pluginConf.getContents(['resources.json'])
     };
   }
+  this.capabilities = {
+    "canGetStatus": false,
+    "canRefresh": false,
+    "canAuthenticate": true,
+    "canAuthorize": true,
+    "proxyAuthorizations": false
+  };
 }
+
+internalAuthenticator.prototype.authorized = () => {return this.capabilities};
 
 /*access requested is one of GET,PUT,POST,DELETE*/
 internalAuthenticator.prototype.authorized = function(override,userName,resourceName,success,failure) {

--- a/plugins/internal-auth/lib/internalAuth.js
+++ b/plugins/internal-auth/lib/internalAuth.js
@@ -53,7 +53,7 @@ function internalAuthenticator(pluginDef, pluginConf, serverConf) {
   };
 }
 
-internalAuthenticator.prototype.authorized = () => {return this.capabilities};
+internalAuthenticator.prototype.getCapabilities = () => {return this.capabilities};
 
 /*access requested is one of GET,PUT,POST,DELETE*/
 internalAuthenticator.prototype.authorized = function(override,userName,resourceName,success,failure) {

--- a/plugins/trivial-auth/lib/trivialAuth.js
+++ b/plugins/trivial-auth/lib/trivialAuth.js
@@ -12,7 +12,7 @@ function TrivialAuthenticator(pluginDef, pluginConf, serverConf) {
   this.authPluginID = pluginDef.identifier;
   this.capabilities = {
     "canGetStatus": true,
-    "canRefresh": false,
+    "canRefresh": true,
     "canAuthenticate": true,
     "canAuthorize": true,
     "proxyAuthorizations": false

--- a/plugins/trivial-auth/lib/trivialAuth.js
+++ b/plugins/trivial-auth/lib/trivialAuth.js
@@ -10,9 +10,20 @@
 
 function TrivialAuthenticator(pluginDef, pluginConf, serverConf) {
   this.authPluginID = pluginDef.identifier;
+  this.capabilities = {
+    "canGetStatus": true,
+    "canRefresh": false,
+    "canAuthenticate": true,
+    "canAuthorize": true,
+    "proxyAuthorizations": false
+  };
 }
 
 TrivialAuthenticator.prototype = {
+
+  getCapabilities(){
+    return this.capabilities;
+  },
 
   getStatus(sessionState) {
     return {


### PR DESCRIPTION
Old authentication handlers which do not support session refreshing will not longer return a 400 or 500 error due to lack of capability, but will allow the session to expire naturally (user logs out/timeout).

Must be merged with:
https://github.com/zowe/zss-auth/pull/19
https://github.com/zowe/zosmf-auth/pull/14

Signed-off-by: Timothy Gerstel tgerstel@rocketsoftware.com