### PR TITLE
Adding Internal-only services feature

### DIFF
--- a/lib/clusterManager.js
+++ b/lib/clusterManager.js
@@ -82,14 +82,19 @@ if (cluster.isMaster) {
       if (crypto_err) {
         return errorHandler(crypto_err);
       }
-      this.secret = buffer.toString('hex');
-      //console.log('secret: ' + this.secret);
+      const secret = buffer.toString('hex');
+      if (this.secret) {
+        this.loopbackSecret = secret;
+      } else {
+        this.secret = secret;
+      }
       completeHandler();
     }.bind(this));
   }
 
   ClusterManager.prototype.initializing = function(completeHandler) {
     var inits = [];
+    inits.push(this.initSecret.bind(this));
     inits.push(this.initSecret.bind(this));
 
     var stopOnError = function(err) {
@@ -110,7 +115,10 @@ if (cluster.isMaster) {
   ClusterManager.prototype.startWorker = function(wi) {
     clusterLogger.info("Fork worker " + wi);
     var thatClusterManager = this;
-    this.workers[wi] = cluster.fork({index : wi, expressSessionSecret: this.secret, overrideFileConfig: this.overrideFileConfig});
+    this.workers[wi] = cluster.fork({index : wi,
+                                     expressSessionSecret: this.secret,
+                                     loopbackSecret: this.loopbackSecret,
+                                     overrideFileConfig: this.overrideFileConfig});
     this.workers[wi].on('exit', function(code, signal) {
       if (stoppingProcess) {
         return;

--- a/lib/webapp.js
+++ b/lib/webapp.js
@@ -36,6 +36,7 @@ const translationUtils = require('./translation-utils');
 const expressStaticGzip = require("express-static-gzip");
 const os = require('os');
 const semver = require('semver');
+const ipaddr = require('ipaddr.js');
 
 /**
  * Sets up an Express application to serve plugin data files and services  
@@ -65,7 +66,7 @@ const LOG_LEVEL_MAX = 5;
 
 const jsonParser = bodyParser.json()
 const urlencodedParser = bodyParser.urlencoded({ extended: false })
-
+const ZLUX_LOOPBACK_HEADER = 'X-ZLUX-Loopback';
 const proxyMap = new Map();
 
 function DataserviceContext(serviceDefinition, serviceConfiguration, 
@@ -697,7 +698,7 @@ WebServiceHandle.prototype = {
       options = options || {};
       let url = this.urlPrefix;
       if (path) {
-        url += '/' + path;
+        url += path.startsWith('/') ? path : '/' + path;
       }
       let rejectUnauthorized;
       let protocol;
@@ -738,6 +739,10 @@ WebServiceHandle.prototype = {
           headers["Content-Length"] =  json.length;
           options.body = json;
         }
+      }
+      if (options.zluxLoopbackSecret) {
+        //TODO use secret in a crypto scheme
+        headers[ZLUX_LOOPBACK_HEADER] = options.zluxLoopbackSecret;
       }
       //console.log("headers: ", headers)
       if (Object.getOwnPropertyNames(headers).length > 0) {
@@ -782,7 +787,7 @@ const commonMiddleware = {
    * authentication data on: we'll do that
    */
   
-  addAppSpecificDataToRequest(globalAppData) {
+  addAppSpecificDataToRequest(globalAppData, loopbackSecret) {
     return function addAppSpecificData(req, res, next) {
       const appData = Object.create(globalAppData);
       if (!req[`${UNP.APP_NAME}Data`]) {
@@ -820,6 +825,8 @@ const commonMiddleware = {
             version = appData.service.def.versionRequirements[name];
           }
           const service = allHandles[version];
+          options = options || {};
+          options.zluxLoopbackSecret = loopbackSecret;
           return service.call(url, options, req);
         } catch (e) {
           return Promise.reject(e);
@@ -918,6 +925,18 @@ const commonMiddleware = {
       next();
     }
   },
+
+  localCheck(loopbackSecret, localIp) {
+    return function localCheck(req, res, next) {
+      const loopbackData = req.get(ZLUX_LOOPBACK_HEADER);
+      const address = ipaddr.process(req.ip)
+      if (loopbackSecret == loopbackData && (req.ip == localIp || address.range() == 'loopback')) {
+        next();
+      } else {
+        res.status(403).json({"error":"Cannot access requested service externally"});
+      }
+    }
+  },
   
   logRootServiceCall(proxied, serviceName) {
     const type = proxied? "Proxied root" : "root"
@@ -1010,8 +1029,13 @@ function WebApp(options){
       secure: 'auto'
     }
   }));
+  this.loopbackSecret = process.env.loopbackSecret ? process.env.loopbackSecret : 'different',
+  process.env.expressSessionSecret = undefined;
+  process.env.loopbackSecret = undefined;
+
+  this.loopbackConfig = makeLoopbackConfig(options.serverConfig.node);
   this.wsEnvironment = {
-    loopbackConfig: makeLoopbackConfig(options.serverConfig.node)
+    loopbackConfig: this.loopbackConfig
   }
   this.options = zluxUtil.makeOptionsObject(defaultOptions, options);
   this.auth = options.auth;
@@ -1104,7 +1128,7 @@ WebApp.prototype = {
 
   installCommonMiddleware() {
     this.expressApp.use(commonMiddleware.addAppSpecificDataToRequest(
-        this.appData));
+      this.appData, this.loopbackSecret));
   },
 
   _installRootService(url, method, handler, {needJson, needAuth, authType, isPseudoSso}) {
@@ -1293,15 +1317,20 @@ WebApp.prototype = {
     if (service.httpCaching !== true) {
       //Per-dataservice middleware to handle tls no-cache
       serviceRouterWithMiddleware.push(commonMiddleware.httpNoCacheHeaders());
-    }    
+    }
+    if (service.internalOnly) {
+      serviceRouterWithMiddleware.push(commonMiddleware.localCheck(this.loopbackSecret, this.loopbackConfig.host));
+    }
     let router;
     switch (service.type) {
     case "service":
       //installLog.info(`${plugin.identifier}: installing proxy at ${subUrl}`);
-      router = this.makeProxy(service.urlPrefix ? 
-        service.urlPrefix : zLuxUrl.makePluginURL(this.options.productCode, plugin.identifier) +
-                              zLuxUrl.makeServiceSubURL(service, false, true), false,
-                              getAgentProxyOptions(this.options, this.options.serverConfig.agent));
+      router = this.makeProxy(service.urlPrefix
+        ? service.urlPrefix
+        : zLuxUrl.makePluginURL(this.options.productCode, plugin.identifier)
+          + zLuxUrl.makeServiceSubURL(service, false, true),
+        false,
+        getAgentProxyOptions(this.options, this.options.serverConfig.agent));
       break;
     case "nodeService":
       //installLog.info(


### PR DESCRIPTION
Adding an ability for a service to be declared as only for use by other services internally.

This allows for a service to be callable by other services of that plugin via the "callService" function, but does not allow these services to be called from outside of the server. Attempting to call them from outside of the server will be met with a 403 return and an error message.
Since a service is a router and routers are attached internally & externally the same way, the way the server discriminates what is internal vs external in this case is that it checks for the request IP, as well as a code, intended to be only known to the server. If the IP is determined to come from the same host as the server, and the code is valid, then the request is passed on to the router, otherwise the 403 results.

How to make use of this:

Dataservices can now contain the attribute "internalOnly"=true/false. If false, current behavior is seen. If missing, treated as false. But if true, the above-described behavior occurs.

Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>