### PR TITLE
Fixed chatty and incorrect printing of cluster worker count calculations

### DIFF
--- a/lib/clusterManager.js
+++ b/lib/clusterManager.js
@@ -39,9 +39,13 @@ const cpuCount = os.cpus().length;
 const highCPU = process.env.highCPU || 0.8;
 const lowCPU = process.env.lowCPU || 0.2;
 
+const maxWorkers = !isNaN(Number(process.env.ZLUX_MAX_WORKERS))
+      ? Math.min(cpuCount*2, Math.max(Number(process.env.ZLUX_MAX_WORKERS), 1))
+      : cpuCount;
 
-const minWorkers = Math.min(Math.max(process.env.ZLUX_MIN_WORKERS, 1), cpuCount*2, process.env.ZLUX_MAX_WORKERS) || 1;
-const maxWorkers = Math.min(cpuCount*2, Math.max(process.env.ZLUX_MAX_WORKERS, 1)) || cpuCount;
+const minWorkers = !isNaN(Number(process.env.ZLUX_MIN_WORKERS))
+      ? Math.min(Math.max(Number(process.env.ZLUX_MIN_WORKERS), 1), maxWorkers)
+      : 1;
 const workerChangeDecisionDelay = process.env.workerChangeDecisionDelay || 4;
 
 var storageTimeout = 5000; /* Default timeout for how long plugins wait for the cluster storage to finish creation */
@@ -50,10 +54,10 @@ var clusterLogger = zluxUtil.loggers.clusterLogger;
 
 // Inserting the Zowe message code inline due to message resource file not loaded yet
 clusterLogger.info("ZWED0211I - The number of processors is: " + cpuCount);
-if (minWorkers != process.env.ZLUX_MIN_WORKERS) {
+if (minWorkers != Number(process.env.ZLUX_MIN_WORKERS)) {
   clusterLogger.info("ZWED0212I - Environmental variable ZLUX_MIN_WORKERS was not a valid number therefore " + minWorkers + " will be used as the minimum workers");
 }
-if (maxWorkers != process.env.ZLUX_MAX_WORKERS) {
+if (process.env.ZLUX_MAX_WORKERS && (maxWorkers != Number(process.env.ZLUX_MAX_WORKERS))) {
   clusterLogger.info("ZWED0213I - Environmental variable ZLUX_MAX_WORKERS was not a valid number therefore " + maxWorkers + " will be used as the maximum workers");
 }
 


### PR DESCRIPTION
Setting min workers appeared to never work, max did but printed warnings when you didn't do anything wrong.
Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>