### PR TITLE
Distinguish errors and set cluster timeout to 30s for storage

### DIFF
--- a/lib/clusterManager.js
+++ b/lib/clusterManager.js
@@ -625,7 +625,7 @@ if (cluster.isMaster) {
         process.exit(constants.EXIT_GENERIC);
         return errorMsg;
       }, storageTimeout /* We need to give ample timeout time since this method is used to verify 
-      the completion of cluster storage initialization in webapp.js, Default: 5 seconds */
+      the completion of cluster storage initialization in webapp.js, Default: 30 seconds */
     )
   }
 

--- a/lib/clusterManager.js
+++ b/lib/clusterManager.js
@@ -615,15 +615,15 @@ if (cluster.isMaster) {
       function(resultHandler) {
         return resultHandler[0]; // Return the first arg (storage object) of getStorageAll
       },
-      function(e) {
-        if (e.message.startsWith('Timeout call')) {
+      function(errorMsg) {
+        if (errorMsg.startsWith('Timeout call')) {
           clusterLogger.severe("ZWED0144E - Cluster storage object timeout." +
                                "\nYou may change the value of '" + storageTimeout + "' ms by setting 'node.cluster.storageTimeout' within the config.");
         } else {
-          clusterLogger.severe("ZWED0115E - Unable to retrieve storage object from cluster.",e);
+          clusterLogger.severe("ZWED0115E - Unable to retrieve storage object from cluster.",errorMsg);
         }
         process.exit(constants.EXIT_GENERIC);
-        return e;
+        return errorMsg;
       }, storageTimeout /* We need to give ample timeout time since this method is used to verify 
       the completion of cluster storage initialization in webapp.js, Default: 5 seconds */
     )
@@ -634,15 +634,15 @@ if (cluster.isMaster) {
       function(resultHandler) {
         return resultHandler[0]; // Return the first arg (storage object) of getStorageCluster
       },
-      function(e) {
-        if (e.message.startsWith('Timeout call')) {
+      function(errorMsg) {
+        if (errorMsg.startsWith('Timeout call')) {
           clusterLogger.severe("ZWED0144E - Cluster storage object timeout." +
                                "\nYou may change the value of '" + storageTimeout + "' ms by setting 'node.cluster.storageTimeout' within the config.");
         } else {
-          clusterLogger.severe("ZWED0115E - Unable to retrieve storage object from cluster.",e);
+          clusterLogger.severe("ZWED0115E - Unable to retrieve storage object from cluster.",errorMsg);
         }
         process.exit(constants.EXIT_GENERIC);
-        return e;
+        return errorMsg;
       }, storageTimeout
     )
   }

--- a/lib/clusterManager.js
+++ b/lib/clusterManager.js
@@ -48,7 +48,7 @@ const minWorkers = !isNaN(Number(process.env.ZLUX_MIN_WORKERS))
       : 1;
 const workerChangeDecisionDelay = process.env.workerChangeDecisionDelay || 4;
 
-var storageTimeout = 5000; /* Default timeout for how long plugins wait for the cluster storage to finish creation */
+var storageTimeout = 30000; /* Default timeout for how long plugins wait for the cluster storage to finish creation */
 
 var clusterLogger = zluxUtil.loggers.clusterLogger;
 
@@ -616,8 +616,12 @@ if (cluster.isMaster) {
         return resultHandler[0]; // Return the first arg (storage object) of getStorageAll
       },
       function(e) {
-        clusterLogger.severe("ZWED0115E - Unable to retrieve storage object from cluster. This is probably due to a timeout." +
-        "\nYou may change the default of '" + storageTimeout + "' ms by setting 'node.cluster.storageTimeout' within the config.", e);
+        if (e.message.startsWith('Timeout call')) {
+          clusterLogger.severe("ZWED0144E - Cluster storage object timeout." +
+                               "\nYou may change the value of '" + storageTimeout + "' ms by setting 'node.cluster.storageTimeout' within the config.");
+        } else {
+          clusterLogger.severe("ZWED0115E - Unable to retrieve storage object from cluster.",e);
+        }
         process.exit(constants.EXIT_GENERIC);
         return e;
       }, storageTimeout /* We need to give ample timeout time since this method is used to verify 
@@ -631,8 +635,12 @@ if (cluster.isMaster) {
         return resultHandler[0]; // Return the first arg (storage object) of getStorageCluster
       },
       function(e) {
-        clusterLogger.severe("ZWED0115E - Unable to retrieve storage object from cluster. This is probably due to a timeout." +
-        "\nYou may change the default of '" + storageTimeout + "' ms by setting 'node.cluster.storageTimeout' within the config.", e);
+        if (e.message.startsWith('Timeout call')) {
+          clusterLogger.severe("ZWED0144E - Cluster storage object timeout." +
+                               "\nYou may change the value of '" + storageTimeout + "' ms by setting 'node.cluster.storageTimeout' within the config.");
+        } else {
+          clusterLogger.severe("ZWED0115E - Unable to retrieve storage object from cluster.",e);
+        }
         process.exit(constants.EXIT_GENERIC);
         return e;
       }, storageTimeout

--- a/plugins/config/lib/assets/i18n/log/messages_en.json
+++ b/plugins/config/lib/assets/i18n/log/messages_en.json
@@ -161,6 +161,7 @@
   "ZWED0108E":"RESERVED: Timestamp mismatch",
   "ZWED0109E":"RESERVED: Timestamp check failure",
   "ZWED0110E":"RESERVED: Response type not implemented.",
+  "ZWED0115E":"RESERVED: Unable to retrieve storage object from cluster.",
   "ZWED0116E":"RESERVED: Cannot reload server unless cluster mode is in use.",
   "ZWED0117E":"RESERVED: Only GET method supported",
   "ZWED0118E":"RESERVED: Only GET method supported",
@@ -189,4 +190,5 @@
   "ZWED0141E":"RESERVED: Internal Server Error",
   "ZWED0142E":"RESERVED: Invalid session action type attempted",
   "ZWED0143E":"RESERVED: Only GET method supported",
+  "ZWED0144E":"RESERVED: Cluster storage object timeout.\nYou may change the value of '%s' ms by setting 'node.cluster.storageTimeout' within the config."
 }


### PR DESCRIPTION
Release note: (probably not needed) Revise error message for cluster storage timeout, and change the default value to better accommodate resource constrained systems.

Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>