### PR TITLE
Get correct count of successfully loaded plugins

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -229,39 +229,39 @@ Server.prototype = {
       pluginCount++;
       if (event.data.error) {
         if (!process.clusterManager || process.clusterManager.getIndexInCluster() == 0) {
-          installLogger.warn(`Exception occurred, plugin (${event.data.identifier}) installation skipped. `
+          installLogger.warn(`Plugin (${event.data.identifier}) loading failed. `
                              +`Message: "${event.data.error.message}"`
-                             + " Successful: (" + pluginsLoaded + "/" + event.count + ")"
-                             + " Attempted: (" + pluginCount + "/" + event.count + ")");
+                             + ` Successful: ${Math.round((pluginsLoaded/event.count)*100)}% (${pluginsLoaded}/${event.count})`
+                             + ` Attempted: ${Math.round((pluginCount/event.count)*100)}% (${pluginCount}/${event.count})`);
         }
         if (pluginCount == event.count) {
           installLogger.info(`Server is ready at ` +
                              `${runningInstances[0]}` +
-                             `, Plugins successfully loaded: (${pluginsLoaded}/${event.count})`);
+                             `, Plugins successfully loaded: ${Math.round((pluginsLoaded/event.count)*100)}% (${pluginsLoaded}/${event.count})`);
         }
       } else {
         return this.pluginLoaded(event.data).then(() => {
           if (!process.clusterManager || process.clusterManager.getIndexInCluster() == 0) {
             pluginsLoaded++;
-            installLogger.info('Installed plugin: ' + event.data.identifier
-                               + " Successful: (" + pluginsLoaded + "/" + event.count + ")"
-                               + " Attempted: (" + pluginCount + "/" + event.count + ")");
+            installLogger.info(`Plugin (${event.data.identifier}) loaded. `
+                               + ` Successful: ${Math.round((pluginsLoaded/event.count)*100)}% (${pluginsLoaded}/${event.count})`
+                               + ` Attempted: ${Math.round((pluginCount/event.count)*100)}% (${pluginCount}/${event.count})`);
             if (pluginCount == event.count) {
               installLogger.info(`Server is ready at ` +
                                  `${runningInstances[0]}` +
-                                 `, Plugins successfully loaded: (${pluginsLoaded}/${event.count})`);
+                                 `, Plugins successfully loaded: ${Math.round((pluginsLoaded/event.count)*100)}% (${pluginsLoaded}/${event.count})`);
             }
           }
         }, err => {
-          installLogger.warn(`Exception occurred, plugin (${event.data.identifier}) installation skipped. `
+          installLogger.warn(`Plugin (${event.data.identifier}) loading failed. `
                              +`Message: "${err.message}"`
-                             + " Successful: (" + pluginsLoaded + "/" + event.count + ")"
-                             + " Attempted: (" + pluginCount + "/" + event.count + ")");
+                             + ` Successful: ${Math.round((pluginsLoaded/event.count)*100)}% (${pluginsLoaded}/${event.count})`
+                             + ` Attempted: ${Math.round((pluginCount/event.count)*100)}% (${pluginCount}/${event.count})`);
           installLogger.debug(err.stack);
           if (pluginCount == event.count) {
             installLogger.info(`Server is ready at ` +
                                `${runningInstances[0]}` +
-                               `, Plugins successfully loaded: (${pluginsLoaded}/${event.count})`);
+                               `, Plugins successfully loaded: ${Math.round((pluginsLoaded/event.count)*100)}% (${pluginsLoaded}/${event.count})`);
           }
         });
       }

--- a/lib/index.js
+++ b/lib/index.js
@@ -225,32 +225,46 @@ Server.prototype = {
         runningInstances.push("http://" + ip + ':' + httpsPort)
       }
     }
-    this.pluginLoader.on('pluginAdded', util.asyncEventListener(event => {
+    this.pluginLoader.on('pluginFound', util.asyncEventListener(event => {
       pluginCount++;
-      return this.pluginLoaded(event.data).then(() => {
+      if (event.data.error) {
         if (!process.clusterManager || process.clusterManager.getIndexInCluster() == 0) {
-          pluginsLoaded++;
-          installLogger.info('Installed plugin: ' + event.data.identifier
+          installLogger.warn(`Exception occurred, plugin (${event.data.identifier}) installation skipped. `
+                             +`Message: "${event.data.error.message}"`
                              + " Successful: (" + pluginsLoaded + "/" + event.count + ")"
                              + " Attempted: (" + pluginCount + "/" + event.count + ")");
-          if (pluginCount == event.count) {
-            installLogger.info(`Server is ready at ` +
-             `${runningInstances[0]}` +
-             `, Plugins successfully loaded: (${pluginsLoaded}/${event.count})`);
-          }
         }
-      }, err => {
-        installLogger.warn(`Exception occurred, plugin (${event.data.identifier}) installation skipped. `
-                           +`Message: ${err.message}`
-                           + " Successful: (" + pluginsLoaded + "/" + event.count + ")"
-                           + " Attempted: (" + pluginCount + "/" + event.count + ")");
-        installLogger.debug(err.stack);
         if (pluginCount == event.count) {
           installLogger.info(`Server is ready at ` +
-            `${runningInstances[0]}` +
-            `, Plugins successfully loaded: (${pluginsLoaded}/${event.count})`);
+                             `${runningInstances[0]}` +
+                             `, Plugins successfully loaded: (${pluginsLoaded}/${event.count})`);
         }
-      });
+      } else {
+        return this.pluginLoaded(event.data).then(() => {
+          if (!process.clusterManager || process.clusterManager.getIndexInCluster() == 0) {
+            pluginsLoaded++;
+            installLogger.info('Installed plugin: ' + event.data.identifier
+                               + " Successful: (" + pluginsLoaded + "/" + event.count + ")"
+                               + " Attempted: (" + pluginCount + "/" + event.count + ")");
+            if (pluginCount == event.count) {
+              installLogger.info(`Server is ready at ` +
+                                 `${runningInstances[0]}` +
+                                 `, Plugins successfully loaded: (${pluginsLoaded}/${event.count})`);
+            }
+          }
+        }, err => {
+          installLogger.warn(`Exception occurred, plugin (${event.data.identifier}) installation skipped. `
+                             +`Message: "${err.message}"`
+                             + " Successful: (" + pluginsLoaded + "/" + event.count + ")"
+                             + " Attempted: (" + pluginCount + "/" + event.count + ")");
+          installLogger.debug(err.stack);
+          if (pluginCount == event.count) {
+            installLogger.info(`Server is ready at ` +
+                               `${runningInstances[0]}` +
+                               `, Plugins successfully loaded: (${pluginsLoaded}/${event.count})`);
+          }
+        });
+      }
     }, installLogger));
     this.pluginLoader.loadPlugins();
     yield this.authManager.loadAuthenticators(this.userConfig);

--- a/lib/plugin-loader.js
+++ b/lib/plugin-loader.js
@@ -580,23 +580,27 @@ PluginLoader.prototype = {
       pluginBasePath = this.options.relativePathResolver(pluginBasePath, process.cwd());
     }
     if (!fs.existsSync(pluginBasePath)) {
-      throw new Error(`${pluginDescriptorFilename}: No plugin directory found at`
-        + ` ${pluginPtrDef.pluginLocation}`);
+      return {location: pluginBasePath,
+              identifier: pluginPtrDef.identifier,
+              error: new Error(`No plugin directory found at ${pluginPtrDef.pluginLocation}`)};
      }
     let pluginDefPath = path.join(pluginBasePath, 'pluginDefinition.json');
     if (!fs.existsSync(pluginDefPath)) {
-      throw new Error(`${pluginDescriptorFilename}: No pluginDefinition.json `
-          + `found at ${pluginBasePath}`);
+      return {location: pluginBasePath,
+              identifier: pluginPtrDef.identifier,
+              error: new Error(`No pluginDefinition.json found at ${pluginBasePath}`)};
     }
     let pluginDef = jsonUtils.parseJSONWithComments(pluginDefPath);
     bootstrapLogger.log(bootstrapLogger.FINER,util.inspect(pluginDef));
     if (pluginDef.identifier !== pluginPtrDef.identifier) {
-      throw new Error(`${pluginDef.identifier} and ${pluginPtrDef.identifier} `
-          + `don't match - plugin ignored`);
+      return {location: pluginBasePath,
+              identifier: pluginPtrDef.identifier,
+              error: new Error(`Identifier doesn't match one found in pluginDefinition: ${pluginDef.identifier}`)};
     }
     if (!pluginDef.pluginType) {
-      throw new Error(`No plugin type found for ${pluginDef.identifier} `
-      + `found at ${pluginBasePath}, skipping`)
+      return {location: pluginBasePath,
+              identifier: pluginPtrDef.identifier,
+              error: new Error(`No plugin type found, skipping`)};
     }
     bootstrapLogger.info(`Read ${pluginBasePath}: found plugin id = ${pluginDef.identifier}, `
         + `type = ${pluginDef.pluginType}`);
@@ -638,10 +642,16 @@ PluginLoader.prototype = {
       config: this.options.serverConfig,
       authManager: this.options.authManager
     };
+    let newPlugins = [];
     let successCount = 0;
     const depgraph = new DependencyGraph(this.plugins);
     for (const pluginDef of pluginDefs) {
-      depgraph.addPlugin(pluginDef);
+      if (pluginDef.error) {
+        //downstream will pick up error
+        newPlugins.push(pluginDef);
+      } else {
+        depgraph.addPlugin(pluginDef);
+      }
     }
     const sortedAndRejectedPlugins = depgraph.processImports();
     for (const rejectedPlugin of sortedAndRejectedPlugins.rejects) {
@@ -650,7 +660,7 @@ PluginLoader.prototype = {
           + zluxUtil.formatErrorStatus(rejectedPlugin.validationError, 
               DependencyGraph.statuses));
     }
-    let newPlugins = [];
+
     for (const pluginDef of sortedAndRejectedPlugins.plugins) { 
       try {
         if (this.pluginMap[pluginDef.identifier]) {
@@ -682,6 +692,7 @@ PluginLoader.prototype = {
         }
       } catch (e) {
         console.log(e);
+        //downstream will pick up error
         newPlugins.push(Object.assign(pluginDef, {error:e}));
       }
     }

--- a/lib/plugin-loader.js
+++ b/lib/plugin-loader.js
@@ -664,7 +664,7 @@ PluginLoader.prototype = {
     for (const pluginDef of sortedAndRejectedPlugins.plugins) { 
       try {
         if (this.pluginMap[pluginDef.identifier]) {
-          bootstrapLogger.warn(`Skipping install of plugin due to existing plugin with same id=${plugin.identifier}`);
+          bootstrapLogger.warn(`Skipping install of plugin due to existing plugin with same id=${pluginDef.identifier}`);
 
            continue;
         }
@@ -691,7 +691,7 @@ PluginLoader.prototype = {
             `Plugin ${pluginDef.identifier} not loaded`);
         }
       } catch (e) {
-        console.log(e);
+        bootstrapLogger.warn(`Error thrown when installing plugin=${pluginDef.identifier}`,e);
         //downstream will pick up error
         newPlugins.push(Object.assign(pluginDef, {error:e}));
       }

--- a/lib/plugin-loader.js
+++ b/lib/plugin-loader.js
@@ -682,14 +682,12 @@ PluginLoader.prototype = {
         }
       } catch (e) {
         console.log(e);
-        //bootstrapLogger.warn(e)
-        bootstrapLogger.log(bootstrapLogger.INFO,
-          `Failed to load ${pluginDef.identifier}: ${e}`);
+        newPlugins.push(Object.assign(pluginDef, {error:e}));
       }
     }
     this.registerStaticPluginsWithManagers(sortedAndRejectedPlugins.plugins);
     for (const plugin of newPlugins) {
-      this.emit('pluginAdded', {
+      this.emit('pluginFound', {
         data: plugin,
         count: newPlugins.length
       });


### PR DESCRIPTION
The messages for plugin loading status did not account for plugins that existed but could not be loaded due to a failure early on.
This fixes one such problem: if a plugin failed to get dataservices set up, it would not be in the array of counted plugins. Now it will be, but will contain an error object, so it can be counted as an error and excluded from further processing.

As an example, before I was reading 15/15 plugins successfully loaded, now I read 15/17 plugins successfully loaded, because one had a require() exception and another was pointing to a folder that didnt exist.

New messages read as:
```
2020-01-30 23:22:44.559 <ZWED:29881> sgrady INFO (_zsf.install,index.js:246) Plugin (org.zowe.terminal.tn3270) loaded.  Successful: 81% (13/16) Attempted: 81% (13/16)
2020-01-30 23:22:44.559 <ZWED:29881> sgrady WARN (_zsf.install,index.js:232) Plugin (org.zowe.error) loading failed. Message: "Cannot find module '/sgrady/error/lib/starter.js'" Successful: 81% (13/16) Attempted: 88% (14/16)
```


Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>