### PR TITLE
Set worker title so you can tell them apart

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -10,7 +10,6 @@
 
 'use strict';
 const Promise = require('bluebird');
-const cluster = require('cluster');
 const util = require('./util');
 const WebServer = require('./webserver');
 const PluginLoader = require('./plugin-loader');
@@ -25,6 +24,7 @@ const checkProxiedHost = require('./proxy').checkProxiedHost;
 const bootstrapLogger = util.loggers.bootstrapLogger;
 const installLogger = util.loggers.installLogger;
 const ipaddr = require('ipaddr.js');
+const cluster = process.clusterManager ? require('cluster') : undefined;
 
 const defaultOptions = {
   relativePathResolver: util.normalizePath

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,3 @@
-
 /*
   This program and the accompanying materials are
   made available under the terms of the Eclipse Public License v2.0 which accompanies
@@ -11,6 +10,7 @@
 
 'use strict';
 const Promise = require('bluebird');
+const cluster = require('cluster');
 const util = require('./util');
 const WebServer = require('./webserver');
 const PluginLoader = require('./plugin-loader');
@@ -39,6 +39,9 @@ function Server(appConfig, userConfig, startUpConfig, configLocation) {
   this.appConfig = appConfig;
   unp.setProductCode(appConfig.productCode);
   util.deepFreeze(appConfig);
+  if (process.clusterManager) {
+    process.title = process.title+'W'+cluster.worker.id;
+  }
   util.resolveRelativePaths(userConfig, this.options.relativePathResolver, process.cwd());
   this.startUpConfig = startUpConfig;
   util.deepFreeze(startUpConfig);


### PR DESCRIPTION
I took creative liberty on our component naming scheme, by adding another letter to the name.
Before:
ZWE D S n
Which is
product=ZWE
component=D, (I think D was for Desktop)
sub-component=S, the app-server
instance=n, which instance of zowe is it? 1? 2?

After:
ZWE D S n W m
sub-sub-component=W, the cluster worker
worker=m, which process in the cluster is it? 1? 2? 3?

When combined with the other commit, https://github.com/zowe/zlux-app-server/pull/109 , the difference is great:
before:
```
sgrady   23252 23235  0 Mar02 pts/4    00:00:00 /bin/sh ./app-server.sh -s 12345
sgrady   23270 23252  0 Mar02 pts/4    00:01:55 node --harmony zluxCluster.js --config=~/.zowe/workspace/app-server/serverConfig/server.json -s 12345
sgrady   23282 23270  0 Mar02 pts/4    00:01:28 /usr/local/bin/node --harmony /home/sgrady/zowe-demo/zlux-app-server/lib/zluxCluster.js --config=~/.zowe/workspace/app-server/serverConfig/server.json -s 12345
sgrady   23283 23270  0 Mar02 pts/4    00:01:25 /usr/local/bin/node --harmony /home/sgrady/zowe-demo/zlux-app-server/lib/zluxCluster.js --config=~/.zowe/workspace/app-server/serverConfig/server.json -s 12345
```

after:
```
sgrady   24744 24740  0 19:42 pts/0    00:00:00 /bin/sh ./app-server.sh -s 12345
sgrady   24745 24744  0 19:42 pts/0    00:00:00 ZWEDS1
sgrady   24757 24745  0 19:42 pts/0    00:00:01 ZWEDS1W1
sgrady   24763 24745  0 19:42 pts/0    00:00:01 ZWEDS1W2
```

Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>