### PR TITLE
Feature/server lifecycle enhancements

### DIFF
--- a/lib/clusterManager.js
+++ b/lib/clusterManager.js
@@ -40,7 +40,6 @@ const maxWorkers = process.env.maxWorkers || cpuCount;
 const workerChangeDecisionDelay = process.env.workerChangeDecisionDelay || 4;
 
 var ClusterManager = function() {
-  console.log("\nCLUSTER MODE BABY!!!!!!!!!!!!!!!!!!\n");
   this.isMaster = cluster.isMaster;
   this.messageIndex = 0;
   this.workersNum = minWorkers;
@@ -157,6 +156,7 @@ if (cluster.isMaster) {
     });
   }
 
+  // WIP
   ClusterManager.prototype.scanForNewPlugins = function() {
     let workers = Object.assign({},this.workers);
     const workerKeys = Object.keys(workers);

--- a/lib/clusterManager.js
+++ b/lib/clusterManager.js
@@ -495,7 +495,6 @@ if (cluster.isMaster) {
   }
 
   ClusterManager.prototype.scanForNewPlugins = function(cb) {
-    console.log("YEET YEET");
     this.callClusterMethodRemote(null, "clusterManager", "scanForNewPlugins", [],
       function() {
         cb();

--- a/lib/clusterManager.js
+++ b/lib/clusterManager.js
@@ -24,6 +24,7 @@ const MessageTypes = {
 const Notifications = {
   initOnce : "initOnce",
   addDynamicPlugin : "addDynamicPlugin",
+  scanPlugins: "scanPlugins"
 };
 
 const events = require('events');
@@ -39,6 +40,7 @@ const maxWorkers = process.env.maxWorkers || cpuCount;
 const workerChangeDecisionDelay = process.env.workerChangeDecisionDelay || 4;
 
 var ClusterManager = function() {
+  console.log("\nCLUSTER MODE BABY!!!!!!!!!!!!!!!!!!\n");
   this.isMaster = cluster.isMaster;
   this.messageIndex = 0;
   this.workersNum = minWorkers;
@@ -140,6 +142,37 @@ if (cluster.isMaster) {
         }
       });
     });
+  }
+
+  ClusterManager.prototype.reloadAllWorkers = function() {
+    let workers = Object.assign({},this.workers);
+    const workerKeys = Object.keys(workers);
+    console.log(`keys=`,workerKeys);
+    workerKeys.forEach((key)=> {
+      let worker = workers[key];
+      console.log(`worker=`,worker);
+      console.log('killing worker pid='+worker.process.pid);
+      delete workers[key];
+      worker.kill();
+    });
+  }
+
+  ClusterManager.prototype.scanForNewPlugins = function() {
+    let workers = Object.assign({},this.workers);
+    const workerKeys = Object.keys(workers);
+    console.log(`keys=`,workerKeys);
+    workerKeys.forEach((key)=> {
+      let worker = workers[key];
+      console.log(`worker=`,worker);
+      console.log('killing worker pid='+worker.process.pid);
+      delete workers[key];
+      worker.kill();
+    });
+  }
+
+   ClusterManager.prototype.notifyWorkersForAddingPlugin = function(resultHandler, indexInCluster) {
+    this.notifyWorkers(Notifications.scanPlugins, indexInCluster);
+    resultHandler(true);
   }
 
   ClusterManager.prototype.startWorkers = function() {
@@ -433,6 +466,10 @@ if (cluster.isMaster) {
     this.once(Notifications.initOnce, handler);
   }
 
+  ClusterManager.prototype.onScanPlugins = function(handler) {
+    this.on(Notifications.scanPlugins, handler);
+  }  
+
   ClusterManager.prototype.onAddDynamicPlugin = function(handler) {
     this.on(Notifications.addDynamicPlugin, handler);
   }
@@ -446,6 +483,29 @@ if (cluster.isMaster) {
       }
     );
   }
+  
+  ClusterManager.prototype.reloadAllWorkers = function() {
+    this.callClusterMethodRemote(null, "clusterManager", "reloadAllWorkers", [],
+      function() {
+      },
+      function(e) {
+        console.log("Error adding plugin: " + e);
+      }
+    );
+  }
+
+  ClusterManager.prototype.scanForNewPlugins = function(cb) {
+    console.log("YEET YEET");
+    this.callClusterMethodRemote(null, "clusterManager", "scanForNewPlugins", [],
+      function() {
+        cb();
+      },
+      function(e) {
+        console.log("Error adding plugin: " + e);
+      }
+    );
+  }
+
 }
 
 ClusterManager.prototype.start = function(appConfig, configJSON, startUpConfig) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -101,6 +101,9 @@ function Server(appConfig, userConfig, startUpConfig, options) {
   this.webServer = new WebServer();
   this.webApp = null;
   if (process.clusterManager) {
+    process.clusterManager.onScanPlugins(function(wi){
+      this.pluginLoader.loadPlugins();
+    }.bind(this));
     process.clusterManager.onAddDynamicPlugin(function(wi, pluginDef) {
       bootstrapLogger.log(bootstrapLogger.INFO, "adding plugin remotely " + pluginDef.identifier);
       this.pluginLoader.addDynamicPlugin(pluginDef);
@@ -199,6 +202,7 @@ Server.prototype = {
       },
       newPluginHandler: (pluginDef) => this.newPluginSubmitted(pluginDef),
       auth: webauth,
+      pluginLoader: this.pluginLoader,
       langManagers: this.langManagers
     };
     this.webApp = makeWebApp(webAppOptions);

--- a/lib/plugin-loader.js
+++ b/lib/plugin-loader.js
@@ -650,8 +650,14 @@ PluginLoader.prototype = {
           + zluxUtil.formatErrorStatus(rejectedPlugin.validationError, 
               DependencyGraph.statuses));
     }
+    let newPlugins = [];
     for (const pluginDef of sortedAndRejectedPlugins.plugins) { 
       try {
+        if (this.pluginMap[pluginDef.identifier]) {
+          bootstrapLogger.warn(`Skipping install of plugin due to existing plugin with same id=${plugin.identifier}`);
+
+           continue;
+        }
         const pluginConfiguration = configService.getPluginConfiguration(
             pluginDef.identifier, this.options.serverConfig,
             this.options.productCode);
@@ -664,6 +670,9 @@ PluginLoader.prototype = {
           bootstrapLogger.log(bootstrapLogger.INFO,
             `Plugin ${plugin.identifier} at path=${plugin.location} loaded.\n`);
           bootstrapLogger.debug(' Content:\n' + plugin.toString());
+          let frozen = zluxUtil.deepFreeze(plugin);
+          this.plugins.push(frozen);
+          newPlugins.push(frozen);
           this.plugins.push(zluxUtil.deepFreeze(plugin));
           this.pluginMap[plugin.identifier] = plugin;
           successCount++;
@@ -679,7 +688,7 @@ PluginLoader.prototype = {
       }
     }
     this.registerStaticPluginsWithManagers(sortedAndRejectedPlugins.plugins);
-    for (const plugin of this.plugins) {
+    for (const plugin of newPlugins) {
       this.emit('pluginAdded', {
         data: plugin
       });

--- a/lib/webapp.js
+++ b/lib/webapp.js
@@ -301,23 +301,36 @@ const staticHandlers = {
     };
   },
 
-   addStaticPlugin() {
+   addStaticPlugin(webapp) {
     return (req,res)=> {
-      const path = req.query.path;
+      let path = req.query.path;
       if (path) { // Attempt to extract a pluginDefinition given a path name & file
-        try {
+         try {
+          path = path.split('\\').join('/'); // Replace '\' with '/'
+          if (path[path.length - 1] == '/') {
+            path = path.slice(0, path.length - 1); // **.filextension/ ---> **.filextension
+          }
+          let fileName = path.split("/");
+          fileName = (fileName[fileName.length-1]);
           const pluginDefFile = require(`${path}`)
-          console.log(pluginDefFile);
+          
+          fs.writeFileSync(`../../zlux-app-server/plugins/${fileName}`, JSON.stringify(pluginDefFile));
+          console.log(webapp.serverConfig.pluginsDir);
+          fs.writeFileSync(`${webapp.serverConfig.pluginsDir}/${fileName}`, JSON.stringify(pluginDefFile));
+          res.status(200).json({message: 'Restarting server, please wait a moment.'});
+          process.clusterManager.reloadAllWorkers();
+          //this.reload();
         }
         catch (err) { // This file doesn't exist.
           bootstrapLogger.warn("File location '" + path + "' doesn't exist.");
         }
       }
-      const name = req.query.name; //future possibility of a repo to search from. think foo@1.0.0
-      console.log(path);
-      console.log(name);
+      let name = req.query.name; //future possibility of a repo to search from. think foo@1.0.0
+      if (name) {
 
-       if (process.clusterManager) {
+      }
+
+      if (process.clusterManager) {
         res.status(200).json({message: 'Adding plugin to cluster, please wait a moment.'});
         process.clusterManager.addPluginViaPathToWorkers();
       } else {

--- a/lib/webapp.js
+++ b/lib/webapp.js
@@ -12,6 +12,7 @@
 
 'use strict';
 const express = require('express');
+const fs = require('fs');
 const util = require('util');
 const url = require('url');
 const expressWs = require('express-ws');
@@ -191,6 +192,88 @@ const staticHandlers = {
         "zssPort": options.proxiedPort
       });
     }
+  },
+
+  
+  reload() {
+    return (req,res)=> {
+      if (process.clusterManager) {
+        res.status(200).json({message: 'Reloading server, please wait a moment.'});
+        process.clusterManager.reloadAllWorkers();
+      } else {
+        res.status(400).json({error: 'Cannot reload server unless cluster mode is in use'});
+      }
+    };
+  },
+
+   deleteAndReload(webapp) {
+    return (req,res)=> {
+      if (process.clusterManager) {
+        const id = req.params.id;
+        //delete
+        let fullPath = path.join(webapp.serverConfig.pluginsDir, id+'.json');
+        installLog.info(`Deleting plugin due to request, id=${id}, path=${fullPath}`);
+        fs.access(fullPath,fs.constants.F_OK,(err)=> {
+          if (err) {
+            //doesnt exist from our point of view
+            res.status(400).json({error: 'Static plugin requested was not found.'});
+            return;
+          }
+          else {
+            fs.stat(fullPath,(err,stats)=> {
+              if (err || stats.isDirectory()) {
+                res.status(500).json({error: 'Could not find plugin locator for requested plugin.'});
+                return;
+              } else {
+                fs.unlink(fullPath,(err)=> {
+                  if (err) {
+                    res.status(500).json({error: 'Could not remove plugin'});
+                    return;
+                  } else {             
+                    res.status(200).json({message: 'Reloading server, please wait a moment.'});
+                    process.clusterManager.reloadAllWorkers();
+                  }
+                });
+              }
+            });
+          }
+        });
+      } else {
+        res.status(400).json({error: 'Cannot reload server unless cluster mode is in use'});
+      }
+    };
+  },
+
+   pickupNewPlugins(webapp) {
+    return (req,res)=> {
+      if (process.clusterManager) {
+        res.status(200).json({message: 'Cluster scanning for new plugins, please wait a moment.'});
+        process.clusterManager.scanForNewPlugins();
+      } else {
+        //look for plugins in plugin dir
+        webapp.pluginLoader.loadPlugins(function() {
+          res.status(200).json({message: 'Scan complete.'});
+        }, function() {
+          res.status(500).json({error: 'Could not complete new plugin scan.'});
+        });
+
+       }
+    };
+  },
+
+   addStaticPlugin() {
+    return (req,res)=> {
+      const path = req.query.path; //if its a file, extract somehow
+      const name = req.query.name; //future possibility of a repo to search from. think foo@1.0.0
+
+       if (process.clusterManager) {
+        res.status(200).json({message: 'Adding plugin to cluster, please wait a moment.'});
+        process.clusterManager.addPluginViaPathToWorkers();
+      } else {
+        //add plugin
+        res.status(200).json({message: 'Plugin added'});
+      }
+    };
   },
   
   echo() {
@@ -699,9 +782,25 @@ WebApp.prototype = {
     this._installRootService('/auth-logout', 'get', this.auth.doLogout, 
         {needJson: true, needAuth: false, isPseudoSso: true});
     serviceHandleMap['auth'] = new WebServiceHandle('/auth', this.wsEnvironment);
+    this._installRootService('/server/reload', 'get', staticHandlers.reload(this.options),
+    {needJson: false, needAuth: true, isPseudoSso: false});
+    serviceHandleMap['server/reload'] = new WebServiceHandle('/server/reload',
+        this.wsEnvironment);
     this._installRootService('/plugins', 'get', staticHandlers.plugins(this.plugins), 
         {needJson: false, needAuth: false, isPseudoSso: false});
     serviceHandleMap['plugins'] = new WebServiceHandle('/plugins', this.wsEnvironment);
+    this._installRootService('/plugins/:id', 'delete', staticHandlers.deleteAndReload(this.options),
+        {needJson: false, needAuth: true, isPseudoSso: false});
+    serviceHandleMap['plugins/:id'] = new WebServiceHandle('/plugins/:id',
+        this.wsEnvironment);
+    this._installRootService('/plugins/scan', 'get', staticHandlers.pickupNewPlugins(this.options),
+        {needJson: false, needAuth: true, isPseudoSso: false});
+    serviceHandleMap['plugins/scan'] = new WebServiceHandle('/plugins/scan',
+        this.wsEnvironment);
+    this._installRootService('/plugins', 'put', staticHandlers.addStaticPlugin(this.options),
+        {needJson: true, needAuth: true, isPseudoSso: false});
+    serviceHandleMap['/plugins'] = new WebServiceHandle('/plugins',
+        this.wsEnvironment);
     this._installRootService('/server/proxies', 'get', staticHandlers.proxies(this.options),
         {needJson: false, needAuth: true, isPseudoSso: false});
     serviceHandleMap['server/proxies'] = new WebServiceHandle('/server/proxies',

--- a/lib/webapp.js
+++ b/lib/webapp.js
@@ -246,31 +246,35 @@ const staticHandlers = {
     };
   },
 
-   deleteAndReload(webapp) {
+  deleteAndReload(webapp) {
     return (req,res)=> {
       if (process.clusterManager) {
         const id = req.params.id;
         //delete
         let fullPath = path.join(webapp.serverConfig.pluginsDir, id+'.json');
         installLog.info(`Deleting plugin due to request, id=${id}, path=${fullPath}`);
-        fs.access(fullPath,fs.constants.F_OK,(err)=> {
+        fs.access(fullPath,
+          fs.constants.F_OK,
+          (err) => {
           if (err) {
             //doesnt exist from our point of view
-            res.status(400).json({error: 'Static plugin requested was not found.'});
+            res.status(400).json({error: "Static plugin '" + id + "' was not found."});
             return;
           }
           else {
-            fs.stat(fullPath,(err,stats)=> {
+            fs.stat(fullPath,
+              (err,stats) => {
               if (err || stats.isDirectory()) {
-                res.status(500).json({error: 'Could not find plugin locator for requested plugin.'});
+                res.status(500).json({error: "Could not find plugin locator for '" + id + "'"});
                 return;
               } else {
                 fs.unlink(fullPath,(err)=> {
                   if (err) {
-                    res.status(500).json({error: 'Could not remove plugin'});
+                    res.status(500).json({error: "Could not remove plugin '" + id + "'"});
                     return;
                   } else {             
-                    res.status(200).json({message: 'Reloading server, please wait a moment.'});
+                    res.status(200).json({message: "Deleted '" + id + "'. Reloading server, please wait a moment."});
+                    process.clusterManager.reloadAllWorkers();
                     process.clusterManager.reloadAllWorkers();
                   }
                 });
@@ -284,7 +288,7 @@ const staticHandlers = {
     };
   },
 
-   pickupNewPlugins(webapp) {
+  pickupNewPlugins(webapp) {
     return (req,res)=> {
       if (process.clusterManager) {
         res.status(200).json({message: 'Cluster scanning for new plugins, please wait a moment.'});
@@ -301,43 +305,55 @@ const staticHandlers = {
     };
   },
 
-   addStaticPlugin(webapp) {
-    return (req,res)=> {
-      let path = req.query.path;
-      if (path) { // Attempt to extract a pluginDefinition given a path name & file
-         try {
-          path = path.split('\\').join('/'); // Replace '\' with '/'
-          if (path[path.length - 1] == '/') {
-            path = path.slice(0, path.length - 1); // **.filextension/ ---> **.filextension
-          }
-          let fileName = path.split("/");
-          fileName = (fileName[fileName.length-1]);
-          const pluginDefFile = require(`${path}`)
-          
-          fs.writeFileSync(`../../zlux-app-server/plugins/${fileName}`, JSON.stringify(pluginDefFile));
-          console.log(webapp.serverConfig.pluginsDir);
-          fs.writeFileSync(`${webapp.serverConfig.pluginsDir}/${fileName}`, JSON.stringify(pluginDefFile));
-          res.status(200).json({message: 'Restarting server, please wait a moment.'});
-          process.clusterManager.reloadAllWorkers();
-          //this.reload();
-        }
-        catch (err) { // This file doesn't exist.
-          bootstrapLogger.warn("File location '" + path + "' doesn't exist.");
-        }
-      }
-      let name = req.query.name; //future possibility of a repo to search from. think foo@1.0.0
-      if (name) {
-
-      }
-
+  addStaticPlugin(webapp) {
+    return (req, res)=> {
       if (process.clusterManager) {
-        res.status(200).json({message: 'Adding plugin to cluster, please wait a moment.'});
-        process.clusterManager.addPluginViaPathToWorkers();
+        let path = req.query.path;
+        let name = req.query.name; //future possibility of a repo to search from. think foo@1.0.0
+
+        if (path) { // Attempt to extract a pluginDefinition given a path name & file
+          try {
+            path = path.split('\\').join('/'); // Replace '\' with '/'
+            if (path[path.length - 1] == '/') {
+              path = path.slice(0, path.length - 1); // **.filextension/ ---> **.filextension
+            }
+
+            const pluginDefFile = require(`${path}`) // Attempt to find specified file
+            let fileName = path.split("/");
+            fileName = (fileName[fileName.length-1]); // Obtain file name
+            
+            let pluginDefFileLoc = `../../zlux-app-server/plugins/${fileName}`;
+            fs.writeFile(pluginDefFileLoc, // Attempt to put file in main /plugins/ dir
+            JSON.stringify(pluginDefFile),
+            (err) => {
+              if (err) {
+                res.status(404).json({message: "Failed to create '" + pluginDefFileLoc + "'"});
+              } else {
+                pluginDefFileLoc = `${webapp.serverConfig.pluginsDir}/${fileName}`;
+                fs.writeFile(pluginDefFileLoc, // Attempt to put file in deploy /plugins/ dir
+                  JSON.stringify(pluginDefFile),
+                  (err) => {
+                    if (err) {
+                      res.status(404).json({message: "Failed to create '" + pluginDefFileLoc + "'"});
+                    } else {
+                      res.status(200).json({message: "Adding plugin '" + fileName + "' to cluster, please wait a moment."});
+                      process.clusterManager.reloadAllWorkers();
+                      process.clusterManager.reloadAllWorkers();
+                    }
+                  });
+              }
+            });
+          }
+          catch (err) {
+            res.status(404).json({message: "File location '" + path + "' doesn't exist."});
+          }
+        } else if (name) { // TODO: Implement logic to check for plugin from repo ex: foo@1.0.0
+          res.status(400).json({message: "Searching from repository is not supported yet."});
+        }
       } else {
-        //add plugin
-        res.status(200).json({message: 'Plugin added'});
+        res.status(400).json({error: 'Cannot reload server unless cluster mode is in use'});
       }
-    };
+    }
   },
   
   echo() {

--- a/lib/webapp.js
+++ b/lib/webapp.js
@@ -239,7 +239,7 @@ const staticHandlers = {
     return (req,res)=> {
       if (process.clusterManager) {
         res.status(200).json({message: 'Reloading server, please wait a moment.'});
-        process.clusterManager.reloadAllWorkers(); // Doesn't seem to kill the master cluster the first time
+        process.clusterManager.reloadAllWorkers(); // (WIP) Doesn't seem to affect the master cluster the first time
         process.clusterManager.reloadAllWorkers();
       } else {
         res.status(500).json({error: 'Cannot reload server unless cluster mode is in use'});
@@ -275,7 +275,7 @@ const staticHandlers = {
                     return;
                   } else {             
                     res.status(200).json({message: "Deleting plugin '" + id + "'. Reloading server, please wait a moment."});
-                    process.clusterManager.reloadAllWorkers(); // Doesn't seem to kill the master cluster the first time
+                    process.clusterManager.reloadAllWorkers(); // (WIP) Doesn't seem to affect the master cluster the first time
                     process.clusterManager.reloadAllWorkers();
                   }
                 });
@@ -349,7 +349,7 @@ const staticHandlers = {
                       else {
                         res.status(200).json({message: "Adding plugin '" + fileName + "' to cluster, please wait a moment."});
                       }
-                      process.clusterManager.reloadAllWorkers(); // Doesn't seem to kill the master cluster the first time
+                      process.clusterManager.reloadAllWorkers(); // (WIP) Doesn't seem to affect the master cluster the first time
                       process.clusterManager.reloadAllWorkers();
                     }
                   });

--- a/lib/webapp.js
+++ b/lib/webapp.js
@@ -239,9 +239,10 @@ const staticHandlers = {
     return (req,res)=> {
       if (process.clusterManager) {
         res.status(200).json({message: 'Reloading server, please wait a moment.'});
+        process.clusterManager.reloadAllWorkers(); // Doesn't seem to kill the master cluster the first time
         process.clusterManager.reloadAllWorkers();
       } else {
-        res.status(400).json({error: 'Cannot reload server unless cluster mode is in use'});
+        res.status(500).json({error: 'Cannot reload server unless cluster mode is in use'});
       }
     };
   },
@@ -273,8 +274,8 @@ const staticHandlers = {
                     res.status(500).json({error: "Could not remove plugin '" + id + "'"});
                     return;
                   } else {             
-                    res.status(200).json({message: "Deleted '" + id + "'. Reloading server, please wait a moment."});
-                    process.clusterManager.reloadAllWorkers();
+                    res.status(200).json({message: "Deleting plugin '" + id + "'. Reloading server, please wait a moment."});
+                    process.clusterManager.reloadAllWorkers(); // Doesn't seem to kill the master cluster the first time
                     process.clusterManager.reloadAllWorkers();
                   }
                 });
@@ -283,7 +284,7 @@ const staticHandlers = {
           }
         });
       } else {
-        res.status(400).json({error: 'Cannot reload server unless cluster mode is in use'});
+        res.status(500).json({error: 'Cannot reload server unless cluster mode is in use'});
       }
     };
   },
@@ -305,7 +306,7 @@ const staticHandlers = {
     };
   },
 
-  addStaticPlugin(webapp) {
+  addOrUpgradeStaticPlugin(webapp) {
     return (req, res)=> {
       if (process.clusterManager) {
         let path = req.query.path;
@@ -330,14 +331,25 @@ const staticHandlers = {
                 res.status(404).json({message: "Failed to create '" + pluginDefFileLoc + "'"});
               } else {
                 pluginDefFileLoc = `${webapp.serverConfig.pluginsDir}/${fileName}`;
+                let amIAnUpgrade;
+                try {
+                  amIAnUpgrade = require(pluginDefFileLoc); // Does this pluginDef already exist?
+                } catch (err) {
+                  amIAnUpgrade = undefined; // If it doesn't, it's not an upgrade...
+                }
                 fs.writeFile(pluginDefFileLoc, // Attempt to put file in deploy /plugins/ dir
                   JSON.stringify(pluginDefFile),
                   (err) => {
                     if (err) {
                       res.status(404).json({message: "Failed to create '" + pluginDefFileLoc + "'"});
                     } else {
-                      res.status(200).json({message: "Adding plugin '" + fileName + "' to cluster, please wait a moment."});
-                      process.clusterManager.reloadAllWorkers();
+                      if (amIAnUpgrade) {
+                        res.status(200).json({message: "Upgrading plugin '" + fileName + "' in cluster, please wait a moment."});
+                      }
+                      else {
+                        res.status(200).json({message: "Adding plugin '" + fileName + "' to cluster, please wait a moment."});
+                      }
+                      process.clusterManager.reloadAllWorkers(); // Doesn't seem to kill the master cluster the first time
                       process.clusterManager.reloadAllWorkers();
                     }
                   });
@@ -351,7 +363,7 @@ const staticHandlers = {
           res.status(400).json({message: "Searching from repository is not supported yet."});
         }
       } else {
-        res.status(400).json({error: 'Cannot reload server unless cluster mode is in use'});
+        res.status(500).json({error: 'Cannot reload server unless cluster mode is in use'});
       }
     }
   },
@@ -877,7 +889,7 @@ WebApp.prototype = {
         {needJson: false, needAuth: true, isPseudoSso: false});
     serviceHandleMap['plugins/scan'] = new WebServiceHandle('/plugins/scan',
         this.wsEnvironment);
-    this._installRootService('/plugins', 'put', staticHandlers.addStaticPlugin(this.options),
+    this._installRootService('/plugins', 'put', staticHandlers.addOrUpgradeStaticPlugin(this.options),
         {needJson: true, needAuth: true, isPseudoSso: false});
     serviceHandleMap['/plugins'] = new WebServiceHandle('/plugins',
         this.wsEnvironment);

--- a/lib/webapp.js
+++ b/lib/webapp.js
@@ -303,8 +303,19 @@ const staticHandlers = {
 
    addStaticPlugin() {
     return (req,res)=> {
-      const path = req.query.path; //if its a file, extract somehow
+      const path = req.query.path;
+      if (path) { // Attempt to extract a pluginDefinition given a path name & file
+        try {
+          const pluginDefFile = require(`${path}`)
+          console.log(pluginDefFile);
+        }
+        catch (err) { // This file doesn't exist.
+          bootstrapLogger.warn("File location '" + path + "' doesn't exist.");
+        }
+      }
       const name = req.query.name; //future possibility of a repo to search from. think foo@1.0.0
+      console.log(path);
+      console.log(name);
 
        if (process.clusterManager) {
         res.status(200).json({message: 'Adding plugin to cluster, please wait a moment.'});


### PR DESCRIPTION
Feature/server lifecycle enhancements that add REST calls to add functionality to the server lifecycle (enhancements to the server without requiring a server restart) 
Note: Most of these will be only available to **admins** and most will only work in **cluster mode**.

(WIP)

• /server/reload - GET Reloads the server by killing of all children in the cluster, and letting the server re-instantiate.

• /plugins/:id - DELETE Deletes a plugin based on plugin id

• /plugins/scan- GET Scans and picks up new plugins if present (for now: functionally the same as /server/reload for cluster mode)

• /plugins?path="" - PUT Attempts to retrieve a plugin identifier JSON from path location and install the plugin & its services, or upgrade an existing plugin & its services
example: /plugins?path=assets/somePlugin.json