### PR TITLE
Add back support for text-plain json

### DIFF
--- a/plugins/config/lib/configService.js
+++ b/plugins/config/lib/configService.js
@@ -2695,9 +2695,23 @@ function ConfigService(context) {
     }
 
     if (!request.currentResourceObject.binary) {
-      if (typeof request.body !== 'string') {
+      if (!request.body) {
         respondWithJsonError(response,"Could not access PUT body.",HTTP_STATUS_BAD_REQUEST,request.resourceURL);
         return 1;
+      }
+      else if (typeof request.body !== 'string') {
+        if (typeof request.body !== 'object') {
+          respondWithJsonError(response,"Could not access PUT body.",HTTP_STATUS_BAD_REQUEST,request.resourceURL);
+          return 1;
+        } else {
+          try {
+            let output = request.body.toString('utf8');
+            request.body = output;
+          } catch (e) {
+            respondWithJsonError(response,"PUT body contents invalid",HTTP_STATUS_BAD_REQUEST,request.resourceURL);
+            return 1;
+          }
+        }
       }
       try {
         //We only support JSON storage for now.


### PR DESCRIPTION
In order to not cause regression, still support text/plain json and binary text/plain at the same time by attempting to parse the buffer into utf8. If it fails, give up.
Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>