### PR TITLE
Minor apiml cleanup

### DIFF
--- a/lib/apiml.js
+++ b/lib/apiml.js
@@ -27,7 +27,7 @@ const MEDIATION_LAYER_EUREKA_DEFAULTS = {
 
 
 const MEDIATION_LAYER_INSTANCE_DEFAULTS = {
-  instanceId: "localhost:zowe-zlux:8543",
+//  instanceId: "localhost:zlux:8543",
   app: "zlux",
   hostName: "localhost",
   ipAddr: "127.0.0.1", 
@@ -52,22 +52,21 @@ const MEDIATION_LAYER_INSTANCE_DEFAULTS = {
     "routed-services.4.service-url": "/",
 
     'mfaas.discovery.catalogUiTile.id': 'zlux',
-    'mfaas.discovery.catalogUiTile.title': 'Zowe Application Server',
-    'mfaas.discovery.catalogUiTile.description': 'The Proxy Server is an '
-       + 'HTTP, HTTPS, and Websocket server built upon NodeJS and ExpressJS. '
-       + 'This serves static content via "Plugins", and is extensible by '
-       + 'REST and Websocket "Dataservices" optionally present within Plugins.',
+    'mfaas.discovery.catalogUiTile.title': 'Zowe App Server',
+    'mfaas.discovery.catalogUiTile.description': 'Zowe\'s Application Server is an '
+       + 'HTTPS and Websocket server built upon NodeJS and ExpressJS. '
+       + 'It powers the Zowe Desktop and serves static content, REST, and Websockets '
+       + 'from extensible plug-ins called Apps.',
     'mfaas.discovery.catalogUiTile.version': '1.0.0',
 
-    'mfaas.discovery.service.title': 'Zowe Application Server',
-    'mfaas.discovery.service.description': 'The Proxy Server is an HTTP, '
-      + 'HTTPS, and Websocket server built upon NodeJS and ExpressJS. This '
-      + 'serves static content via "Plugins", and is extensible by REST and '
-      + 'Websocket "Dataservices" optionally present within Plugins.',
+    'mfaas.discovery.service.title': 'Zowe App Server',
+    'mfaas.discovery.service.description': 'Zowe\'s Application Server is an '
+       + 'HTTPS and Websocket server built upon NodeJS and ExpressJS. '
+       + 'It powers the Zowe Desktop and serves static content, REST, and Websockets '
+       + 'from extensible plug-ins called Apps.',
 
-    'mfaas.api-info.apiVersionProperties.v1.title': 'Zowe Application Server API',
-    'mfaas.api-info.apiVersionProperties.v1.description': 'An API for the ZLux '
-      +' Proxy Server',
+    'mfaas.api-info.apiVersionProperties.v1.title': 'Zowe App Server API',
+    'mfaas.api-info.apiVersionProperties.v1.description': 'An API for the App Server.',
     'mfaas.api-info.apiVersionProperties.v1.version': '1.0.0'
   }
 };
@@ -184,11 +183,13 @@ ApimlConnector.prototype = {
       'default': [
         url
       ]};
-      log.info(`ZWED0020I`, url); //log.info(`Registering at ${url}...`);
-      log.debug("ZWED0145I", JSON.stringify(zluxProxyServerInstanceConfig)); //log.debug(`zluxProxyServerInstanceConfig ${JSON.stringify(zluxProxyServerInstanceConfig)}`)
+    log.info(`ZWED0020I`, url); //log.info(`Registering at ${url}...`);
+    log.debug("ZWED0145I", zluxProxyServerInstanceConfig); //log.debug(`zluxProxyServerInstanceConfig ${JSON.stringify(zluxProxyServerInstanceConfig)}`)
     const zluxServerEurekaClient = new eureka(zluxProxyServerInstanceConfig);
-    //zluxServerEurekaClient.logger.level('debug');
+
     this.zluxServerEurekaClient = zluxServerEurekaClient;
+    //zluxServerEurekaClient.logger.level('debug');
+
     return new Promise(function (resolve, reject) {
       zluxServerEurekaClient.start(function (error) {
         if (error) {

--- a/lib/webapp.js
+++ b/lib/webapp.js
@@ -1258,7 +1258,7 @@ WebApp.prototype = {
   installStaticHanders() {
     const webdir = path.join(path.join(this.options.productDir,
       this.options.productCode), 'web');
-    const rootPage = this.options.rootRedirectURL? this.options.rootRedirectURL 
+    const rootPage = this.options.rootRedirectURL? '.'+this.options.rootRedirectURL 
         : '/';
     if (rootPage != '/') {
       this.expressApp.get('/', function(req,res) {


### PR DESCRIPTION
Fixes case in which desktop-through-apiml needed full URL. Redirect was doing an absolute path and breaking out of apiml routing. Now it is relative, so it should work better.

Also cleanup on apiml metadata referring to the app server as "proxy server" and such.

Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>