### PR TITLE
Remove POST /server/logLevels/pattern/.  Users now only able to remove applications

### DIFF
--- a/lib/webapp.js
+++ b/lib/webapp.js
@@ -509,7 +509,7 @@ const staticHandlers = {
               receivedLogLevel: Number(logLevel)
             });
           }
-          global.COM_RS_COMMON_LOGGER.setLogLevelForComponentPattern(pattern.toString(), Number(logLevel));
+          global.COM_RS_COMMON_LOGGER.setLogLevelForComponentPattern(pattern.source, Number(logLevel));
           return res.status(200).json(global.COM_RS_COMMON_LOGGER.getConfig());
         }
       });

--- a/lib/webapp.js
+++ b/lib/webapp.js
@@ -491,28 +491,6 @@ const staticHandlers = {
           return res.status(200).json(global.COM_RS_COMMON_LOGGER.getConfig());
         }
       });
-      router.post('/logLevels/pattern/:componentPattern/level/:level', function(req, res){
-        const logLevel = req.params.level;
-        try{
-          var pattern = new RegExp(req.params.componentPattern);
-        }catch(e){
-          return res.status(400).json({error: "Invalid regex in query."});
-        }
-        if(isNaN(Number(logLevel))){
-          return res.status(400).json({error: "Log level must be a number"});
-        } else {
-          if (Number(logLevel) < LOG_LEVEL_MIN || Number(logLevel) > LOG_LEVEL_MAX) {
-            return res.status(400).json({
-              error: "Log level must be within the accepted levels of '" + LOG_LEVEL_MIN + "' and '" + LOG_LEVEL_MAX + "'",
-              maxLogLevel: LOG_LEVEL_MIN,
-              maxLogLevel: LOG_LEVEL_MAX,
-              receivedLogLevel: Number(logLevel)
-            });
-          }
-          global.COM_RS_COMMON_LOGGER.setLogLevelForComponentPattern(pattern.source, Number(logLevel));
-          return res.status(200).json(global.COM_RS_COMMON_LOGGER.getConfig());
-        }
-      });
       router.get('/environment', function(req, res){
         getUserEnv().then(result => {
           res.status(200).json(result);

--- a/lib/webapp.js
+++ b/lib/webapp.js
@@ -482,7 +482,7 @@ const staticHandlers = {
           if (Number(logLevel) < LOG_LEVEL_MIN || Number(logLevel) > LOG_LEVEL_MAX) {
             return res.status(400).json({
               error: "Log level must be within the accepted levels of '" + LOG_LEVEL_MIN + "' and '" + LOG_LEVEL_MAX + "'",
-              maxLogLevel: LOG_LEVEL_MIN,
+              minLogLevel: LOG_LEVEL_MIN,
               maxLogLevel: LOG_LEVEL_MAX,
               receivedLogLevel: Number(logLevel)
             });
@@ -511,7 +511,7 @@ const staticHandlers = {
     return router;
   },
 
-  pluginLifecycle(options){
+  pluginLifecycle(options, plugins){
     const router = express.Router();
     const dataserviceAuth = options.serverConfig["dataserviceAuthentication"];
     const rbac = (dataserviceAuth == undefined) ? false : dataserviceAuth.rbac === true;
@@ -556,6 +556,22 @@ const staticHandlers = {
       router.delete('/:id', function(req, res){
         if(process.clusterManager){
           const id = req.params.id;
+          let found = false;
+          for(let i = 0; i < plugins.length; i++){
+            if(plugins[i].identifier === id){
+              found = true;
+              if(plugins[i].pluginType !== 'application'){
+                return res.status(400).json({
+                  error: `Cannot remove plugins of type ${plugins[i].pluginType}`,
+                  expectedType: 'application',
+                  receivedType: plugins[i].pluginType
+                });
+              }
+            }
+          }
+          if(!found){
+            return res.status(400).json({error: `${id} does not exist.`});
+          }
           let fullPath = path.join(options.serverConfig.pluginsDir, id+'.json');
           installLog.info(`Deleting plugin due to request, id '${id}', path '${fullPath}'`);
           fs.unlink(fullPath, (err) => {
@@ -1092,7 +1108,7 @@ WebApp.prototype = {
     serviceHandleMap['auth'] = new WebServiceHandle('/auth', this.wsEnvironment);
     this._installRootService('/plugins', 'get', staticHandlers.plugins(this.plugins), 
         {needJson: false, needAuth: false, isPseudoSso: false}); 
-    this._installRootService('/plugins', 'use', staticHandlers.pluginLifecycle(this.options),
+    this._installRootService('/plugins', 'use', staticHandlers.pluginLifecycle(this.options, this.plugins),
       {needJson: true, needAuth: true, isPseudoSso: false});
     serviceHandleMap['plugins'] = new WebServiceHandle('/plugins', this.wsEnvironment);
     this._installRootService('/server', 'use', staticHandlers.server(this.options), 

--- a/lib/webapp.js
+++ b/lib/webapp.js
@@ -468,7 +468,7 @@ const staticHandlers = {
         if(process.env.ZLUX_LOG_PATH){
           return res.sendFile(process.env.ZLUX_LOG_PATH);
         } else {
-          return res.status(500).send('Log not found');
+          return res.status(500).json({error: 'Log not found'});
         }
       });
       router.get('/logLevels', function(req, res){
@@ -477,25 +477,40 @@ const staticHandlers = {
       router.post('/logLevels/name/:componentName/level/:level', function(req, res){
         const logLevel = req.params.level;
         if(isNaN(Number(logLevel))){
-          res.status(400).send("Log level must be a number");
+          return res.status(400).json({error: "Log level must be a number"});
         } else {
           if (Number(logLevel) < LOG_LEVEL_MIN || Number(logLevel) > LOG_LEVEL_MAX) {
-            res.status(400).send("Log level must be within the accepted levels of '" + LOG_LEVEL_MIN + "' and '" + LOG_LEVEL_MAX + "'");
+            return res.status(400).json({
+              error: "Log level must be within the accepted levels of '" + LOG_LEVEL_MIN + "' and '" + LOG_LEVEL_MAX + "'",
+              maxLogLevel: LOG_LEVEL_MIN,
+              maxLogLevel: LOG_LEVEL_MAX,
+              receivedLogLevel: Number(logLevel)
+            });
           }
           global.COM_RS_COMMON_LOGGER.setLogLevelForComponentName(req.params.componentName, Number(logLevel));
-          res.status(200).json(global.COM_RS_COMMON_LOGGER.getConfig());
+          return res.status(200).json(global.COM_RS_COMMON_LOGGER.getConfig());
         }
       });
       router.post('/logLevels/pattern/:componentPattern/level/:level', function(req, res){
         const logLevel = req.params.level;
+        try{
+          var pattern = new RegExp(req.params.componentPattern);
+        }catch(e){
+          return res.status(400).json({error: "Invalid regex in query."});
+        }
         if(isNaN(Number(logLevel))){
-          res.status(400).send("Log level must be a number");
+          return res.status(400).json({error: "Log level must be a number"});
         } else {
           if (Number(logLevel) < LOG_LEVEL_MIN || Number(logLevel) > LOG_LEVEL_MAX) {
-            res.status(400).send("Log level must be within the accepted levels of '" + LOG_LEVEL_MIN + "' and '" + LOG_LEVEL_MAX + "'");
+            return res.status(400).json({
+              error: "Log level must be within the accepted levels of '" + LOG_LEVEL_MIN + "' and '" + LOG_LEVEL_MAX + "'",
+              maxLogLevel: LOG_LEVEL_MIN,
+              maxLogLevel: LOG_LEVEL_MAX,
+              receivedLogLevel: Number(logLevel)
+            });
           }
-          global.COM_RS_COMMON_LOGGER.setLogLevelForComponentPattern(req.params.componentPattern, Number(logLevel));
-          res.status(200).json(global.COM_RS_COMMON_LOGGER.getConfig());
+          global.COM_RS_COMMON_LOGGER.setLogLevelForComponentPattern(pattern.toString(), Number(logLevel));
+          return res.status(200).json(global.COM_RS_COMMON_LOGGER.getConfig());
         }
       });
       router.get('/environment', function(req, res){


### PR DESCRIPTION
This pull request fixes the following:

Ability to set log levels by pattern which causes errors relating to SAF profile names.
Change error messages to JSON response
Only plugins of type "application" can be removed