### PR TITLE
Browser-based apiml token, auth simplification

### DIFF
--- a/lib/apiml.js
+++ b/lib/apiml.js
@@ -128,11 +128,11 @@ ApimlConnector.prototype = {
        homePageUrl: `${proto}://${this.hostName}:${port}/`,
        port: {
          "$": mlHttpPort, // This is a workaround for the mediation layer
-         "@enabled": protocolObject.httpEnabled
+         "@enabled": ''+protocolObject.httpEnabled
        },
        securePort: {
          "$": Number(protocolObject.httpsPort),
-         "@enabled": protocolObject.httpsEnabled
+         "@enabled": ''+protocolObject.httpsEnabled
        }
      });
 
@@ -168,13 +168,13 @@ ApimlConnector.prototype = {
   },*/
   
   registerMainServerInstance() {
+    const overrideOptions = this.tlsOptions.rejectUnauthorized === false
+          ? {rejectUnauthorized: false} : this.tlsOptions;
     const zluxProxyServerInstanceConfig = {
       instance: this._makeMainInstanceProperties(),
       eureka: Object.assign({}, MEDIATION_LAYER_EUREKA_DEFAULTS, this.eurekaOverrides),
-      requestMiddleware: (requestOpts, done) => {
-        const { pfx, ca, cert, key, passphrase } = this.tlsOptions;
-        Object.assign(requestOpts, { pfx, ca, cert, key, passphrase });
-        done(requestOpts);
+      requestMiddleware: function (requestOpts, done) {
+        done(Object.assign(requestOpts, overrideOptions));
       }
     }
     log.debug("ZWED0144I", JSON.stringify(zluxProxyServerInstanceConfig, null, 2)); //log.debug("zluxProxyServerInstanceConfig: " 

--- a/lib/auth-manager.js
+++ b/lib/auth-manager.js
@@ -69,8 +69,7 @@ AuthManager.prototype = {
   pendingPlugins: null,
 
   isConfigValid(serviceAuthJSON) {
-    if (!serviceAuthJSON || !serviceAuthJSON.implementationDefaults
-        || !serviceAuthJSON.defaultAuthentication) {
+    if (!serviceAuthJSON || !serviceAuthJSON.defaultAuthentication) {
       bootstrapLogger.warn('ZWED0007W'); //bootstrapLogger.warn('Dataservice authentication definition is not present'
           //+ 'in server configuration file, or malformed.\n Correct the configuration'
           //+' file before restarting the server');
@@ -101,16 +100,34 @@ AuthManager.prototype = {
         authenticationHandler.pluginID = plugin.identifier;
         authenticationHandler.pluginDef = plugin;
         this.handlers[plugin.identifier] = authenticationHandler;
-        let category = this.authTypes[plugin.authenticationCategory];
-        if (!category) {
-          category = [];
-          this.authTypes[plugin.authenticationCategory] = category;
+        let categories;
+        if (authenticationHandler.capabilities && authenticationHandler.capabilities.canGetCategories) {
+          categories = authenticationHandler.getCategories();
+        } else if (plugin.authenticationCategories) {
+          categories = plugin.authenticationCategories;
+        } else {
+          categories = [plugin.authenticationCategory];
         }
-        category.push(plugin.identifier);
-        bootstrapLogger.info(`ZWED0111I`, plugin.identifier, plugin.authenticationCategory); //bootstrapLogger.log(bootstrapLogger.INFO,
+        categories.forEach((category)=> {
+          let pluginsByCategory = this.authTypes[category];
+          if (!pluginsByCategory) {
+            pluginsByCategory = [];
+            this.authTypes[category] = pluginsByCategory;
+          }
+          if (this.config.implementationDefaults[category]) {
+            const index = this.config.implementationDefaults[category].plugins.indexOf(plugin.identifier);
+            if (index != -1) {
+              pluginsByCategory.splice(index, 0, plugin.identifier);
+            } else {
+              pluginsByCategory.push(plugin.identifier);
+            }
+          } else {
+            pluginsByCategory.push(plugin.identifier);
+          }
+          bootstrapLogger.info(`ZWED0111I`, plugin.identifier, category); //bootstrapLogger.log(bootstrapLogger.INFO,
           //`Authentication plugin ${plugin.identifier} added to category `
-            //+ `${plugin.authenticationCategory}`);
-        
+          //+ `${category}`);
+        });
       } catch (e) {
         authLog.warn('ZWED0008W', plugin.identifier, e); //authLog.warn(`error loading auth plugin ${plugin.identifier}: ` + e);
       }
@@ -145,22 +162,13 @@ AuthManager.prototype = {
       process.exit(constants.EXIT_AUTH);    
     }
   },
-  
+
+  /*
+    This forced unneccessary configuration steps on the admin.
+    It is easier to say a plugin was requested if it was installed.
+  */
   authPluginRequested(pluginID, pluginCategory) {
-    const category = this.config.implementationDefaults[pluginCategory];
-    if (!(category && category.plugins)) {
-      bootstrapLogger.warn("ZWED0012W", pluginCategory); //bootstrapLogger.warn("Implementation defaults for "+pluginCategory+" was not an"
-          //+ " object, or did not contain a plugins attribute. Other criteria for selecting"
-          //+ " authentication implementations is not yet implemented.");
-      return false;
-    }
-    const plugins = category.plugins;
-    for (let i = 0; i < plugins.length; i++) {
-      if (plugins[i] === pluginID) {
-        return true;
-      }
-    }
-    return false;
+    return true;
   }, 
   
   getBestAuthenticationHandler(authType, criteria) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -316,7 +316,7 @@ Server.prototype = {
       } else {
         apimlTlsOptions = this.webServer.getTlsOptions();
       }
-      installLogger.info('ZWED0033I', JSON.stringify(webAppOptions.httpPort), JSON.stringify(webAppOptions.httpsPort), JSON.stringify(apimlConfig)); //installLogger.info('The http port given to the APIML is: ', webAppOptions.httpPort);
+      installLogger.debug('ZWED0033I', JSON.stringify(webAppOptions.httpPort), JSON.stringify(webAppOptions.httpsPort), JSON.stringify(apimlConfig)); //installLogger.info('The http port given to the APIML is: ', webAppOptions.httpPort);
       //installLogger.info('The https port given to the APIML is: ', webAppOptions.httpsPort);
       //installLogger.info('The zlux-apiml config are: ', apimlConfig);
       this.apiml = new ApimlConnector({

--- a/lib/plugin-loader.js
+++ b/lib/plugin-loader.js
@@ -429,7 +429,7 @@ NodeAuthenticationPlugIn.prototype = {
   
   isValid(context) {
     if (!(super.isValid(context) && this.filename 
-        && this.authenticationCategory)) {
+          && (this.authenticationCategory || this.authenticationCategories))) {
       return false;
     }
     //we should not load authentication types that are 

--- a/lib/webauth.js
+++ b/lib/webauth.js
@@ -196,7 +196,7 @@ module.exports = function(authManager, cookiePort, isSecurePort) {
       let handlerResult;
       if (handler.getCapabilities) {
         try {
-          let authPluginSession = util.getOrInit(req.session, pluginID, {});          
+          let authPluginSession = getAuthPluginSession(req, pluginID, {});
           let caps = handler.getCapabilities();
           if (caps.canLogout === true) {
             handlerResult = yield handler.logout(req, authPluginSession);
@@ -239,7 +239,7 @@ module.exports = function(authManager, cookiePort, isSecurePort) {
       if (pluginID == req.body.serviceHandler) {
         if (handler.getCapabilities) {
           try {
-            let authPluginSession = util.getOrInit(req.session, pluginID, {});
+            let authPluginSession = getAuthPluginSession(req, pluginID, {});
             let caps = handler.getCapabilities();
             if (caps.canResetPassword == true) {
               handlerResult = yield handler.passwordReset(req, authPluginSession);
@@ -392,7 +392,7 @@ module.exports = function(authManager, cookiePort, isSecurePort) {
       const result = new StatusResponse();
       for (const handler of handlers) {
         const pluginID = handler.pluginID;
-        const authPluginSession = util.getOrInit(req.session, pluginID, {});
+        const authPluginSession = getAuthPluginSession(req, pluginID, {});
         let status;
         try {
           status = handler.getStatus(authPluginSession);

--- a/lib/webauth.js
+++ b/lib/webauth.js
@@ -225,8 +225,6 @@ module.exports = function(authManager, cookiePort, isSecurePort) {
       res.clearCookie('connect.sid.'+cookiePort, { path: '/',
                                                    httpOnly: true,
                                                    secure: isSecurePort});
-    } else {
-      console.log('Not clearing? plugins=',req.session.authPlugins);
     }
 
     res.status(result.success? 200 : 500).json(result);

--- a/lib/webauth.js
+++ b/lib/webauth.js
@@ -225,6 +225,8 @@ module.exports = function(authManager, cookiePort, isSecurePort) {
       res.clearCookie('connect.sid.'+cookiePort, { path: '/',
                                                    httpOnly: true,
                                                    secure: isSecurePort});
+    } else {
+      console.log('Not clearing? plugins=',req.session.authPlugins);
     }
 
     res.status(result.success? 200 : 500).json(result);

--- a/lib/webauth.js
+++ b/lib/webauth.js
@@ -322,8 +322,9 @@ module.exports = function(authManager, cookiePort, isSecurePort) {
           authLogger.info(`ZWED0070I`, req.session.id, functionName, pluginID, JSON.stringify(resultCopy)); //authLogger.info(`${req.session.id}: Session security call ${functionName} succesful for auth ` + `handler ${pluginID}. Plugin response: ` + JSON.stringify(handlerResult));
         } else {
           //new sessions get a refresh call which always fails unless sso is involved, so don't warn for this.
-          const logFunction = type === SESSION_ACTION_TYPE_AUTHENTICATE ? authLogger.warn : authLogger.debug;
-          logFunction(`ZWED0003W`, req.session.id, functionName, pluginID, JSON.stringify(resultCopy)); //authLogger.info(`${req.session.id}: Session security call ${functionName} failed for auth ` + `handler ${pluginID}. Plugin response: ` + JSON.stringify(handlerResult));
+          authLogger[type === SESSION_ACTION_TYPE_AUTHENTICATE ? 'warn' : 'debug'](`ZWED0003W`,
+            req.session.id, functionName, pluginID, JSON.stringify(resultCopy));
+          //authLogger.info(`${req.session.id}: Session security call ${functionName} failed for auth ` + `handler ${pluginID}. Plugin response: ` + JSON.stringify(handlerResult));
         }
         //do not modify session if not authenticated or deauthenticated
         if (wasAuthenticated || handlerResult.success) {

--- a/lib/webauth.js
+++ b/lib/webauth.js
@@ -88,16 +88,26 @@ AuthResponse.prototype = {
   /**
    * Takes a report from an auth plugin and adds it to the structure 
    */
-  addHandlerResult(handlerResult, handler) {
+  addHandlerResult(handlerResult, handler, res) {
     const pluginID = handler.pluginID;
-    const authCategory = handler.pluginDef.authenticationCategory;
-    const authCategoryResult = util.getOrInit(this.categories, authCategory, {
-      [this.keyField]: false,
-      plugins: {}
-    });
-    if (handlerResult[this.keyField]) {
-      authCategoryResult[this.keyField] = true;
+    let authCategories;
+    if (handler.getCategories) {
+      authCategories = handler.getCategories();
+    } else if (handler.pluginDef.authenticationCategories) {
+      authCategories = handler.pluginDef.authenticationCategories;
+    } else {
+      authCategories = [handler.pluginDef.authenticationCategory];
     }
+    authCategories.forEach((authCategory)=> {
+      const authCategoryResult = util.getOrInit(this.categories, authCategory, {
+        [this.keyField]: false,
+        plugins: {}
+      });
+      if (handlerResult[this.keyField]) {
+        authCategoryResult[this.keyField] = true;
+      }
+      authCategoryResult.plugins[pluginID] = handlerResult;
+    });
     //alert client of when this session expires one way or another
     if (handlerResult.authenticated && !handlerResult.expms) {
       //handler may only know expiration time due to login process, as a response,
@@ -109,7 +119,18 @@ AuthResponse.prototype = {
         || (handlerResult.expms && handlerResult.expms > this.expms)) {
       this.expms = handlerResult.expms;
     }
-    authCategoryResult.plugins[pluginID] = handlerResult;
+
+    if (handlerResult.cookies) {
+      handlerResult.cookies.forEach((cookie)=> {
+        if (cookie.name && cookie.value) {
+          try {
+            res.cookie(cookie.name,cookie.value,cookie.options);
+          } catch (e) {
+            authLogger.warn(`Auth handler ${handler.pluginDef.identifier} caused exception when setting cookie`);
+          }
+        }
+      });
+    }
   },
   
   /**
@@ -188,7 +209,7 @@ module.exports = function(authManager, cookiePort, isSecurePort) {
       } else {
         handlerResult = {success: true};
       }
-      result.addHandlerResult(handlerResult, handler);
+      result.addHandlerResult(handlerResult, handler, res);
       if (req.session.authPlugins) {
         delete req.session.authPlugins[pluginID];
       }
@@ -274,14 +295,16 @@ module.exports = function(authManager, cookiePort, isSecurePort) {
 
         if(type === SESSION_ACTION_TYPE_REFRESH){
           if(authManager.sessionTimeoutMs !== TIMEOUT_VALUE_NO_EXPIRE
-              && (!timeout || timeout < Date.now())){
+              && (timeout && timeout < Date.now())){
             req.session.zlux = undefined;
             handlerResult = {success:false, reason:REASON_ZLUX_SESSION_EXPIRE};
           } else if (hasGetCapabilities && handler.getCapabilities().canRefresh){
             handlerResult = yield handler.refreshStatus(req, authPluginSession);
           } else if (hasGetCapabilities && handler.getCapabilities().canGetStatus){
             handlerResult = handler.getStatus(authPluginSession);
-            if (handlerResult.authenticated !== undefined) {
+            if (!handlerResult.authenticated) {
+              handlerResult = yield handler.authenticate(req, authPluginSession);
+            } else {
               handlerResult.success = handlerResult.authenticated;
               delete handlerResult.authenticated;
             }
@@ -291,16 +314,20 @@ module.exports = function(authManager, cookiePort, isSecurePort) {
         } else if(type == SESSION_ACTION_TYPE_AUTHENTICATE){
           handlerResult = yield handler.authenticate(req, authPluginSession);
         }
+        let resultCopy = Object.assign({},handlerResult);
+        //dont print
+        delete resultCopy.cookies;
+        delete resultCopy.password;
         if (handlerResult.success) {
-          authLogger.info(`ZWED0070I`, req.session.id, functionName, pluginID, JSON.stringify(handlerResult)); //authLogger.info(`${req.session.id}: Session security call ${functionName} succesful for auth ` + `handler ${pluginID}. Plugin response: ` + JSON.stringify(handlerResult));
+          authLogger.info(`ZWED0070I`, req.session.id, functionName, pluginID, JSON.stringify(resultCopy)); //authLogger.info(`${req.session.id}: Session security call ${functionName} succesful for auth ` + `handler ${pluginID}. Plugin response: ` + JSON.stringify(handlerResult));
         } else {
-          authLogger.warn(`ZWED0003W`, req.session.id, functionName, pluginID, JSON.stringify(handlerResult)); //authLogger.info(`${req.session.id}: Session security call ${functionName} failed for auth ` + `handler ${pluginID}. Plugin response: ` + JSON.stringify(handlerResult));
+          authLogger.warn(`ZWED0003W`, req.session.id, functionName, pluginID, JSON.stringify(resultCopy)); //authLogger.info(`${req.session.id}: Session security call ${functionName} failed for auth ` + `handler ${pluginID}. Plugin response: ` + JSON.stringify(handlerResult));
         }
         //do not modify session if not authenticated or deauthenticated
         if (wasAuthenticated || handlerResult.success) {
           setAuthPluginSession(req, pluginID, authPluginSession);
         }
-        result.addHandlerResult(handlerResult, handler);
+        result.addHandlerResult(handlerResult, handler, res);
       }
       
       result.updateStatus(authManager.sessionTimeoutMs);
@@ -371,7 +398,7 @@ module.exports = function(authManager, cookiePort, isSecurePort) {
             error
           }
         }
-        result.addHandlerResult(status, handler);
+        result.addHandlerResult(status, handler, res);
       }
       res.status(200).json(result);
     },

--- a/lib/webauth.js
+++ b/lib/webauth.js
@@ -321,7 +321,9 @@ module.exports = function(authManager, cookiePort, isSecurePort) {
         if (handlerResult.success) {
           authLogger.info(`ZWED0070I`, req.session.id, functionName, pluginID, JSON.stringify(resultCopy)); //authLogger.info(`${req.session.id}: Session security call ${functionName} succesful for auth ` + `handler ${pluginID}. Plugin response: ` + JSON.stringify(handlerResult));
         } else {
-          authLogger.warn(`ZWED0003W`, req.session.id, functionName, pluginID, JSON.stringify(resultCopy)); //authLogger.info(`${req.session.id}: Session security call ${functionName} failed for auth ` + `handler ${pluginID}. Plugin response: ` + JSON.stringify(handlerResult));
+          //new sessions get a refresh call which always fails unless sso is involved, so don't warn for this.
+          const logFunction = type === SESSION_ACTION_TYPE_AUTHENTICATE ? authLogger.warn : authLogger.debug;
+          logFunction(`ZWED0003W`, req.session.id, functionName, pluginID, JSON.stringify(resultCopy)); //authLogger.info(`${req.session.id}: Session security call ${functionName} failed for auth ` + `handler ${pluginID}. Plugin response: ` + JSON.stringify(handlerResult));
         }
         //do not modify session if not authenticated or deauthenticated
         if (wasAuthenticated || handlerResult.success) {

--- a/lib/webserver.js
+++ b/lib/webserver.js
@@ -156,6 +156,9 @@ WebServer.prototype = {
     if (this.config.https && this.config.https.port) {
       let options = this.config.https;
       this.httpsOptions = {};
+      if (typeof this.config.allowInvalidTLSProxy == 'boolean') {
+        this.httpsOptions.rejectUnauthorized = !this.config.allowInvalidTLSProxy;
+      }
       //secureOptions and secureProtocol documented here: 
       //https://nodejs.org/api/tls.html#tls_tls_createsecurecontext_options
       if (typeof options.secureOptions == 'number') {

--- a/plugins/sso-auth/lib/apimlHandler.js
+++ b/plugins/sso-auth/lib/apimlHandler.js
@@ -180,7 +180,7 @@ class ApimlHandler {
           resolve({success: true, username: sessionState.username, expms: expiration});
         }
       }).catch(e=> {
-        this.logger.warn('APIML query failed, trying login. Error=',e);
+        this.logger.warn('APIML query failed, trying login.');
         this.doLogin(request, sessionState).then(result=> resolve(result))
           .catch(e => reject(e));
       });
@@ -249,13 +249,13 @@ class ApimlHandler {
               reject(new Error('No body in response'));
             }
           } else {
-            reject(new Error('Status code='+res.statusCode));
+            reject(new Error('Status code:'+res.statusCode));
           }
         });
       });
 
       req.on('error', (error) => {
-        this.logger.warn("APIML query failed:", error);
+        this.logger.warn("APIML query error:", error.message);
         reject(error);
       });
       req.end();
@@ -306,6 +306,8 @@ class ApimlHandler {
               } else {
                 resolve({ success: false, reason: 'Unknown'});
               }
+            }).catch(e=> {
+              reject({ success: false, reason: 'Unknown', error: {message:e.message.toString()}});
             });
             return;
           } else {

--- a/plugins/sso-auth/lib/apimlHandler.js
+++ b/plugins/sso-auth/lib/apimlHandler.js
@@ -180,7 +180,7 @@ class ApimlHandler {
           resolve({success: true, username: sessionState.username, expms: expiration});
         }
       }).catch(e=> {
-        this.logger.warn('APIML query failed, trying login.');
+        this.logger.debug('APIML query failed, trying login.');
         this.doLogin(request, sessionState).then(result=> resolve(result))
           .catch(e => reject(e));
       });

--- a/plugins/sso-auth/lib/apimlHandler.js
+++ b/plugins/sso-auth/lib/apimlHandler.js
@@ -93,7 +93,11 @@ class ApimlHandler {
         res.on('end', () => {
           let apimlCookie;
           if (res.statusCode >= 200 && res.statusCode < 300) {
-            resolve({ success: true, cookies: [{name:TOKEN_NAME, value:'non-token', options: {httpOnly: true}}]});
+            resolve({ success: true, cookies: [{name:TOKEN_NAME,
+                                                value:'non-token',
+                                                options: {httpOnly: true,
+                                                          secure: true,
+                                                          expires: new Date(1)}}]});
             return;
           } else {
             let response = {

--- a/plugins/sso-auth/lib/apimlHandler.js
+++ b/plugins/sso-auth/lib/apimlHandler.js
@@ -249,7 +249,7 @@ class ApimlHandler {
               reject(new Error('No body in response'));
             }
           } else {
-            resolve({valid:false});
+            reject(new Error('Status code=',res.statusCode));
           }
         });
       });

--- a/plugins/sso-auth/lib/apimlHandler.js
+++ b/plugins/sso-auth/lib/apimlHandler.js
@@ -249,7 +249,7 @@ class ApimlHandler {
               reject(new Error('No body in response'));
             }
           } else {
-            reject(new Error('Status code=',res.statusCode));
+            reject(new Error('Status code='+res.statusCode));
           }
         });
       });

--- a/plugins/sso-auth/lib/ssoAuth.js
+++ b/plugins/sso-auth/lib/ssoAuth.js
@@ -115,14 +115,17 @@ SsoAuthenticator.prototype = {
     return new Promise((resolve, reject)=> {
       if (this.usingSso || !this.usingZss) {
         this.apimlHandler.logout(request, sessionState).then((result)=> {
+          this.apimlHandler.cleanupSession(sessionState);
           resolve(this._insertHandlerStatus(result));
         }).catch((e) => {
           resolve(this._insertHandlerStatus({success: false, reason: e.message}));
         });
       } else {
         this.zssHandler.logout(request, sessionState).then((zssResult)=> {
+          this.zssHandler.cleanupSession(sessionState);
           if (this.usingApiml) {
             this.apimlHandler.logout(request, sessionState).then((apimlResult)=> {
+              this.apimlHandler.cleanupSession(sessionState);
               resolve(this._insertHandlerStatus({success: (zssResult.success && apimlResult.success)}));
             }).catch((e) => {
               resolve(this._insertHandlerStatus({success: false, reason: e.message}));

--- a/plugins/sso-auth/lib/ssoAuth.js
+++ b/plugins/sso-auth/lib/ssoAuth.js
@@ -72,6 +72,7 @@ function SsoAuthenticator(pluginDef, pluginConf, serverConf, context) {
     "canAuthenticate": true,
     "canAuthorize": true,
     "canLogout": true,
+    "canResetPassword": this.usingZss ? true : false,
     "proxyAuthorizations": true,
     //TODO do we need to process proxy headers for both?
     "processesProxyHeaders": this.usingZss ? true: false
@@ -204,6 +205,14 @@ SsoAuthenticator.prototype = {
         username: sessionState.username,
         expms: shortestExpms
       });
+    }
+  },
+
+  passwordReset(request, sessionState) {
+    if (this.usingZss) {
+      return this.zssHandler.passwordReset(request, sessionState);
+    } else {
+      return Promise.reject(new Error('Password reset not yet supported through APIML'));
     }
   },
 

--- a/plugins/sso-auth/lib/ssoAuth.js
+++ b/plugins/sso-auth/lib/ssoAuth.js
@@ -138,6 +138,7 @@ SsoAuthenticator.prototype = {
   _insertHandlerStatus(response) {
     response.apiml = this.usingApiml;
     response.zss = this.usingZss;
+    response.canChangePassword = this.usingZss;
     response.sso = this.usingSso;
     return response;
   },

--- a/plugins/sso-auth/lib/ssoAuth.js
+++ b/plugins/sso-auth/lib/ssoAuth.js
@@ -48,7 +48,10 @@ function SsoAuthenticator(pluginDef, pluginConf, serverConf, context) {
   this.usingApiml = doesApimlExist(serverConf);
   this.usingZss = doesZssExist(serverConf);
   //TODO this seems temporary, will need to unconditionally say usingApiml=usingSso when sso support is complete
-  this.apimlSsoEnabled = process.env['APIML_ENABLE_SSO'] == 'true';
+  //this.apimlSsoEnabled = process.env['APIML_ENABLE_SSO'] == 'true';
+
+  //TODO temporary, once zss is finished we can switch over to true
+  this.apimlSsoEnabled = false;
   //Sso here meaning just authenticate to apiml, and handle jwt
   this.usingSso = this.apimlSsoEnabled && this.usingApiml;
 

--- a/plugins/sso-auth/lib/zssHandler.js
+++ b/plugins/sso-auth/lib/zssHandler.js
@@ -160,7 +160,7 @@ class ZssHandler {
           sessionState.authenticated = false;
           delete sessionState.zssUsername;
           delete sessionState.zssCookies;
-          resolve({ success: false, reason: 'Expired Password', canChangePassword: true});
+          resolve({ success: false, reason: 'Expired Password'});
         }
         let zssCookie;
         if (typeof response.headers['set-cookie'] === 'object') {
@@ -179,7 +179,7 @@ class ZssHandler {
           //intended to be known as result of network call
           sessionState.zssCookies = zssCookie;
           resolve({ success: true, username: sessionState.username,
-                    expms: DEFAULT_EXPIRATION_MS, canChangePassword: true })
+                    expms: DEFAULT_EXPIRATION_MS})
         } else {
           let res = { success: false, error: {message: `ZSS ${response.statusCode} ${response.statusMessage}`}};
           if (response.statusCode === 500) {

--- a/plugins/sso-auth/pluginDefinition.json
+++ b/plugins/sso-auth/pluginDefinition.json
@@ -3,7 +3,7 @@
   "pluginType": "nodeAuthentication",
   "authenticationCategory": "saf",
   "apiVersion": "1.0.0",
-  "pluginVersion": "1.0.0",
+  "pluginVersion": "1.1.0",
   "license": "EPL-2.0",
   "filename": "ssoAuth.js",
   "dataServices": [

--- a/plugins/sso-auth/pluginDefinition.json
+++ b/plugins/sso-auth/pluginDefinition.json
@@ -1,8 +1,8 @@
 {
   "identifier": "org.zowe.zlux.auth.safsso",
   "pluginType": "nodeAuthentication",
-  "authenticationCategory": "saf",
-  "apiVersion": "1.0.0",
+  "authenticationCategories": ["saf","zss","apiml"],
+  "apiVersion": "1.2.0",
   "pluginVersion": "1.1.0",
   "license": "EPL-2.0",
   "filename": "ssoAuth.js",


### PR DESCRIPTION
**Release notes:**
**1. API mediation layer token is now held in the browser upon login via the Desktop. This also allows for the Desktop to do single-sign-on login with the token if it is already present in the browser.**
**2. Auth plugins no longer need to be specified explicitly within the server configuration file, the capability remains for backwards compatibility. The server will now auto-detect the auth plugins that are available**
**3. Auth plugins can now be of more than one type, to satisfy environments that have plugins that need access to APIs of similar but different types**

Removed requirement for redundant specification of auth plugins. Added ability for an auth plugin to be of more than one type, and specify it dynamically. Added ability for apiml token to be held in browser and for server to detect its expiration regardless

Resolves https://github.com/zowe/zlux/issues/409