### PR TITLE
Bugfix - Fix PFX & Hide Password

### DIFF
--- a/lib/encryption.js
+++ b/lib/encryption.js
@@ -54,7 +54,6 @@ function decryptWithKeyAndIV(text,key,iv) {
 exports.encryptWithKeyAndIV = encryptWithKeyAndIV;
 exports.decryptWithKeyAndIV = decryptWithKeyAndIV;
 exports.getKeyFromPassword = getKeyFromPassword;
-exports.getKeyFromPasswordSync = getKeyFromPasswordSync;
 exports.encryptWithKey = encryptWithKey;
 exports.decryptWithKey = decryptWithKey;
 

--- a/lib/reader.js
+++ b/lib/reader.js
@@ -29,16 +29,17 @@ Reader.prototype = {
       // The below logic only works in hiding the password for non-mingw terminals
       // aka: for when the terminal is in raw mode
       if (process.stdout.isTTY) { 
-        stdin.on('data', function(c) {
-          c+='';
-          switch (c) {
-          case '\n':
-          case '\r':
-            stdin.pause();
-            break;
-          default:
-            process.stdout.write('\b*');
-          }
+        let waiting = false;
+        process.stdin.on("data", function(data) {
+          'use strict';
+            readline.cursorTo(process.stdout, 0);
+            readline.clearLine(process.stdout);
+        })
+        this.readlineReader.question(question + "\n", (answer) => {
+          resolve(answer);
+          
+          if (this.readlineReader.history)
+          this.readlineReader.history = this.readlineReader.history.slice(1); 
         });
       }
       // The below logic works in hiding the password for mingw terminals where setRawMode() is unavailable
@@ -58,13 +59,13 @@ Reader.prototype = {
                 clearInterval(i);
             }
         }, 0);
+        this.readlineReader.question(question, (answer) => {
+          resolve(answer);
+          
+          if (this.readlineReader.history)
+          this.readlineReader.history = this.readlineReader.history.slice(1); 
+        });
       }
-      this.readlineReader.question(question, (answer) => {
-        resolve(answer);
-        
-        if (this.readlineReader.history)
-        this.readlineReader.history = this.readlineReader.history.slice(1); 
-      });
     })
   },
 

--- a/lib/reader.js
+++ b/lib/reader.js
@@ -11,11 +11,26 @@
 */
 
 const readline = require('readline');
+var Prompt = require('prompt-password');
+const readlineSync = require('readline-sync');
+var Writable = require('stream').Writable;
+
+var mutableStdout = new Writable({
+  write: function(chunk, encoding, callback) {
+    if (!this.muted)
+      process.stdout.write(chunk, encoding);
+    callback();
+  }
+});
+
+mutableStdout.muted = false;
+process.stdin.muted = true;
 
 function Reader() {
   this.readlineReader = readline.createInterface({
     input: process.stdin,
-    output: process.stdout
+    output: process.stdout,
+    terminal: false
   });
 }
 Reader.prototype = {
@@ -24,28 +39,34 @@ Reader.prototype = {
 
   readPassword(question) {
     return new Promise((resolve, reject) => {
-      const stdin = process.openStdin();
-      stdin.on('data', function(c) {
-        c+='';
-        switch (c) {
-        case '\n':
-        case '\r':
-          stdin.pause();
-          break;
-        default:
-          process.stdout.write('\b*');
+
+      var prompt = new Prompt({
+        type: 'password',
+        message: 'Enter your password please',
+        name: 'password',
+        mask: function(input) {
+          return 'H' + new Array(String(input).length).join('H');
         }
       });
-      this.readlineReader.question(question, (answer) => {
-        resolve(answer);
-        //do not retain the history of the password for future questions
-        this.readlineReader.history = this.readlineReader.history.slice(1); 
-      });
+       
+      prompt.run()
+        .then(function(answers) {
+          resolve(answers);
+        });
+
+        //process.stdin.resume();
+
     })
   },
 
   close() {
     this.readlineReader.close();
+  }, 
+
+  readPasswordSync (question) {
+   let passPhrase = readlineSync.question(question, {hideEchoBack: true, caseSensitive: true, print: function(display, encoding)
+     { process.stdout.write("Passphrase received...\n", encoding); }} );
+   return passPhrase
   }
 };
 

--- a/lib/webserver.js
+++ b/lib/webserver.js
@@ -241,7 +241,7 @@ WebServer.prototype = {
   },
 
   messageAndDelay(milliseconds, message) {
-    process.stdout.write("\n" + message + "\n");
+    networkLogger.info("\n" + message + "\n");
     var start = new Date().getTime();
     for (var i = 0; i < 1e7; i++) {
       if ((new Date().getTime() - start) > milliseconds){

--- a/lib/webserver.js
+++ b/lib/webserver.js
@@ -199,6 +199,7 @@ WebServer.prototype = {
             this.httpsServers.push(httpsServer);
             this.expressWsHttps.push(expressWs(app, httpsServer, {maxPayload: 50000}));
             listening = true;
+            this.messageAndDelay(1000, "Server creation successful.");
           } catch (e) {
             if (e.message == 'mac verify failure') {
               const r = new reader();
@@ -239,6 +240,16 @@ WebServer.prototype = {
     methodServer.listen(port, ipAddress, logFunction);
   },
 
+  messageAndDelay(milliseconds, message) {
+    process.stdout.write("\n" + message + "\n");
+    var start = new Date().getTime();
+    for (var i = 0; i < 1e7; i++) {
+      if ((new Date().getTime() - start) > milliseconds){
+        break;
+      }
+    }
+  },
+
   close() {
     this.httpServers.forEach((server)=> {
       let info = server.address();
@@ -256,7 +267,7 @@ WebServer.prototype = {
       }
       server.close();      
     });
-  }
+  },
 };
 
 module.exports = WebServer;

--- a/lib/webserver.js
+++ b/lib/webserver.js
@@ -22,6 +22,8 @@ const expressWs = require('express-ws');
 const util = require('./util');
 const constants = require('./unp-constants');
 const reader = require('./reader');
+const readlineSync = require('readline-sync');
+const read = require('read');
 const crypto = require('crypto');
 
 const bootstrapLogger = util.loggers.bootstrapLogger;
@@ -186,6 +188,9 @@ WebServer.prototype = {
   },
 
   startListening: Promise.coroutine(function* (app) {
+    // let start = Date.now();
+    //     let end = start + 5000;
+    //     while (Date.now() < end) {}
     if (this.config.https && this.config.https.port) {
       const port = this.config.https.port;
       for (let ipAddress of this.config.https.ipAddresses) {
@@ -201,10 +206,15 @@ WebServer.prototype = {
             listening = true;
           } catch (e) {
             if (e.message == 'mac verify failure') {
-              const r = reader();
+              const r = new reader();
               try {
-                this.httpsOptions.passphrase = yield reader.readPassword(
-                  'HTTPS key or PFX decryption failure. Please enter passphrase: ');
+                //process.removeAllListeners();
+                //process.env.removeAllListeners();
+                this.httpsOptions.passphrase = r.readPassword(
+                  'HTTPS key or PFX decryption failure. Please enter passphrase: ').next().value;
+                  });
+                // read({prompt: "Please enter passphrase: ", default: "test-question"}, function (response) {
+                // })
               } finally {
                 r.close();
               }


### PR DESCRIPTION
• Fixes previous PFX syntax errors so that PFX can be used as an authentication container for Zowe keys & certificates
• Enhancement to PFX password prompt that hides password, even when terminals don't allow functionality to hide input, usually meaning the input is cooked and rawMode cannot be set (for ex: Git Bash only processes input after a line break and has no detection of keypress to mututate chars into '*' for example)
• Fixes a bug where old PFX password hiding logic (asterisks) would break with backspace on Windows

![image](https://user-images.githubusercontent.com/20528015/60369728-9a1fef00-99c2-11e9-9bfb-45a1e7b478c2.png)

**No PFX file to test with?**
In Git Bash, you can generate one very simply by navigating to `/zlux-app-server/deploy/product/ZLUX/serverConfig` and running
`certutil -mergepfx zlux.keystore.cer out.pfx`
Certutil should be a built-in utility that will take the zlux.keystore certificate and make it into a PFX "out.pfx"

To use the PFX, go to `zlux-app-server\deploy\instance\ZLUX\serverConfig\zluxserver.json`
and comment out

"keys": ["../deploy/product/ZLUX/serverConfig/zlux.keystore.key"],
 "certificates": ["../deploy/product/ZLUX/serverConfig/zlux.keystore.cer"],
"certificateAuthorities": ["../deploy/product/ZLUX/serverConfig/apiml-localca.cer"]

into

"pfx": "../deploy/product/ZLUX/serverConfig/out.pfx"
// "keys": ["../deploy/product/ZLUX/serverConfig/zlux.keystore.key"],
// "certificates": ["../deploy/product/ZLUX/serverConfig/zlux.keystore.cer"],
// "certificateAuthorities": ["../deploy/product/ZLUX/serverConfig/apiml-localca.cer"]

**Note: To have the password prompt appear, you need to disable output to log. **
Currently, we don't have a way to use the terminal for output & log at the same time. Usi To have the password prompt appear in terminal so you can type inside it, go inside `C:\Users\lastrakou\Desktop\src3\zlux\zlux-app-server\bin\`
and change
 `node --harmony zluxServer.js --config=../deploy/instance/ZLUX/serverConfig/zluxserver.json %* > %ZLUX_NODE_LOG_DIR%\nodeServer.log 2>&1`
into 
`node --harmony zluxServer.js --config=../deploy/instance/ZLUX/serverConfig/zluxserver.json %*`

Or use [https://github.com/zowe/zlux-app-server/pull/62](url)
