### PR TITLE
Add plugin logout ability

### DIFF
--- a/lib/webauth.js
+++ b/lib/webauth.js
@@ -128,7 +128,7 @@ AuthResponse.prototype = {
       }
     }
     //default expiration if none found
-    if (!this.expms) {
+    if (!this.expms && (defaultExpiration != -1)) {
       this.expms = defaultExpiration;
     }
     this[this.keyField] = result;
@@ -162,6 +162,51 @@ const SESSION_ACTION_TYPE_REFRESH = 2;
  * Assumes req.session is there and behaves as it should
  */
 module.exports = function(authManager, cookiePort, isSecurePort) {
+  const _doLogoutInner = Promise.coroutine(function*(req, res) {
+    //FIXME XSRF
+    const handlers = getRelevantHandlers(authManager, req.body);
+    const result = new LoginResult();      
+    for (const handler of handlers) {
+      const pluginID = handler.pluginID;
+      authLogger.info(`${req.session.id}: User logout for auth handler ${pluginID}`);
+      let handlerResult;
+      if (handler.getCapabilities) {
+        try {
+          let authPluginSession = util.getOrInit(req.session, pluginID, {});          
+          let caps = handler.getCapabilities();
+          if (caps.canLogout === true) {
+            handlerResult = yield handler.logout(req, authPluginSession);
+          } else {
+            handlerResult = {success: true};
+          }
+        } catch (e) {
+          handlerResult = {success: false, reason: e.message};
+        }
+      } else {
+        handlerResult = {success: true};
+      }
+      result.addHandlerResult(handlerResult, handler);
+      if (req.session.authPlugins) {
+        delete req.session.authPlugins[pluginID];
+      }
+    }
+
+    result.updateStatus(-1);
+    if (!req.session.authPlugins || Object.keys(req.session.authPlugins).length == 0) {
+      if (req.session.id) {
+        req.session.zlux = undefined;
+        req.sessionStore.destroy(req.session.id);
+      }
+      req.session.id = null;
+      res.clearCookie('connect.sid.'+cookiePort, { path: '/',
+                                                   httpOnly: true,
+                                                   secure: isSecurePort});
+    }
+
+    res.status(result.success? 200 : 500).json(result);
+    return;
+  });
+
   const _authenticateOrRefresh = Promise.coroutine(function*(req, res, type) {
     let functionName;
     if (type == SESSION_ACTION_TYPE_AUTHENTICATE) {
@@ -301,26 +346,7 @@ module.exports = function(authManager, cookiePort, isSecurePort) {
     },
     
     doLogout(req, res) {
-      //FIXME XSRF
-      const handlers = getRelevantHandlers(authManager, req.body);
-      for (const handler of handlers) {
-        const pluginID = handler.pluginID;
-        authLogger.debug(`${req.session.id}: User logout for auth handler ${pluginID}`);
-        if (req.session.authPlugins) {
-          delete req.session.authPlugins[pluginID];
-        }
-      }
-      if (!req.session.authPlugins || Object.keys(req.session.authPlugins).length == 0) {
-        if (req.session.id) {
-          req.session.zlux = undefined;
-          req.sessionStore.destroy(req.session.id);
-        }
-        req.session.id = null;
-        res.clearCookie('connect.sid.'+cookiePort, { path: '/',
-                                                     httpOnly: true,
-                                                     secure: isSecurePort});
-      }
-      res.status(200).send('');
+      return _doLogoutInner(req, res);
     },
 
     // This only checks to see if there is a username or not therefore it does

--- a/plugins/sso-auth/lib/zssHandler.js
+++ b/plugins/sso-auth/lib/zssHandler.js
@@ -86,6 +86,28 @@ class ZssHandler {
 
   }
 
+  logout(request, sessionState) {
+    return new Promise((resolve, reject) => {
+      sessionState.authenticated = false;
+      delete sessionState.zssUsername;
+      let options = {
+        method: 'GET',
+        headers: {'cookie': sessionState.zssCookies+''}
+      };
+      delete sessionState.zssCookies;
+      request.zluxData.webApp.callRootService("logout", options).then((response) => {
+        //did logout or already logged out
+        if (response.statusCode === 200 || response.statusCode === 401) {
+          resolve({ success: true });
+        } else {
+          resolve({ success: false, reason: response.statusCode });
+        }
+      }).catch((e) =>  {
+        reject(e);
+      });
+    });
+  }
+
   /**
    * Should be called e.g. when the users enters credentials
    * 


### PR DESCRIPTION
The auth-logout endpoint never reached the security plugins, in case there was something else they should be doing on the backend during the logout process.
Now, if the plugins support it, they are called. This is similar to the logic used for login, except that regardless of what the plugins do, the server core still deletes the session storage area at the end.