### PR TITLE
Added error message for invalid http methods (server status REST API)

### DIFF
--- a/lib/webapp.js
+++ b/lib/webapp.js
@@ -337,6 +337,8 @@ const staticHandlers = {
             },
           ]
         });
+      }).all('/', function (req, res) {
+        return res.status(405).json({error: 'Only GET method supported'});
       });
       let proxyOptions = {
         urlPrefix: '/server', 
@@ -360,11 +362,15 @@ const staticHandlers = {
         } else {
           res.status(500).json({error: 'Cannot reload server unless cluster mode is in use.'});
         }
+      }).all('/reload', function (req, res) {
+        return res.status(405).json({error: 'Only GET method supported'});
       });
       router.get('/config', function(req, res){
         return res.status(200).json({
           "options": options.serverConfig
         });
+      }).all('/config', function (req, res) {
+        return res.status(405).json({error: 'Only GET method supported'});
       });
       //This route consumes the replacement key/value pair in the request body.
       //For example, post(/config/node.https.ipAddresses), with a JSON request body:
@@ -463,6 +469,8 @@ const staticHandlers = {
         } else {
           return res.status(400).json({error: `${attrib} is not available for modification`});
         }
+      }).all('/config/:attribute', function (req, res) {
+        return res.status(405).json({error: 'Only POST method supported'});
       });
       router.get('/log', function(req, res){
         if(process.env.ZLUX_LOG_PATH){
@@ -470,9 +478,13 @@ const staticHandlers = {
         } else {
           return res.status(500).json({error: 'Log not found'});
         }
+      }).all('/log', function (req, res) {
+        return res.status(405).json({error: 'Only GET method supported'});
       });
       router.get('/logLevels', function(req, res){
         return res.status(200).json(global.COM_RS_COMMON_LOGGER.getConfig());
+      }).all('/logLevels', function (req, res) {
+        return res.status(405).json({error: 'Only GET method supported'});
       });
       router.post('/logLevels/name/:componentName/level/:level', function(req, res){
         const logLevel = req.params.level;
@@ -490,11 +502,15 @@ const staticHandlers = {
           global.COM_RS_COMMON_LOGGER.setLogLevelForComponentName(req.params.componentName, Number(logLevel));
           return res.status(200).json(global.COM_RS_COMMON_LOGGER.getConfig());
         }
+      }).all('/logLevels/name/:componentName/level/:level', function (req, res) {
+        return res.status(405).json({error: 'Only POST method supported'});
       });
       router.get('/environment', function(req, res){
         getUserEnv().then(result => {
           res.status(200).json(result);
         });
+      }).all('/environment', function (req, res) {
+        return res.status(405).json({error: 'Only GET method supported'});
       });
       return router;
     }


### PR DESCRIPTION
This pull requests fixes the following:
HTTP methods other than the intended call would return 404 rather than an error message.  Routes now return 405 for invalid methods.

Signed-off-by: Timothy Gerstel <tgerstel@rocketsoftware.com>