### PR TITLE
Use English as a fallback for log messages

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -45,12 +45,22 @@ module.exports.initLoggerMessages = function initLoggerMessages(logLanguage) {
   try { // Attempt to get a log message for a language a user may have specified
     var logFile = require(`./assets/i18n/log/messages_${logLanguage}.json`);
     messages = logFile;
-  } catch (err) { // If we cannot get the file...
-      try { // Attempt to get a default message file (English)
-        var logFile = require(`./assets/i18n/log/messages_en.json`);
-        messages = logFile;
+
+    var logFileEN = require(`./assets/i18n/log/messages_en.json`);
+    messages = { ...logFileEN, ...messages } // Merge the two, with the language-specific file
+    // overwriting the non-English one (so English messages get preserved even if no translations exist)
+
+  } catch (err) { // If we encountered an error...
+      try {
+        if (messages) { // and 'messages' exist, then these messages came from a language file,
+          // but the EN language file lookup failed (that is why we are in this catch), so we are all done here.
+        } 
+        else { // If 'messages' does not exist, then the first 'logFile' lookup failed and put us here,
+          var logFileEN = require(`./assets/i18n/log/messages_en.json`); // so let's try English.
+          messages = logFileEN;
+        }
       }
-      catch (err) { // If all else fails, create loggers without specified messages
+      catch (err) { // If all else fails, create loggers without specified messages.
         messages = undefined;
       }
   }


### PR DESCRIPTION
Use English as a fallback for log messages, so for example:

English
**"Z0001", "Z0002", "Z0003"**

Russian
**"RU001"**

A Russian-selected server log message now has
**"Z0001", "Z0002", "Z0003"** & **"RU001"** instead of just **"RU001"**

Signed-off-by: Leanid Astrakou <lastrakou@rocketsoftware.com>