### PR TITLE
Search for new plugins on request and or periodically

### DIFF
--- a/lib/assets/i18n/log/messages_en.json
+++ b/lib/assets/i18n/log/messages_en.json
@@ -177,6 +177,7 @@
   "ZWED0290I":"Plugin (%s) loaded. Successful: %s% (%s/%s) Attempted: %s% (%s/%s)",
   "ZWED0291I":"Server is ready at %s Plugins successfully loaded: %s% (%s/%s)",
   "ZWED0292I":"Plugin (%s) loaded.",
+  "ZWED0293I":"Handling scan plugin request from worker=%d",
   
   "ZWED0003W":"%s: Session security call %s failed for auth handler %s. Plugin response: %s",
   "ZWED0004W":"Tomcat for ID=%s not starting, no services succeeded loading",

--- a/lib/assets/i18n/log/messages_en.json
+++ b/lib/assets/i18n/log/messages_en.json
@@ -176,7 +176,8 @@
   "ZWED0289I":"RESERVED: JarMgr with id=%s invoked to startup with config=%s",
   "ZWED0290I":"Plugin (%s) loaded. Successful: %s% (%s/%s) Attempted: %s% (%s/%s)",
   "ZWED0291I":"Server is ready at %s Plugins successfully loaded: %s% (%s/%s)",
-
+  "ZWED0292I":"Plugin (%s) loaded.",
+  
   "ZWED0003W":"%s: Session security call %s failed for auth handler %s. Plugin response: %s",
   "ZWED0004W":"Tomcat for ID=%s not starting, no services succeeded loading",
   "ZWED0005W":"",
@@ -285,6 +286,7 @@
   "ZWED0167W":"RESERVED: Error adding to the storage: %s",
   "ZWED0168W":"RESERVED: Unable to retrieve storage value from cluster %s",
   "ZWED0169W":"RESERVED: Error deleting the storage with id: %s %s",
+  "ZWED0170W":"Plugin (%s) loading failed. Message: \"%s\"",
   
   "ZWED0001E":"RESERVED: Error: %s",
   "ZWED0002E":"Could not stop language manager for types=%s",

--- a/lib/clusterManager.js
+++ b/lib/clusterManager.js
@@ -241,9 +241,15 @@ if (cluster.isMaster) {
   }
 
   ClusterManager.prototype.notifyWorkersForAddingPlugin = function(resultHandler, indexInCluster) {
+    this.notifyWorkers(Notifications.addDynamicPlugin, indexInCluster);
+    resultHandler(true);
+  }
+
+  ClusterManager.prototype.notifyWorkersForScanningPlugins = function(resultHandler, indexInCluster) {
     this.notifyWorkers(Notifications.scanPlugins, indexInCluster);
     resultHandler(true);
   }
+
 
   ClusterManager.prototype.startWorkers = function() {
     clusterLogger.info("ZWED0026I - Fork " + this.workersNum + " workers.");
@@ -406,6 +412,11 @@ if (cluster.isMaster) {
     resultHandler(true);
   }
 
+  ClusterManager.prototype.notifyWorkersForScanningPlugins = function(resultHandler, indexInCluster) {
+    this.notifyWorkers(Notifications.scanPlugins, null, indexInCluster);
+    resultHandler(true);
+  }
+  
   ClusterManager.prototype.rememberNodeState = function(type, object) {
     if (!this.nodeStates) {
       this.nodeStates = new Map();
@@ -538,8 +549,18 @@ if (cluster.isMaster) {
 
   ClusterManager.prototype.onScanPlugins = function(handler) {
     this.on(Notifications.scanPlugins, handler);
-  }  
+  }
 
+  ClusterManager.prototype.scanPlugins = function() {
+    this.callClusterMethodRemote(null, "clusterManager", "notifyWorkersForScanningPlugins", [],
+      function() {
+      },
+      function(e) {
+        clusterLogger.warn("ZWED0014W - Error adding plugin: " + e);
+      }
+    );
+  }
+  
   ClusterManager.prototype.onAddDynamicPlugin = function(handler) {
     this.on(Notifications.addDynamicPlugin, handler);
   }

--- a/lib/depgraph.js
+++ b/lib/depgraph.js
@@ -97,8 +97,10 @@ DependencyGraph.prototype = {
           logger.debug('ZWED0148I', providerId, depLink); //logger.debug('Found dependency: ', providerId, depLink)
           if (depLink.valid) {
             providerNode.deps.push(Object.freeze(depLink));
-            serviceImport.version = depLink.actualVersion;
-            logger.debug(`ZWED0149I`, depLink); //logger.debug(`resolved actual version for import`,depLink);
+            if (!serviceImport.version) {
+              serviceImport.version = depLink.actualVersion;
+              logger.debug(`ZWED0149I`, depLink); //logger.debug(`resolved actual version for import`,depLink);
+            }
           } else {
             brokenDeps.push(depLink)
           }

--- a/lib/index.js
+++ b/lib/index.js
@@ -233,31 +233,45 @@ Server.prototype = {
       pluginCount++;
       if (event.data.error) {
         if (!process.clusterManager || process.clusterManager.getIndexInCluster() == 0) {
-          installLogger.warn(`ZWED0027W`, event.data.identifier, event.data.error.message, 
-            Math.round((pluginsLoaded/event.count)*100), pluginsLoaded, event.count, 
-            Math.round((pluginCount/event.count)*100), pluginCount, event.count);
+          if (event.count) {
+            installLogger.warn(`ZWED0027W`, event.data.identifier, event.data.error.message, 
+                               Math.round((pluginsLoaded/event.count)*100), pluginsLoaded, event.count, 
+                               Math.round((pluginCount/event.count)*100), pluginCount, event.count);
+          } else {
+            installLogger.warn(`ZWED0170W`, event.data.identifier, event.data.error.message);
+          }
         }
-        if (pluginCount == event.count) {
-          installLogger.info(`ZWED0031I`, runningInstances[0], Math.round((pluginsLoaded/event.count)*100), pluginsLoaded, event.count);
+        if (pluginCount === event.count) {
+          this.pluginLoadingFinished(runningInstances[0], Math.round((pluginsLoaded/event.count)*100), pluginsLoaded, event.count);
         }
       } else {
         return this.pluginLoaded(event.data).then(() => {
+          pluginsLoaded++;
           if (!process.clusterManager || process.clusterManager.getIndexInCluster() == 0) {
-            pluginsLoaded++;
-            installLogger.info(`ZWED0290I`, event.data.identifier, 
-              Math.round((pluginsLoaded/event.count)*100), pluginsLoaded, event.count, 
-              Math.round((pluginCount/event.count)*100), pluginCount, event.count);
-            if (pluginCount == event.count) {
-              installLogger.info(`ZWED0032I`, runningInstances[0], Math.round((pluginsLoaded/event.count)*100), pluginsLoaded, event.count);
+            if (event.count) {
+              installLogger.info(`ZWED0290I`, event.data.identifier, 
+                                 Math.round((pluginsLoaded/event.count)*100), pluginsLoaded, event.count, 
+                                 Math.round((pluginCount/event.count)*100), pluginCount, event.count);                  
+            } else {
+              installLogger.info(`ZWED0290I`, event.data.identifier);
             }
           }
+          if (pluginCount === event.count) {
+            this.pluginLoadingFinished(runningInstances[0], Math.round((pluginsLoaded/event.count)*100), pluginsLoaded, event.count);
+          }
         }, err => {
-          installLogger.warn(`ZWED0159W`, event.data.identifier, err.message, 
-            Math.round((pluginsLoaded/event.count)*100), pluginsLoaded, event.count,
-            Math.round((pluginCount/event.count)*100), pluginCount, event.count);
-          installLogger.debug(err.stack);
-          if (pluginCount == event.count) {
-            installLogger.info(`ZWED0291I`, runningInstances[0], Math.round((pluginsLoaded/event.count)*100), pluginsLoaded, event.count);
+          if (!process.clusterManager || process.clusterManager.getIndexInCluster() == 0) {            
+            if (event.count) {
+              installLogger.warn(`ZWED0159W`, event.data.identifier, err.message, 
+                                 Math.round((pluginsLoaded/event.count)*100), pluginsLoaded, event.count,
+                                 Math.round((pluginCount/event.count)*100), pluginCount, event.count);
+            } else {
+              installLogger.warn(`ZWED0170W`, event.data.identifier, err.message);
+            }
+            installLogger.debug(err.stack);
+          }
+          if (pluginCount === event.count) {
+            this.pluginLoadingFinished(runningInstances[0], Math.round((pluginsLoaded/event.count)*100), pluginsLoaded, event.count);            
           }
         });
       }
@@ -296,6 +310,14 @@ Server.prototype = {
       yield this.apiml.registerMainServerInstance();
     }
   }),
+
+  pluginLoadingFinished(adr, percent, loaded, total) {
+    if (!process.clusterManager || process.clusterManager.getIndexInCluster() == 0) {    
+      installLogger.info(`ZWED0031I`, adr, percent, loaded, total);
+      //Server is ready at ${adr}, Plugins successfully loaded: ${percent}% (${loaded}/${total})`);
+    }
+    this.pluginLoader.enablePluginScanner(this.userConfig.node.pluginScanIntervalSec);
+  },
 
   newPluginSubmitted(pluginDef) {
     installLogger.debug("ZWED0162I", pluginDef); //installLogger.debug("Adding plugin ", pluginDef);

--- a/lib/index.js
+++ b/lib/index.js
@@ -103,7 +103,9 @@ function Server(appConfig, userConfig, startUpConfig, configLocation) {
   this.webApp = null;
   if (process.clusterManager) {
     process.clusterManager.onScanPlugins(function(wi){
-      this.pluginLoader.loadPlugins();
+      bootstrapLogger.debug('ZWED0293I',wi);
+      //"Handling scan plugin request from worker=%d"
+      this.pluginLoader.scanForPlugins();
     }.bind(this));
     process.clusterManager.onAddDynamicPlugin(function(wi, pluginDef) {
       bootstrapLogger.info("ZWED0114I", pluginDef.identifier); //bootstrapLogger.log(bootstrapLogger.INFO, "adding plugin remotely " + pluginDef.identifier);
@@ -229,11 +231,12 @@ Server.prototype = {
         runningInstances.push("http://" + ip + ':' + httpsPort)
       }
     }
+    let messageIssued = false;
     this.pluginLoader.on('pluginFound', util.asyncEventListener(event => {
       pluginCount++;
       if (event.data.error) {
         if (!process.clusterManager || process.clusterManager.getIndexInCluster() == 0) {
-          if (event.count) {
+          if (!messageIssued) {
             installLogger.warn(`ZWED0027W`, event.data.identifier, event.data.error.message, 
                                Math.round((pluginsLoaded/event.count)*100), pluginsLoaded, event.count, 
                                Math.round((pluginCount/event.count)*100), pluginCount, event.count);
@@ -242,26 +245,38 @@ Server.prototype = {
           }
         }
         if (pluginCount === event.count) {
-          this.pluginLoadingFinished(runningInstances[0], Math.round((pluginsLoaded/event.count)*100), pluginsLoaded, event.count);
+          if (!messageIssued) {
+            this.pluginLoadingFinished(runningInstances[0], Math.round((pluginsLoaded/event.count)*100), pluginsLoaded, event.count);
+            messageIssued = true;
+          } else {
+            this.pluginLoader.issueRefreshFinish();
+          }
+          pluginCount = 0;
         }
       } else {
         return this.pluginLoaded(event.data).then(() => {
           pluginsLoaded++;
           if (!process.clusterManager || process.clusterManager.getIndexInCluster() == 0) {
-            if (event.count) {
+            if (!messageIssued) {
               installLogger.info(`ZWED0290I`, event.data.identifier, 
                                  Math.round((pluginsLoaded/event.count)*100), pluginsLoaded, event.count, 
                                  Math.round((pluginCount/event.count)*100), pluginCount, event.count);                  
             } else {
-              installLogger.info(`ZWED0290I`, event.data.identifier);
+              installLogger.info(`ZWED0292I`, event.data.identifier);
             }
           }
           if (pluginCount === event.count) {
-            this.pluginLoadingFinished(runningInstances[0], Math.round((pluginsLoaded/event.count)*100), pluginsLoaded, event.count);
+            if (!messageIssued) {
+              this.pluginLoadingFinished(runningInstances[0], Math.round((pluginsLoaded/event.count)*100), pluginsLoaded, event.count);
+              messageIssued = true;
+            } else {
+              this.pluginLoader.issueRefreshFinish();
+            }
+            pluginCount = 0;
           }
         }, err => {
           if (!process.clusterManager || process.clusterManager.getIndexInCluster() == 0) {            
-            if (event.count) {
+            if (!messageIssued) {
               installLogger.warn(`ZWED0159W`, event.data.identifier, err.message, 
                                  Math.round((pluginsLoaded/event.count)*100), pluginsLoaded, event.count,
                                  Math.round((pluginCount/event.count)*100), pluginCount, event.count);
@@ -271,7 +286,13 @@ Server.prototype = {
             installLogger.debug(err.stack);
           }
           if (pluginCount === event.count) {
-            this.pluginLoadingFinished(runningInstances[0], Math.round((pluginsLoaded/event.count)*100), pluginsLoaded, event.count);            
+            if (!messageIssued) {
+              this.pluginLoadingFinished(runningInstances[0], Math.round((pluginsLoaded/event.count)*100), pluginsLoaded, event.count);
+              messageIssued = true;
+            } else {
+              this.pluginLoader.issueRefreshFinish();
+            }
+            pluginCount = 0;
           }
         });
       }

--- a/lib/jsonUtils.js
+++ b/lib/jsonUtils.js
@@ -12,25 +12,25 @@
 
 const fs = require('fs');
 const util = require('./util');
-
+const Promise = require('bluebird');
 const log = global.COM_RS_COMMON_LOGGER.makeComponentLogger("_zsf.json");
 
 function JSONUtils(){
 
 }
 
-JSONUtils.readJSONFileWithComments = function(filename){
- var fileAsString = fs.readFileSync(filename).toString();  // because readFileSync returns Buffer
+
+function readJSONStringWithComments(contents, filename) {
   var cleanJSON = ""; 
   var pos = 0;
   var done = false;
   while (!done){
-    var newlinePos = fileAsString.indexOf('\n',pos);
+    var newlinePos = contents.indexOf('\n',pos);
     var line = "";
     if (newlinePos != -1){
-      line = fileAsString.substring(pos,newlinePos);
+      line = contents.substring(pos,newlinePos);
     } else {
-      line = fileAsString.substring(pos);
+      line = contents.substring(pos);
       done = true;
     }
     // console.log("LINE: "+line);
@@ -86,12 +86,33 @@ JSONUtils.readJSONFileWithComments = function(filename){
     throw e;
   }
   return parsedJSON;
+}
+
+JSONUtils.readJSONFileWithComments = function(filename){
+ var fileAsString = fs.readFileSync(filename).toString();  // because readFileSync returns Buffer
+  return readJSONStringWithComments(fileAsString, filename);
 };
+
+JSONUtils.readJSONFileWithCommentsAsync = function(filename) {
+  return new Promise(function(resolve, reject) {
+    fs.readFile(filename, function(err, contents) {
+      if (err) {
+        reject(err);
+      } else {
+        const fileAsString = contents.toString();
+        resolve(readJSONStringWithComments(fileAsString, filename));
+      }
+    });
+  });
+}
 
 exports.parseJSONWithComments = function(filename) {
   return JSONUtils.readJSONFileWithComments(filename);
 };
 
+exports.readJSONFileWithComments = JSONUtils.readJSONFileWithComments;
+exports.readJSONFileWithCommentsAsync = JSONUtils.readJSONFileWithCommentsAsync;
+exports.readJSONStringWithComments = JSONUtils.readJSONStringWithComments;
 
 /*
   This program and the accompanying materials are

--- a/lib/plugin-loader.js
+++ b/lib/plugin-loader.js
@@ -183,6 +183,9 @@ function makeDataService(def, plugin, context) {
 
 function Plugin(def, configuration) {
   Object.assign(this, def);
+  this.definition = Object.assign({},def);
+  delete this.definition.location;
+  delete this.definition.nodeModule;
   this.configuration = configuration;
   if (!this.location) {
     this.location = process.cwd();
@@ -225,17 +228,7 @@ Plugin.prototype = {
   },
   
   exportDef() {
-    return {
-      identifier: this.identifier,
-      pluginVersion: this.pluginVersion,
-      apiVersion: this.apiVersion,
-      pluginType: this.pluginType,
-      copyright: this.copyright,
-      //TODO move these to the appropraite plugin type(s)
-      webContent: this.webContent, 
-      configurationData: this.configurationData,
-      dataServices: this.dataServices
-    };
+    return this.definition;
   },
 
   exportTranslatedDef(acceptLanguage) {
@@ -452,7 +445,7 @@ NodeAuthenticationPlugIn.prototype = {
   },
   
   exportDef() {
-    return Object.assign(super.exportDef(), {
+    return Object.assign({}, super.exportDef(), {
       filename: this.filename,
       authenticationCategory: this.authenticationCategory
     });

--- a/lib/plugin-loader.js
+++ b/lib/plugin-loader.js
@@ -11,6 +11,7 @@
 
 'use strict';
 const util = require('util');
+const Promise = require('bluebird');
 const fs = require('fs');
 const http = require('http');
 const https = require('https');
@@ -598,6 +599,45 @@ PluginLoader.prototype = {
     pluginDef.location = pluginBasePath;
     return pluginDef;
   },
+
+  _readPluginDefAsync(pluginDescriptorFilename) {
+    return new Promise((resolve, reject)=> {
+      const pluginPtrPath = this.options.relativePathResolver(pluginDescriptorFilename,
+                                                              this.options.pluginsDir);
+      bootstrapLogger.info(`Processing plugin reference ${pluginPtrPath}...`);
+      jsonUtils.readJSONFileWithCommentsAsync(pluginPtrPath).then((pluginPtrDef)=> {
+        bootstrapLogger.log(bootstrapLogger.FINER, util.inspect(pluginPtrDef));
+        let pluginBasePath = pluginPtrDef.pluginLocation;
+        if (!path.isAbsolute(pluginBasePath)) {
+          pluginBasePath = this.options.relativePathResolver(pluginBasePath, process.cwd());
+        }
+        let pluginDefPath = path.join(pluginBasePath, 'pluginDefinition.json');
+        jsonUtils.readJSONFileWithCommentsAsync(pluginDefPath).then(function(pluginDef){
+          bootstrapLogger.log(bootstrapLogger.FINER,util.inspect(pluginDef));
+          if (pluginDef.identifier !== pluginPtrDef.identifier) {
+            return reject({location: pluginBasePath,
+                     identifier: pluginPtrDef.identifier,
+                     error: new Error(`Identifier doesn't match one found in pluginDefinition: ${pluginDef.identifier}`)});
+          }
+          if (!pluginDef.pluginType) {
+            return reject({location: pluginBasePath,
+                           identifier: pluginPtrDef.identifier,
+                           error: new Error(`No plugin type found, skipping`)});
+          }
+          bootstrapLogger.info(`Read ${pluginBasePath}: found plugin id = ${pluginDef.identifier}, `
+                               + `type = ${pluginDef.pluginType}`);
+          pluginDef.location = pluginBasePath;
+          resolve(pluginDef);
+        }).catch((e)=> {
+        reject({location: pluginBasePath,
+                identifier: pluginPtrDef.identifier,
+                error: e});
+        });
+      }).catch((e)=> {
+        reject({error: e});
+      });
+    });
+  },
   
   readPluginDefs() {
     const defs = [];
@@ -619,10 +659,59 @@ PluginLoader.prototype = {
     } 
     return defs;
   },
+
+  readNewPluginDefs() {
+    const defs = [];
+    bootstrapLogger.debug(`Scanning for new plugins in ${this.options.pluginsDir}`);
+    return new Promise((resolve, reject)=> {
+      fs.readdir(this.options.pluginsDir, (err, results)=> {
+        if (!err) {
+          const pluginLocationJSONs = results.filter((value)=>{
+            if (value.endsWith('.json')) {
+              return !this.pluginMap[value.substr(0,value.length-5)];
+            } else {
+              return false;
+            }
+          });
+          let counter = 0;
+          for (const pluginDescriptorFilename of pluginLocationJSONs) {
+            //TODO stopped here, dont promise in a for loop.
+            const plugin = this._readPluginDefAsync(pluginDescriptorFilename).then((plugin)=> {
+              defs.push(plugin);
+              counter++;
+              if (counter == pluginLocationJSONs.length) {
+                resolve(defs);
+              }
+            }).catch(function(e) {
+              counter++;
+              bootstrapLogger.log(bootstrapLogger.INFO,
+                                  `Failed to load ${pluginDescriptorFilename}\n`);
+              bootstrapLogger.warn(e)
+              if (counter == pluginLocationJSONs.length) {
+                resolve(defs);
+              }
+            });
+          }
+        } else {
+          bootstrapLogger.warn('Could not read plugins dir, e=',e);
+        }
+      });
+    });
+  },
   
   loadPlugins() {
     const defs = this.readPluginDefs();
     this.installPlugins(defs);
+  },
+
+  enablePluginScanner(intervalSec) {
+    if (intervalSec >= 1) {
+      this.intervalScanner = setInterval(()=> {
+        this.readNewPluginDefs().then((defs)=> {
+          this.installPlugins(defs);
+        });
+      },intervalSec*1000);
+    }
   },
   
   installPlugins(pluginDefs) {
@@ -643,6 +732,9 @@ PluginLoader.prototype = {
       }
     }
     const sortedAndRejectedPlugins = depgraph.processImports();
+    sortedAndRejectedPlugins.plugins = sortedAndRejectedPlugins.plugins.filter((plugin)=> {
+      return !this.pluginMap[plugin.identifier];
+    });
     for (const rejectedPlugin of sortedAndRejectedPlugins.rejects) {
       bootstrapLogger.warn(`ZWED0033W`, rejectedPlugin.pluginId, zluxUtil.formatErrorStatus(rejectedPlugin.validationError, DependencyGraph.statuses)); //bootstrapLogger.warn(`Could not initialize plugin` 
           //+ ` ${rejectedPlugin.pluginId}: `  
@@ -650,6 +742,8 @@ PluginLoader.prototype = {
               //DependencyGraph.statuses));
     }
 
+    let isFirstRun = Object.keys(this.pluginMap).length === 0;
+    
     for (const pluginDef of sortedAndRejectedPlugins.plugins) { 
       try {
         if (this.pluginMap[pluginDef.identifier]) {
@@ -672,12 +766,12 @@ PluginLoader.prototype = {
           let frozen = zluxUtil.deepFreeze(plugin);
           this.plugins.push(frozen);
           newPlugins.push(frozen);
-          this.plugins.push(zluxUtil.deepFreeze(plugin));
           this.pluginMap[plugin.identifier] = plugin;
           successCount++;
         } else {
           bootstrapLogger.info("ZWED0125I", pluginDef.identifier); //bootstrapLogger.log(bootstrapLogger.INFO,
             //`Plugin ${pluginDef.identifier} not loaded`);
+          this.pluginMap[pluginDef.identifier] = {}; //mark it as having failed so it will not be retried
         }
       } catch (e) {
         bootstrapLogger.warn("ZWED0035W", pluginDef.identifier, e);
@@ -686,10 +780,11 @@ PluginLoader.prototype = {
       }
     }
     this.registerStaticPluginsWithManagers(sortedAndRejectedPlugins.plugins);
+    let pluginCounter = isFirstRun ? newPlugins.length : 0;
     for (const plugin of newPlugins) {
       this.emit('pluginFound', {
         data: plugin,
-        count: newPlugins.length
+        count: pluginCounter
       });
     }
   },

--- a/lib/plugin-loader.js
+++ b/lib/plugin-loader.js
@@ -667,8 +667,10 @@ PluginLoader.prototype = {
             }
           });
           let counter = 0;
+          if (pluginLocationJSONs.length === 0) {
+            return resolve(pluginLocationJSONs);
+          }
           for (const pluginDescriptorFilename of pluginLocationJSONs) {
-            //TODO stopped here, dont promise in a for loop.
             const plugin = this._readPluginDefAsync(pluginDescriptorFilename).then((plugin)=> {
               defs.push(plugin);
               counter++;
@@ -697,12 +699,16 @@ PluginLoader.prototype = {
     this.installPlugins(defs);
   },
 
+  scanForPlugins() {
+    this.readNewPluginDefs().then((defs)=> {
+      this.installPlugins(defs);
+    });
+  },
+
   enablePluginScanner(intervalSec) {
     if (intervalSec >= 1) {
       this.intervalScanner = setInterval(()=> {
-        this.readNewPluginDefs().then((defs)=> {
-          this.installPlugins(defs);
-        });
+        this.scanForPlugins();
       },intervalSec*1000);
     }
   },
@@ -773,13 +779,16 @@ PluginLoader.prototype = {
       }
     }
     this.registerStaticPluginsWithManagers(sortedAndRejectedPlugins.plugins);
-    let pluginCounter = isFirstRun ? newPlugins.length : 0;
     for (const plugin of newPlugins) {
       this.emit('pluginFound', {
         data: plugin,
-        count: pluginCounter
+        count: newPlugins.length
       });
     }
+  },
+
+  issueRefreshFinish() {
+    this.emit('refreshFinish', {});
   },
 
   /**

--- a/lib/webapp.js
+++ b/lib/webapp.js
@@ -321,12 +321,9 @@ function waitForHeadersBeforeReload(res, maxRetries, timeout){
 
 const staticHandlers = {
   plugins: function(webapp) {
-    return function(req, res) {
-      let parsedRequest = url.parse(req.url, true);
-      let type = parsedRequest.query["type"] ? parsedRequest.query["type"] : 'all';
-      let plugins = webapp.plugins;
+    const respondToGetPlugins = function(req, res, webapp, type, plugins) {
       const acceptLanguage = 
-        translationUtils.getAcceptLanguageFromCookies(req.cookies) || req.headers['accept-language'] || '';
+            translationUtils.getAcceptLanguageFromCookies(req.cookies) || req.headers['accept-language'] || '';
       const pluginDefs = plugins.map(p => p.exportTranslatedDef(acceptLanguage));
       let pluginId;
       let pluginLocation;
@@ -370,7 +367,7 @@ const staticHandlers = {
         response.pluginDefinitions = filteredPluginDefs.filter(def => {
           if (def.pluginType != null) {
             contentLogger.debug('ZWED0191I', def.pluginType); //contentLogger.debug('Returning true if type matches, type='
-                //+ def.pluginType);
+            //+ def.pluginType);
             return def.pluginType === type;
           } else if (type == 'application') {
             contentLogger.debug('ZWED0192I'); //contentLogger.debug('Returning true because type is application');
@@ -382,6 +379,40 @@ const staticHandlers = {
         });
       }
       res.json(response);
+    }
+
+    let lastCall = Date.now();
+    const CALL_INTERVAL = 1000;
+    //To not abuse FS, cache for a second
+    
+    return function(req, res) {
+      let parsedRequest = url.parse(req.url, true);
+      const type = parsedRequest.query["type"] ? parsedRequest.query["type"] : 'all';
+      const refresh = parsedRequest.query['refresh'];
+      const now = Date.now();
+      if (refresh == 'true' && (lastCall+CALL_INTERVAL < now)) {
+        lastCall = now;
+        if (!req.username) {
+          res.status(400).json({error: 'Login required for refresh feature'});
+        } else {
+          if (process.clusterManager) {
+            process.clusterManager.scanPlugins();
+          }
+          const loader = webapp.options.pluginLoader;
+          loader.readNewPluginDefs().then((defs)=> {
+            if (defs.length === 0) {
+              respondToGetPlugins(req, res, webapp, type, webapp.plugins);
+            } else {
+              loader.once('refreshFinish', (event) => {
+                respondToGetPlugins(req, res, webapp, type, webapp.plugins);
+              });
+              loader.installPlugins(defs);
+            }
+          });
+        }
+      } else {
+        respondToGetPlugins(req, res, webapp, type, webapp.plugins);
+      } 
     }
   },
   

--- a/lib/webapp.js
+++ b/lib/webapp.js
@@ -320,23 +320,11 @@ function waitForHeadersBeforeReload(res, maxRetries, timeout){
 }
 
 const staticHandlers = {
-  plugins: function(plugins, options) {
+  plugins: function(webapp) {
     return function(req, res) {
       let parsedRequest = url.parse(req.url, true);
-      if (!parsedRequest.query) {
-        do404(req.url, res, "A plugin query must be specified");
-        return;
-      }
-      let type = parsedRequest.query["type"];
-      /*
-        Note: here, we query for installed plugins using a filter of either 'all' or a specific pluginType.
-        But, some plugins do not have pluginTypes currently. People can forget to include that information.
-        In our code, we've been assuming that plugins that do not declare a type are of type 'application',
-        but this should be enforced somehow in the future.
-      */
-      if (!type) {
-        type = "all"
-      }
+      let type = parsedRequest.query["type"] ? parsedRequest.query["type"] : 'all';
+      let plugins = webapp.plugins;
       const acceptLanguage = 
         translationUtils.getAcceptLanguageFromCookies(req.cookies) || req.headers['accept-language'] || '';
       const pluginDefs = plugins.map(p => p.exportTranslatedDef(acceptLanguage));
@@ -344,7 +332,7 @@ const staticHandlers = {
       let pluginLocation;
       let filteredPluginDefs = []
       let allowedPlugins;
-      if (options.serverConfig.dataserviceAuthentication.rbac) {
+      if (webapp.options.serverConfig.dataserviceAuthentication.rbac) {
         for (let plugin of plugins) {
           if (plugin.pluginType === "bootstrap") {
             pluginId = plugin.identifier
@@ -352,7 +340,7 @@ const staticHandlers = {
             break;
           }
         }
-        allowedPlugins = configService.getAllowedPlugins(options, req.username, pluginId, pluginLocation);
+        allowedPlugins = configService.getAllowedPlugins(webapp.options, req.username, pluginId, pluginLocation);
         if (allowedPlugins != null) {
           for(let plugin of pluginDefs) {
             let obj = allowedPlugins.allowedPlugins.find(o => o.identifier === plugin.identifier)
@@ -1312,7 +1300,7 @@ WebApp.prototype = {
     this._installRootService('/auth-logout', 'get', this.auth.doLogout, 
         {needJson: true, needAuth: false, isPseudoSso: true});
     serviceHandleMap['auth'] = new WebServiceHandle('/auth', this.wsEnvironment);
-    this._installRootService('/plugins', 'get', staticHandlers.plugins(this.plugins, this.options), 
+    this._installRootService('/plugins', 'get', staticHandlers.plugins(this), 
         {needJson: false, needAuth: true, authType: "semi", isPseudoSso: false}); 
     this._installRootService('/plugins', 'use', staticHandlers.pluginLifecycle(this.options, this.plugins),
       {needJson: true, needAuth: true, isPseudoSso: false});


### PR DESCRIPTION
If node.pluginScanIntervalSec is defined as greater than or equal to 1, then the server will read the plugin folder at that interval to find new plugins to load.
Loading new plugins is the same process as is done at startup, so there is no additional security concern in the process. The only difference is that the plugin loading is async, as opposed to sync that happens during startup.
Due to this command being relatively safe, users can also request this by calling GET /plugins with ?refresh=true. But they must be logged in first.
Because this reads the filesystem, we do not want too many users at once to overwhelm, so it is limited to once per second.

In the case a worker crashes, the bootstrap process picks up the plugins as usual, including these new plugins, so this does not disrupt existing behavior.

This PR complicates the flow of plugin loading by needing to connect parts of plugin-loader, index, and webapp in ways that I suppose were not originally intended. However, I didn't want to do a further reorganization, so I'm making minor use of event listening.