### PR TITLE
Add ability for global headers to exist and possibly override plugins

### DIFF
--- a/lib/webapp.js
+++ b/lib/webapp.js
@@ -152,6 +152,8 @@ function getPresetHeader(name, preset, req) {
   case 'content-security-policy':
     if (preset == 'strict') {
       return `default-src 'self' ${req.hostname};`;
+    } else if (preset == 'frame-strict') {
+      return `frame-src 'self' ${req.hostname};`;
     }
     break;
   }
@@ -969,10 +971,10 @@ headers: {
 
   customHeaderInjection(headerDescriptions) {
     return function injectHeaders(req, res, next) {
-      const headerNames = Object.keys(headerDescriptions);
-      for (let i = 0; i < headerNames.length; i++) {
-        const headerName = headerNames[i];
-        const headerDescription=headerDescriptions[headerName];
+      for (let i = 0; i < headerDescriptions.length; i++) {
+        const headerDescription = headerDescriptions[i];
+
+        const headerName = headerDescription.name;
         if (headerDescription.preset) {
           //TODO do preset
           const preset = getPresetHeader(headerName, headerDescription.preset, req);
@@ -1572,8 +1574,31 @@ WebApp.prototype = {
       
       let middleware = [];
       middleware.push(commonMiddleware.setHstsIfSecure());
-      if (plugin.webContent.headers) {
-        middleware.push(commonMiddleware.customHeaderInjection(plugin.webContent.headers));
+      if (this.options.serverConfig.node.headers || plugin.webContent.headers) {
+        let headers = Object.assign({}, this.options.serverConfig.node.headers || {});
+        let pluginHeaders = plugin.webContent.headers;
+        if (pluginHeaders) {
+          if (Object.keys(headers).length == 0) {
+            headers = plugin.webContent.headers;
+          } else {
+            let keys = Object.keys(pluginHeaders);
+            for (let i = 0; i < keys.length; i++) {
+              if (!headers[keys[i]]) {
+                headers[keys[i]] = pluginHeaders[keys[i]];
+              } else if (!headers[keys[i]].override) {
+                headers[keys[i]] = pluginHeaders[keys[i]];
+              }
+            }
+          }
+        }
+        let headersArray = [];
+        let keys = Object.keys(headers);
+        for (let i = 0; i < keys.length; i++) {
+          let header = Object.assign({}, headers[keys[i]]);
+          header.name = keys[i];
+          headersArray.push(header);
+        }
+        middleware.push(commonMiddleware.customHeaderInjection(headersArray));
       }
       middleware.push(expressStaticGzip(path.join(plugin.location, '/web'),
                                         {enableBrotli: true, orderPreference: ['br', 'gzip']}));


### PR DESCRIPTION
Another layer of customization on top of previous PR https://github.com/zowe/zlux-server-framework/pull/173
In this case, server.json (or env, cli) can be used to specify a node.headers section which has objects identical to what is in PR 173. The difference is the attribute "override" which when defined will override whatever the plugin says.
This gives the administrator the ability to set more (or less) restrictive headers to meet their needs.
Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>