### PR TITLE
Added fix for PUT /plugins and DELETE /plugins/:id returning invalid JSON

### DIFF
--- a/lib/webapp.js
+++ b/lib/webapp.js
@@ -451,11 +451,7 @@ const staticHandlers = {
               newConfig.zssPort = options.proxiedPort;
             }
             setAttrib(newConfig, attrib, body[lastProperty]);
-            fs.writeFileSync(options.configLocation, JSON.stringify(newConfig, null, 2), (err) => {
-              if(err){
-                return res.status(500).json({error: "Unable to update server configuration file"});
-              }
-            });
+            fs.writeFileSync(options.configLocation, JSON.stringify(newConfig, null, 2));
             process.clusterManager.setOverrideFileConfig(false);
             res.status(200).json({
               message: "Config updated. Reloading server, please wait.",

--- a/lib/webapp.js
+++ b/lib/webapp.js
@@ -439,20 +439,23 @@ const staticHandlers = {
               }
             });
             process.clusterManager.setOverrideFileConfig(false);
-            process.clusterManager.reloadAllWorkers();
-            // TODO: Server startup after initial reload doesn't complete 100% with Node < 8.x. Resulting in
-            // failed ZSS authentication issues. Error is uncertain, as increasing the timeout doesn't solve
-            // the issue. Is probably a deeper sync that newer versions of Node handle in correct order.
-            if (nodeMajorVer <= 7) {
-              process.clusterManager.reloadAllWorkers();
-            }
-            return res.status(200).json({
+            res.status(200).json({
               message: "Config updated. Reloading server, please wait.",
               expectedType: allowedPropertyType,
               receivedType: (typeof body[attribParts[attribParts.length - 1]]),
               requestBody: body,
               newConfig: newConfig
             });
+            if(res.headersSent){
+              process.clusterManager.reloadAllWorkers();
+              // TODO: Server startup after initial reload doesn't complete 100% with Node < 8.x. Resulting in
+              // failed ZSS authentication issues. Error is uncertain, as increasing the timeout doesn't solve
+              // the issue. Is probably a deeper sync that newer versions of Node handle in correct order.
+              if (nodeMajorVer <= 7) {
+                process.clusterManager.reloadAllWorkers();
+              }
+            }
+            return;
           } else {
             return res.status(400).json({
               error: `Request body of type ${(typeof body[attribParts[attribParts.length - 1]])} does not match expected type of ${allowedPropertyType}`,

--- a/lib/webapp.js
+++ b/lib/webapp.js
@@ -217,6 +217,30 @@ function setAttrib(object, path, value){
   setAttrib(object[path.shift()], path, value);
 }
 
+function waitForHeadersBeforeReload(res, maxRetries, timeout){
+  if(typeof waitForHeadersBeforeReload.retries === 'undefined'){
+    waitForHeadersBeforeReload.retries = 0;
+  }
+  setTimeout(() => {
+    if(waitForHeadersBeforeReload.retries > maxRetries){
+      return;
+    }
+    if(!res.headersSent){
+      waitForHeadersBeforeReload.retries++;
+      waitForHeadersBeforeReload(res);
+    }
+    if(process.clusterManager){
+      process.clusterManager.reloadAllWorkers();
+      // TODO: Server startup after initial reload doesn't complete 100% with Node < 8.x. Resulting in
+      // failed ZSS authentication issues. Error is uncertain, as increasing the timeout doesn't solve
+      // the issue. Is probably a deeper sync that newer versions of Node handle in correct order.
+      if (nodeMajorVer <= 7) {
+        process.clusterManager.reloadAllWorkers();
+      }
+    }
+  }, timeout);
+}
+
 const staticHandlers = {
   plugins: function(plugins) {
     return function(req, res) {
@@ -350,13 +374,7 @@ const staticHandlers = {
       router.get('/reload', function(req, res){
         if (process.clusterManager) {
           res.status(200).json({message: 'Reloading server, please wait a moment.'});
-          process.clusterManager.reloadAllWorkers();
-          // TODO: Server startup after initial reload doesn't complete 100% with Node < 8.x. Resulting in
-          // failed ZSS authentication issues. Error is uncertain, as increasing the timeout doesn't solve
-          // the issue. Is probably a deeper sync that newer versions of Node handle in correct order.
-          if (nodeMajorVer <= 7) {
-            process.clusterManager.reloadAllWorkers();
-          }
+          waitForHeadersBeforeReload(res, 3, 2000);
         } else {
           res.status(500).json({error: 'Cannot reload server unless cluster mode is in use.'});
         }
@@ -446,15 +464,7 @@ const staticHandlers = {
               requestBody: body,
               newConfig: newConfig
             });
-            if(res.headersSent){
-              process.clusterManager.reloadAllWorkers();
-              // TODO: Server startup after initial reload doesn't complete 100% with Node < 8.x. Resulting in
-              // failed ZSS authentication issues. Error is uncertain, as increasing the timeout doesn't solve
-              // the issue. Is probably a deeper sync that newer versions of Node handle in correct order.
-              if (nodeMajorVer <= 7) {
-                process.clusterManager.reloadAllWorkers();
-              }
-            }
+            waitForHeadersBeforeReload(res, 3, 2000);
             return;
           } else {
             return res.status(400).json({
@@ -534,15 +544,7 @@ const staticHandlers = {
               var installResponse = installApp.addToServer(pathToApp, options.serverConfig.pluginsDir);
               if(installResponse.success === true){
                 res.status(200).json({message: `Successfully installed '${installResponse.message}'. Reloading server, please wait a moment.`})
-                if(res.headersSent){
-                  process.clusterManager.reloadAllWorkers();
-                  // TODO: Server startup after initial reload doesn't complete 100% with Node < 8.x. Resulting in
-                  // failed ZSS authentication issues. Error is uncertain, as increasing the timeout doesn't solve
-                  // the issue. Is probably a deeper sync that newer versions of Node handle in correct order.
-                  if (nodeMajorVer <= 7) {
-                    process.clusterManager.reloadAllWorkers();
-                  }
-                }
+                waitForHeadersBeforeReload(res, 3, 2000);
                 return;
               } else {
                 return res.status(400).json({error: `Failed to install plugin.  Error: ${installResponse.message}`});
@@ -589,15 +591,7 @@ const staticHandlers = {
               return res.status(400).json({error: err});
             }       
             res.status(200).json({message: "Deleting plugin '" + id + "'. Reloading server, please wait a moment."});
-            if(res.headersSent){
-              process.clusterManager.reloadAllWorkers();
-              // TODO: Server startup after initial reload doesn't complete 100% with Node < 8.x. Resulting in
-              // failed ZSS authentication issues. Error is uncertain, as increasing the timeout doesn't solve
-              // the issue. Is probably a deeper sync that newer versions of Node handle in correct order.
-              if (nodeMajorVer <= 7) {
-                process.clusterManager.reloadAllWorkers();
-              }
-            }
+            waitForHeadersBeforeReload(res, 3, 2000);
             return;
           })
         } else {

--- a/lib/webapp.js
+++ b/lib/webapp.js
@@ -48,6 +48,8 @@ const WEBSOCKET_CLOSE_INTERNAL_ERROR = 4999;
 const WEBSOCKET_CLOSE_BY_PROXY = 4998;
 const WEBSOCKET_CLOSE_CODE_MINIMUM = 3000;
 const DEFAULT_READBODY_LIMIT = process.env.ZLUX_DEFAULT_READBODY_LIMIT || 102400;//100kb
+const DEFAULT_RELOAD_RETRIES = 3;
+const DEFAULT_RELOAD_TIMEOUT = 2000; //2 seconds
 const nodeVer = process.version.substring(1, process.version.length);
 let nodeMajorVer = nodeVer.split('.')[0];
 
@@ -227,7 +229,7 @@ function waitForHeadersBeforeReload(res, maxRetries, timeout){
     }
     if(!res.headersSent){
       waitForHeadersBeforeReload.retries++;
-      waitForHeadersBeforeReload(res);
+      waitForHeadersBeforeReload(res, maxRetries, timeout);
     }
     if(process.clusterManager){
       process.clusterManager.reloadAllWorkers();
@@ -374,7 +376,7 @@ const staticHandlers = {
       router.get('/reload', function(req, res){
         if (process.clusterManager) {
           res.status(200).json({message: 'Reloading server, please wait a moment.'});
-          waitForHeadersBeforeReload(res, 3, 2000);
+          waitForHeadersBeforeReload(res, DEFAULT_RELOAD_RETRIES, DEFAULT_RELOAD_TIMEOUT);
         } else {
           res.status(500).json({error: 'Cannot reload server unless cluster mode is in use.'});
         }
@@ -451,7 +453,11 @@ const staticHandlers = {
               newConfig.zssPort = options.proxiedPort;
             }
             setAttrib(newConfig, attrib, body[lastProperty]);
-            fs.writeFileSync(options.configLocation, JSON.stringify(newConfig, null, 2));
+            try{
+              fs.writeFileSync(options.configLocation, JSON.stringify(newConfig, null, 2));
+            }catch(e){
+              return res.status(500).json({error: e});
+            }
             process.clusterManager.setOverrideFileConfig(false);
             res.status(200).json({
               message: "Config updated. Reloading server, please wait.",
@@ -460,7 +466,7 @@ const staticHandlers = {
               requestBody: body,
               newConfig: newConfig
             });
-            waitForHeadersBeforeReload(res, 3, 2000);
+            waitForHeadersBeforeReload(res, DEFAULT_RELOAD_RETRIES, DEFAULT_RELOAD_TIMEOUT);
             return;
           } else {
             return res.status(400).json({
@@ -540,7 +546,7 @@ const staticHandlers = {
               var installResponse = installApp.addToServer(pathToApp, options.serverConfig.pluginsDir);
               if(installResponse.success === true){
                 res.status(200).json({message: `Successfully installed '${installResponse.message}'. Reloading server, please wait a moment.`})
-                waitForHeadersBeforeReload(res, 3, 2000);
+                waitForHeadersBeforeReload(res, DEFAULT_RELOAD_RETRIES, DEFAULT_RELOAD_TIMEOUT);
                 return;
               } else {
                 return res.status(400).json({error: `Failed to install plugin.  Error: ${installResponse.message}`});
@@ -587,7 +593,7 @@ const staticHandlers = {
               return res.status(400).json({error: err});
             }       
             res.status(200).json({message: "Deleting plugin '" + id + "'. Reloading server, please wait a moment."});
-            waitForHeadersBeforeReload(res, 3, 2000);
+            waitForHeadersBeforeReload(res, DEFAULT_RELOAD_RETRIES, DEFAULT_RELOAD_TIMEOUT);
             return;
           })
         } else {

--- a/lib/webapp.js
+++ b/lib/webapp.js
@@ -530,14 +530,17 @@ const staticHandlers = {
             if(!installApp.isFile(pathToApp)){
               var installResponse = installApp.addToServer(pathToApp, options.serverConfig.pluginsDir);
               if(installResponse.success === true){
-                process.clusterManager.reloadAllWorkers();
-                // TODO: Server startup after initial reload doesn't complete 100% with Node < 8.x. Resulting in
-                // failed ZSS authentication issues. Error is uncertain, as increasing the timeout doesn't solve
-                // the issue. Is probably a deeper sync that newer versions of Node handle in correct order.
-                if (nodeMajorVer <= 7) {
+                res.status(200).json({message: `Successfully installed '${installResponse.message}'. Reloading server, please wait a moment.`})
+                if(res.headersSent){
                   process.clusterManager.reloadAllWorkers();
+                  // TODO: Server startup after initial reload doesn't complete 100% with Node < 8.x. Resulting in
+                  // failed ZSS authentication issues. Error is uncertain, as increasing the timeout doesn't solve
+                  // the issue. Is probably a deeper sync that newer versions of Node handle in correct order.
+                  if (nodeMajorVer <= 7) {
+                    process.clusterManager.reloadAllWorkers();
+                  }
                 }
-                return res.status(200).json({message: `Successfully installed '${installResponse.message}'. Reloading server, please wait a moment.`});
+                return;
               } else {
                 return res.status(400).json({error: `Failed to install plugin.  Error: ${installResponse.message}`});
               }
@@ -581,15 +584,18 @@ const staticHandlers = {
               return res.status(400).json({error: `Improper access permissions for path '${fullPath}'`});
             } else if(err){
               return res.status(400).json({error: err});
-            }
-            process.clusterManager.reloadAllWorkers();
-            // TODO: Server startup after initial reload doesn't complete 100% with Node < 8.x. Resulting in
-            // failed ZSS authentication issues. Error is uncertain, as increasing the timeout doesn't solve
-            // the issue. Is probably a deeper sync that newer versions of Node handle in correct order.
-            if (nodeMajorVer <= 7) {
+            }       
+            res.status(200).json({message: "Deleting plugin '" + id + "'. Reloading server, please wait a moment."});
+            if(res.headersSent){
               process.clusterManager.reloadAllWorkers();
+              // TODO: Server startup after initial reload doesn't complete 100% with Node < 8.x. Resulting in
+              // failed ZSS authentication issues. Error is uncertain, as increasing the timeout doesn't solve
+              // the issue. Is probably a deeper sync that newer versions of Node handle in correct order.
+              if (nodeMajorVer <= 7) {
+                process.clusterManager.reloadAllWorkers();
+              }
             }
-            return res.status(200).json({message: "Deleting plugin '" + id + "'. Reloading server, please wait a moment."});
+            return;
           })
         } else {
           return res.status(500).send({error: 'Cannot reload server unless cluster mode is in use.'});


### PR DESCRIPTION
Sometimes, the server would be in the process of reloading when the response was being sent.  This instance would result in some of the response body being dropped, such as end brackets.

Signed-off-by: Timothy Gerstel <tgerstel@rocketsoftware.com>