### PR TITLE
Get status for auth plugins that cant refresh

### DIFF
--- a/lib/webauth.js
+++ b/lib/webauth.js
@@ -202,6 +202,12 @@ module.exports = function(authManager, cookiePort, isSecurePort) {
             handlerResult = {success:false, reason:REASON_ZLUX_SESSION_EXPIRE};
           } else if (hasGetCapabilities && handler.getCapabilities().canRefresh){
             handlerResult = yield handler.refreshStatus(req, authPluginSession);
+          } else if (hasGetCapabilities && handler.getCapabilities().canGetStatus){
+            handlerResult = handler.getStatus(authPluginSession);
+            if (handlerResult.authenticated !== undefined) {
+              handlerResult.success = handlerResult.authenticated;
+              delete handlerResult.authenticated;
+            }
           } else {
             handlerResult = { success: true };
           }


### PR DESCRIPTION
Add ability to get most recent timeout info for auth plugins that cant do a refresh. This way, browser can keep up to date upon page load.