### PR TITLE
Dont issue rbac request if rbac is turned off, for /plugins

### DIFF
--- a/lib/webapp.js
+++ b/lib/webapp.js
@@ -1332,8 +1332,13 @@ WebApp.prototype = {
     this._installRootService('/auth-logout', 'get', this.auth.doLogout, 
         {needJson: true, needAuth: false, isPseudoSso: true});
     serviceHandleMap['auth'] = new WebServiceHandle('/auth', this.wsEnvironment);
-    this._installRootService('/plugins', 'get', staticHandlers.plugins(this), 
-        {needJson: false, needAuth: true, authType: "semi", isPseudoSso: false}); 
+    if (this.options.serverConfig.dataserviceAuthentication.rbac) {
+      this._installRootService('/plugins', 'get', staticHandlers.plugins(this),
+                               {needJson: false, needAuth: true, authType: "semi", isPseudoSso: false});
+    } else {
+      this._installRootService('/plugins', 'get', staticHandlers.plugins(this),
+                               {needJson: false, needAuth: false, isPseudoSso: false});
+    }
     this._installRootService('/plugins', 'use', staticHandlers.pluginLifecycle(this.options, this.plugins),
       {needJson: true, needAuth: true, isPseudoSso: false});
     serviceHandleMap['plugins'] = new WebServiceHandle('/plugins', this.wsEnvironment);


### PR DESCRIPTION
Before, this would spam warnings on zss because I did not have my user set up to allow in racf properly. I knew this, so it was annoying.
Now, because i don't, and have rbac off, it will not issue a request sure to fail.
Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>