### PR TITLE
Retreive plugin default config from plugin dir

### DIFF
--- a/lib/plugin-loader.js
+++ b/lib/plugin-loader.js
@@ -163,7 +163,7 @@ ExternalService.prototype = {
 }
 
 function makeDataService(def, plugin, context) {
-  const configuration = configService.getServiceConfiguration(plugin.identifier,
+  const configuration = configService.getServiceConfiguration(plugin.identifier, plugin.location,
       def.name, context.config, context.productCode);
   let dataservice;
   if (def.type == "external") {
@@ -653,8 +653,8 @@ PluginLoader.prototype = {
     for (const pluginDef of sortedAndRejectedPlugins.plugins) { 
       try {
         const pluginConfiguration = configService.getPluginConfiguration(
-            pluginDef.identifier, this.options.serverConfig,
-            this.options.productCode);
+          pluginDef.identifier, pluginDef.location,
+          this.options.serverConfig, this.options.productCode);
         bootstrapLogger.debug(`For plugin with id=${pluginDef.identifier}, internal config` 
                                 + ` found=\n${JSON.stringify(pluginConfiguration)}`);
 
@@ -713,8 +713,8 @@ PluginLoader.prototype = {
     //
     bootstrapLogger.info("Adding dynamic plugin " + pluginDef.identifier);
     const pluginConfiguration = configService.getPluginConfiguration(
-      pluginDef.identifier, this.options.serverConfig,
-      this.options.productCode);
+      pluginDef.identifier, pluginDef.location,
+      this.options.serverConfig, this.options.productCode);
     const plugin = makePlugin(pluginDef, pluginConfiguration, null, pluginContext,
         true);
 //    if (!this.unresolvedImports.allImportsResolved(pluginContext.plugins)) {


### PR DESCRIPTION
To solve the issue of how plugins can ship default behavior that can be overridden while having read-only directories for server & plugins, plugins must keep their default config files within their root folder. So, the config service must be made to locate the plugin directory to read there as part of its decision making as to what config gets returned. This turns **plugin** into the new broadest scope of config service, but otherwise has the characteristics of the **product** scope.