### PR TITLE
saf keyring support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Zlux Server Framework Changelog
 
 All notable changes to the Zlux Server Framework package will be documented in this file.
+This repo is part of the app-server Zowe Component, and the change logs here may appear on Zowe.org in that section.
 
 ## Recent Changes
 
-- Node server will now reattempt to connect to zss if it doesn't initially
+- Support for reading keys, certificates, and certificate authority content from SAF keyrings via safkeyring:// specification in the node.https configuration object
+- App server will now reattempt to connect to zss if it doesn't initially
 

--- a/lib/assets/i18n/log/messages_en.json
+++ b/lib/assets/i18n/log/messages_en.json
@@ -346,5 +346,11 @@
   "ZWED0112E":"The server found no plugin implementing the specified default authentication type of %s.",
   "ZWED0113E":"The server found no authentication types. Verify that the server configuration file defines server authentication.",
   "ZWED0114E":"The server found no plugin implementing the specified default authentication type of %s.",
-  "ZWED0115E":"RESERVED: Unable to retrieve storage object from cluster. This is probably due to a timeout.\nYou may change the default of '%s' ms by setting 'node.cluster.storageTimeout' within the config. %s"
+  "ZWED0115E":"RESERVED: Unable to retrieve storage object from cluster. This is probably due to a timeout.\nYou may change the default of '%s' ms by setting 'node.cluster.storageTimeout' within the config. %s",
+  "ZWED0145E":"Cannot load SAF keyring content outside of z/OS",
+  "ZWED0146E":"SAF keyring data had no attribute \"%s\". Attributes=",
+  "ZWED0147E":"SAF keyring data was not found for \"%s\"",
+  "ZWED0148E":"Exception thrown when reading SAF keyring, e=",
+  "ZWED0149E":"SAF keyring reference missing userId \"%s\", keyringName \"%s\", or label \"%s\"",
+  "ZWED0150E":"Cannot load SAF keyring due to missing keyring_js library"
 }

--- a/lib/unp-constants.js
+++ b/lib/unp-constants.js
@@ -15,7 +15,7 @@ exports.EXIT_AUTH = 3;
 exports.EXIT_PFX_READ = 4;
 exports.EXIT_HTTPS_LOAD = 5;
 exports.EXIT_NO_PLUGINS = 6;
-
+exports.EXIT_NO_SAFKEYRING = 7;
 
 
 

--- a/lib/webserver.js
+++ b/lib/webserver.js
@@ -84,7 +84,7 @@ function getAttributeNameForCryptoType(locationType, cryptoType) {
   switch (locationType) {
   case 'safkeyring':
   default:
-    if (cryptoType == CRYPTO_CONTENT_CERT) {
+    if (cryptoType == CRYPTO_CONTENT_CERT || cryptoType == CRYPTO_CONTENT_CA) {
       return 'certificate';
     } else if (cryptoType == CRYPTO_CONTENT_KEY) {
       return 'key';
@@ -119,7 +119,7 @@ function loadPem(locations, type, keyrings) {
   let content = [];
   const saf = locationsByType['safkeyring'];
   if (saf && os.platform != 'os390') {
-    bootstrapLogger.severe('Cannot load SAF keyring content outside of z/OS');
+    bootstrapLogger.severe('ZWED0145E');//Cannot load SAF keyring content outside of z/OS'
     process.exit(constants.EXIT_NO_SAFKEYRING);
   } else if (saf && keyring_js) {
     saf.forEach((safEntry)=> {
@@ -133,23 +133,31 @@ function loadPem(locations, type, keyrings) {
             bootstrapLogger.debug(`Cache not found for ${cachedKey}`);
             keyringData = keyring_js.getPemEncodedData(userId, keyringName, label);
             keyrings[cachedKey] = keyringData;
-            bootstrapLogger.debug(`SAF keyring query returned `,keyringData);
           }
-          if (keyringData && keyringData[attribute]) {
-            content.push(keyringData[attribute]);
+          if (keyringData) {
+            if (keyringData[attribute]) {
+              content.push(keyringData[attribute]);
+            } else {
+              //SAF keyring data had no attribute "%s". Attributes=',attribute,Object.keys(keyringData));
+              bootstrapLogger.warn('ZWED0146E',attribute,Object.keys(keyringData));
+            }
           } else {
-            bootstrapLogger.warn('SAF keyring could not be read or attribute "%s" not found.',attribute);
+            //SAF keyring data was not found for %s',cachedKey);
+            bootstrapLogger.warn('ZWED0147E',cachedKey);
           }
         } catch (e) {
-          bootstrapLogger.warn('Exception thrown when reading SAF keyring, e=',e);
+          //Exception thrown when reading SAF keyring, e=',e);
+          bootstrapLogger.warn('ZWED0148E',e);
         }
       } else {
-        bootstrapLogger.warn('SAF keyring reference missing userId %s, keyringName %s, or label %s',
+        //SAF keyring reference missing userId %s, keyringName %s, or label %s',
+        bootstrapLogger.warn('ZWED0149E',
                              userId, keyringName, label);
       }
     });
   } else if (!keyring_js) {
-    bootstrapLogger.warn('Cannot load SAF keyring due to missing keyring_js library');
+    //Cannot load SAF keyring due to missing keyring_js library');
+    bootstrapLogger.warn('ZWED0150E');
   }
   const files = locationsByType['file'];
   if (files) {

--- a/lib/webserver.js
+++ b/lib/webserver.js
@@ -32,7 +32,7 @@ const networkLogger = util.loggers.network;
 const os = require('os');
 let keyring_js;
 try {
-  if (os.platform == 'os390') {
+  if (os.platform() == 'os390') {
     keyring_js = require('keyring_js');
   }
 } catch (e) {
@@ -118,7 +118,7 @@ function loadPem(locations, type, keyrings) {
   const locationsByType = splitCryptoLocationsByType(locations);
   let content = [];
   const saf = locationsByType['safkeyring'];
-  if (saf && os.platform != 'os390') {
+  if (saf && os.platform() != 'os390') {
     bootstrapLogger.severe('ZWED0145E');//Cannot load SAF keyring content outside of z/OS'
     process.exit(constants.EXIT_NO_SAFKEYRING);
   } else if (saf && keyring_js) {

--- a/lib/webserver.js
+++ b/lib/webserver.js
@@ -29,6 +29,17 @@ const contentLogger = util.loggers.contentLogger;
 const childLogger = util.loggers.childLogger;
 const networkLogger = util.loggers.network;
 
+const os = require('os');
+let zcrypto;
+try {
+  if (os.platform == 'os390') {
+    const zcrypto = require('zcrypto');
+  }
+} catch (e) {
+  bootstrapLogger.warn('Could not load zcrypto library, SAF keyrings will be unavailable');
+}
+
+
 function readCiphersFromArray(stringArray) {
   if (stringArray && Array.isArray(stringArray)) {
     let uppercase = [];
@@ -45,6 +56,57 @@ function readCiphersFromArray(stringArray) {
   }
 };
 
+function splitCryptoLocationsByType(locations) {
+  const locationsByType = {};
+  locations.forEach((location)=> {
+    const index = location.indexOf('://');
+    if (index != -1 && (location.length > index+3)) {
+      const type = location.substring(0,index);
+      const typeArray = locationsByType[type] || [];
+      typeArray.push(location.substring(index+3));
+      locationsByType[type] = typeArray;
+    }
+    else {
+      const typeArray = locationsByType['file://'] || [];
+      typeArray.push(location);
+      locationsByType['file://'] = typeArray;
+    }
+  });
+  return locationsByType;
+}
+
+//  safkeyring://
+function loadKeys(locations) {
+  const locationsByType = splitCryptoLocationsByType(locations);
+  let keys = [];
+  const saf = locationsByType['safkeyring'];
+  if (saf && os.platform != 'os390') {
+    bootstrapLogger.severe('Cannot load SAF keyring content outside of z/OS');
+    process.exit(constants.EXIT_NO_SAFKEYRING);
+  } else {
+    //TODO HERE load saf keys, but how?
+    bootstrapLogger.warn('TODO: handle SAF keyrings=',saf);
+  }
+  const files = locationsByType['file'];
+  keys = util.readFilesToArray(files).concat(keys);
+  return keys;
+}
+
+function loadCerts(locations) {
+  const locationsByType = splitCryptoLocationsByType(locations);
+  let certs = [];
+  const saf = locationsByType['safkeyring'];
+  if (saf && os.platform != 'os390') {
+    bootstrapLogger.severe('Cannot load SAF keyring content outside of z/OS');
+    process.exit(constants.EXIT_NO_SAFKEYRING);
+  } else {
+    bootstrapLogger.warn('TODO: handle SAF keyrings=',saf);
+  }
+  const files = locationsByType['file'];
+  certs = util.readFilesToArray(files).concat(certs);
+  return certs;
+}
+
 
 function readTlsOptionsFromConfig(config, httpsOptions) {
   if (config.https.pfx) {
@@ -59,19 +121,18 @@ function readTlsOptionsFromConfig(config, httpsOptions) {
     }
   } else {
     if (config.https.certificates) {
-      httpsOptions.cert = util.readFilesToArray(
-          config.https.certificates);
-          bootstrapLogger.info('ZWED0072I', config.https.certificates); //bootstrapLogger.info('Using Certificate: ' + config.https.certificates);
+      httpsOptions.cert = loadCerts(config.https.certificates);
+      bootstrapLogger.info('ZWED0072I', config.https.certificates); //bootstrapLogger.info('Using Certificate: ' + config.https.certificates);
     }
     if (config.https.keys) {
-      httpsOptions.key = util.readFilesToArray(config.https.keys);
+      httpsOptions.key = loadKeys(config.https.keys);
     }
   }
   if (config.https.certificateAuthorities) {
-    httpsOptions.ca = util.readFilesToArray(config.https.certificateAuthorities);
+    httpsOptions.ca = loadCerts(config.https.certificateAuthorities);
   }
   if (config.https.certificateRevocationLists) {
-    httpsOptions.crl = util.readFilesToArray(config.https.certificateRevocationLists);
+    httpsOptions.crl = loadCerts(config.https.certificateRevocationLists);
   }
 }
   

--- a/lib/webserver.js
+++ b/lib/webserver.js
@@ -67,9 +67,9 @@ function splitCryptoLocationsByType(locations) {
       locationsByType[type] = typeArray;
     }
     else {
-      const typeArray = locationsByType['file://'] || [];
+      const typeArray = locationsByType['file'] || [];
       typeArray.push(location);
-      locationsByType['file://'] = typeArray;
+      locationsByType['file'] = typeArray;
     }
   });
   return locationsByType;

--- a/lib/webserver.js
+++ b/lib/webserver.js
@@ -83,7 +83,7 @@ function loadKeys(locations) {
   if (saf && os.platform != 'os390') {
     bootstrapLogger.severe('Cannot load SAF keyring content outside of z/OS');
     process.exit(constants.EXIT_NO_SAFKEYRING);
-  } else {
+  } else if (saf) {
     //TODO HERE load saf keys, but how?
     bootstrapLogger.warn('TODO: handle SAF keyrings=',saf);
   }
@@ -99,7 +99,7 @@ function loadCerts(locations) {
   if (saf && os.platform != 'os390') {
     bootstrapLogger.severe('Cannot load SAF keyring content outside of z/OS');
     process.exit(constants.EXIT_NO_SAFKEYRING);
-  } else {
+  } else if (saf) {
     bootstrapLogger.warn('TODO: handle SAF keyrings=',saf);
   }
   const files = locationsByType['file'];

--- a/lib/webserver.js
+++ b/lib/webserver.js
@@ -30,14 +30,19 @@ const childLogger = util.loggers.childLogger;
 const networkLogger = util.loggers.network;
 
 const os = require('os');
-let zcrypto;
+let keyring_js;
 try {
   if (os.platform == 'os390') {
-    const zcrypto = require('zcrypto');
+    keyring_js = require('keyring_js');
   }
 } catch (e) {
   bootstrapLogger.warn('Could not load zcrypto library, SAF keyrings will be unavailable');
 }
+
+const CRYPTO_CONTENT_CERT=0;
+const CRYPTO_CONTENT_KEY=1;
+const CRYPTO_CONTENT_CA=2;
+const CRYPTO_CONTENT_CRL=3;
 
 
 function readCiphersFromArray(stringArray) {
@@ -55,6 +60,39 @@ function readCiphersFromArray(stringArray) {
     return null;
   }
 };
+
+function parseSafKeyringAddress(safEntry) {
+  const endUserIndex = safEntry.indexOf('/');
+  if (endUserIndex == -1) {
+    return null;
+  } else {
+    const userId = safEntry.substring(0,endUserIndex);
+    const endNameIndex = safEntry.indexOf('/',endUserIndex+1);
+    if (endNameIndex == -1 || endNameIndex == safEntry.length-1) {
+      return null;
+    } else {
+      return {
+        userId,
+        keyringName: safEntry.substring(endUserIndex+1,endNameIndex),
+        label: safEntry.substring(endNameIndex+1)
+      };
+    }
+  }
+}
+
+function getAttributeNameForCryptoType(locationType, cryptoType) {
+  switch (locationType) {
+  case 'safkeyring':
+  default:
+    if (cryptoType == CRYPTO_CONTENT_CERT) {
+      return 'cert';
+    } else if (cryptoType == CRYPTO_CONTENT_KEY) {
+      return 'key';
+    } else {
+      return null;
+    }
+  }
+}
 
 function splitCryptoLocationsByType(locations) {
   const locationsByType = {};
@@ -76,39 +114,53 @@ function splitCryptoLocationsByType(locations) {
 }
 
 //  safkeyring://
-function loadKeys(locations) {
+function loadPem(locations, type, keyrings) {
   const locationsByType = splitCryptoLocationsByType(locations);
-  let keys = [];
+  let content = [];
   const saf = locationsByType['safkeyring'];
   if (saf && os.platform != 'os390') {
     bootstrapLogger.severe('Cannot load SAF keyring content outside of z/OS');
     process.exit(constants.EXIT_NO_SAFKEYRING);
-  } else if (saf) {
-    //TODO HERE load saf keys, but how?
-    bootstrapLogger.warn('TODO: handle SAF keyrings=',saf);
+  } else if (saf && keyring_js) {
+    saf.forEach((safEntry)=> {
+      const {userId, keyringName, label} = parseSafKeyringAddress(safEntry);
+      if (userId && keyringName && label) {
+        const cachedKey = 'safkeyring://'+safEntry;
+        let keyringData = keyrings[cachedKey];
+        const attribute = getAttributeNameForCryptoType('safkeyring', type);
+        try {
+          if (!keyringData) {
+            bootstrapLogger.debug(`Cache not found for ${cachedKey}`);
+            keyringData = keyring_js.getPemEncodedData(userId, keyringName, label);
+            keyrings[cachedKey] = keyringData;
+            bootstrapLogger.debug(`SAF keyring query returned `,keyringData);
+          }
+          if (keyringData && keyringData[attribute]) {
+            content.push(keyringData[attribute]);
+          } else {
+            bootstrapLogger.warn('SAF keyring could not be read or attribute %s not found.',attribute);
+          }
+        } catch (e) {
+          bootstrapLogger.warn('Exception thrown when reading SAF keyring, e=',e);
+        }
+      } else {
+        bootstrapLogger.warn('SAF keyring reference missing userId %s, keyringName %s, or label %s',
+                             userId, keyringName, label);
+      }
+    });
+  } else if (!keyring_js) {
+    bootstrapLogger.warn('Cannot load SAF keyring due to missing keyring_js library');
   }
   const files = locationsByType['file'];
-  keys = util.readFilesToArray(files).concat(keys);
-  return keys;
-}
-
-function loadCerts(locations) {
-  const locationsByType = splitCryptoLocationsByType(locations);
-  let certs = [];
-  const saf = locationsByType['safkeyring'];
-  if (saf && os.platform != 'os390') {
-    bootstrapLogger.severe('Cannot load SAF keyring content outside of z/OS');
-    process.exit(constants.EXIT_NO_SAFKEYRING);
-  } else if (saf) {
-    bootstrapLogger.warn('TODO: handle SAF keyrings=',saf);
+  if (files) {
+    content = util.readFilesToArray(files).concat(content);
   }
-  const files = locationsByType['file'];
-  certs = util.readFilesToArray(files).concat(certs);
-  return certs;
+  return {content, keyrings};
 }
-
 
 function readTlsOptionsFromConfig(config, httpsOptions) {
+  //in case keys and certs can be read from the same keyring, store them here for later retrieval
+  let keyrings = {};
   if (config.https.pfx) {
     try {
       httpsOptions.pfx = fs.readFileSync(config.https.pfx);
@@ -121,18 +173,18 @@ function readTlsOptionsFromConfig(config, httpsOptions) {
     }
   } else {
     if (config.https.certificates) {
-      httpsOptions.cert = loadCerts(config.https.certificates);
+      httpsOptions.cert = loadPem(config.https.certificates, CRYPTO_CONTENT_CERT, keyrings);
       bootstrapLogger.info('ZWED0072I', config.https.certificates); //bootstrapLogger.info('Using Certificate: ' + config.https.certificates);
     }
     if (config.https.keys) {
-      httpsOptions.key = loadKeys(config.https.keys);
+      httpsOptions.key = loadPem(config.https.keys, CRYPTO_CONTENT_KEY, keyrings);
     }
   }
   if (config.https.certificateAuthorities) {
-    httpsOptions.ca = loadCerts(config.https.certificateAuthorities);
+    httpsOptions.ca = loadPem(config.https.certificateAuthorities, CRYPTO_CONTENT_CA, keyrings);
   }
   if (config.https.certificateRevocationLists) {
-    httpsOptions.crl = loadCerts(config.https.certificateRevocationLists);
+    httpsOptions.crl = loadPem(config.https.certificateRevocationLists, CRYPTO_CONTENT_CRL, keyrings);
   }
 }
   

--- a/lib/webserver.js
+++ b/lib/webserver.js
@@ -173,18 +173,18 @@ function readTlsOptionsFromConfig(config, httpsOptions) {
     }
   } else {
     if (config.https.certificates) {
-      httpsOptions.cert = loadPem(config.https.certificates, CRYPTO_CONTENT_CERT, keyrings);
+      httpsOptions.cert = loadPem(config.https.certificates, CRYPTO_CONTENT_CERT, keyrings).content;
       bootstrapLogger.info('ZWED0072I', config.https.certificates); //bootstrapLogger.info('Using Certificate: ' + config.https.certificates);
     }
     if (config.https.keys) {
-      httpsOptions.key = loadPem(config.https.keys, CRYPTO_CONTENT_KEY, keyrings);
+      httpsOptions.key = loadPem(config.https.keys, CRYPTO_CONTENT_KEY, keyrings).content;
     }
   }
   if (config.https.certificateAuthorities) {
-    httpsOptions.ca = loadPem(config.https.certificateAuthorities, CRYPTO_CONTENT_CA, keyrings);
+    httpsOptions.ca = loadPem(config.https.certificateAuthorities, CRYPTO_CONTENT_CA, keyrings).content;
   }
   if (config.https.certificateRevocationLists) {
-    httpsOptions.crl = loadPem(config.https.certificateRevocationLists, CRYPTO_CONTENT_CRL, keyrings);
+    httpsOptions.crl = loadPem(config.https.certificateRevocationLists, CRYPTO_CONTENT_CRL, keyrings).content;
   }
 }
   

--- a/lib/webserver.js
+++ b/lib/webserver.js
@@ -67,7 +67,7 @@ function parseSafKeyringAddress(safEntry) {
     return null;
   } else {
     const userId = safEntry.substring(0,endUserIndex);
-    const endNameIndex = safEntry.indexOf('/',endUserIndex+1);
+    const endNameIndex = safEntry.indexOf('&',endUserIndex+1);
     if (endNameIndex == -1 || endNameIndex == safEntry.length-1) {
       return null;
     } else {
@@ -85,7 +85,7 @@ function getAttributeNameForCryptoType(locationType, cryptoType) {
   case 'safkeyring':
   default:
     if (cryptoType == CRYPTO_CONTENT_CERT) {
-      return 'cert';
+      return 'certificate';
     } else if (cryptoType == CRYPTO_CONTENT_KEY) {
       return 'key';
     } else {
@@ -138,7 +138,7 @@ function loadPem(locations, type, keyrings) {
           if (keyringData && keyringData[attribute]) {
             content.push(keyringData[attribute]);
           } else {
-            bootstrapLogger.warn('SAF keyring could not be read or attribute %s not found.',attribute);
+            bootstrapLogger.warn('SAF keyring could not be read or attribute "%s" not found.',attribute);
           }
         } catch (e) {
           bootstrapLogger.warn('Exception thrown when reading SAF keyring, e=',e);

--- a/lib/webserver.js
+++ b/lib/webserver.js
@@ -123,9 +123,15 @@ function loadPem(locations, type, keyrings) {
     process.exit(constants.EXIT_NO_SAFKEYRING);
   } else if (saf && keyring_js) {
     saf.forEach((safEntry)=> {
-      const {userId, keyringName, label} = parseSafKeyringAddress(safEntry);
+      /*
+        In the latest code it's possible the entry could start with
+        safkeyring://// instead of safkeyring://, so ignore extra slashes
+        TODO: Is this a possibility for other key types also? Keep an eye on this during future enhancements
+      */
+      const safRingAddress = safEntry.startsWith('//') ? safEntry.substr(2) : safEntry;
+      const {userId, keyringName, label} = parseSafKeyringAddress(safRingAddress);
       if (userId && keyringName && label) {
-        const cachedKey = 'safkeyring://'+safEntry;
+        const cachedKey = 'safkeyring://'+safRingAddress;
         let keyringData = keyrings[cachedKey];
         const attribute = getAttributeNameForCryptoType('safkeyring', type);
         try {

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,9 +55,9 @@
       }
     },
     "@types/express-serve-static-core": {
-      "version": "4.17.3",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.3.tgz",
-      "integrity": "sha512-sHEsvEzjqN+zLbqP+8OXTipc10yH1QLR+hnr5uw29gi9AhCAAAdri8ClNV7iMdrJrIzXIQtlkPvq8tJGhj3QJQ==",
+      "version": "4.17.5",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.5.tgz",
+      "integrity": "sha512-578YH5Lt88AKoADy0b2jQGwJtrBxezXtVe/MBqWXKZpqx91SnC0pVkVCcxcytz3lWW+cHBYDi3Ysh0WXc+rAYw==",
       "dev": true,
       "requires": {
         "@types/node": "*",
@@ -117,9 +117,9 @@
       }
     },
     "ajv": {
-      "version": "6.12.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.0.tgz",
-      "integrity": "sha512-D6gFiFA0RRLyUbvijN74DWAjXSFxWKaWP7mldxkVhyhAV3+SWA9HEJPHQ2c9soIeTFJqcSdFDGFgdqs1iUU2Hw==",
+      "version": "6.12.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.2.tgz",
+      "integrity": "sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==",
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -842,16 +842,16 @@
       "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
     },
     "mime-db": {
-      "version": "1.43.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
-      "integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ=="
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
+      "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg=="
     },
     "mime-types": {
-      "version": "2.1.26",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
-      "integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
+      "version": "2.1.27",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
+      "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
       "requires": {
-        "mime-db": "1.43.0"
+        "mime-db": "1.44.0"
       }
     },
     "minimatch": {
@@ -889,6 +889,18 @@
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
       "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
+    },
+    "node-addon-api": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.1.tgz",
+      "integrity": "sha512-2+DuKodWvwRTrCfKOeR24KIc5unKjOh8mz17NCzVnHWfjAdDqbfbjqh7gUT+BkXBRQM52+xCHciKWonJ3CbJMQ==",
+      "optional": true
+    },
+    "node-forge": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.8.5.tgz",
+      "integrity": "sha512-vFMQIWt+J/7FLNyKouZ9TazT74PRV3wgv9UT4cRjC8BffxFbKXkgIWR42URCPSnHm/QDz6BOlb2Q0U4+VQT67Q==",
+      "optional": true
     },
     "normalize-url": {
       "version": "4.3.0",
@@ -1251,6 +1263,15 @@
       "resolved": "https://registry.npmjs.org/swagger-schema-official/-/swagger-schema-official-2.0.0-bab6bed.tgz",
       "integrity": "sha1-cAcEaNbSl3ylI3suUZyn0Gouo/0="
     },
+    "tmp": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.1.0.tgz",
+      "integrity": "sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==",
+      "optional": true,
+      "requires": {
+        "rimraf": "^2.6.3"
+      }
+    },
     "tough-cookie": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
@@ -1383,6 +1404,17 @@
         "lodash.get": "^4.0.0",
         "lodash.isequal": "^4.0.0",
         "validator": "^10.0.0"
+      }
+    },
+    "zcrypto": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/zcrypto/-/zcrypto-1.0.6.tgz",
+      "integrity": "sha512-tNHJ56012Pz7HjSmLmTtk46L91Z0kWqwskrIsmcMO1InLzPCJZCegi7aPeLH+FQK9K5/wCpFjA0gVfuAyeRMHw==",
+      "optional": true,
+      "requires": {
+        "node-addon-api": "^1.6.3",
+        "node-forge": "^0.8.5",
+        "tmp": "^0.1.0"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -806,6 +806,15 @@
         "verror": "1.10.0"
       }
     },
+    "keyring_js": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/keyring_js/-/keyring_js-1.0.1.tgz",
+      "integrity": "sha512-A5vMeGoSHnFuveee7OjyNFJd9Mo+yZs4weLIhegCvBu/3OjgFUNmeWUFbM4NwX/FBz3/lGX4uB8E/jpgjd8VwA==",
+      "optional": true,
+      "requires": {
+        "node-gyp-build": "^4.2.1"
+      }
+    },
     "lodash": {
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
@@ -890,16 +899,10 @@
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
       "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
     },
-    "node-addon-api": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.1.tgz",
-      "integrity": "sha512-2+DuKodWvwRTrCfKOeR24KIc5unKjOh8mz17NCzVnHWfjAdDqbfbjqh7gUT+BkXBRQM52+xCHciKWonJ3CbJMQ==",
-      "optional": true
-    },
-    "node-forge": {
-      "version": "0.8.5",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.8.5.tgz",
-      "integrity": "sha512-vFMQIWt+J/7FLNyKouZ9TazT74PRV3wgv9UT4cRjC8BffxFbKXkgIWR42URCPSnHm/QDz6BOlb2Q0U4+VQT67Q==",
+    "node-gyp-build": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.2.tgz",
+      "integrity": "sha512-Lqh7mrByWCM8Cf9UPqpeoVBBo5Ugx+RKu885GAzmLBVYjeywScxHXPGLa4JfYNZmcNGwzR0Glu5/9GaQZMFqyA==",
       "optional": true
     },
     "normalize-url": {
@@ -1263,15 +1266,6 @@
       "resolved": "https://registry.npmjs.org/swagger-schema-official/-/swagger-schema-official-2.0.0-bab6bed.tgz",
       "integrity": "sha1-cAcEaNbSl3ylI3suUZyn0Gouo/0="
     },
-    "tmp": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.1.0.tgz",
-      "integrity": "sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==",
-      "optional": true,
-      "requires": {
-        "rimraf": "^2.6.3"
-      }
-    },
     "tough-cookie": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
@@ -1404,17 +1398,6 @@
         "lodash.get": "^4.0.0",
         "lodash.isequal": "^4.0.0",
         "validator": "^10.0.0"
-      }
-    },
-    "zcrypto": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/zcrypto/-/zcrypto-1.0.6.tgz",
-      "integrity": "sha512-tNHJ56012Pz7HjSmLmTtk46L91Z0kWqwskrIsmcMO1InLzPCJZCegi7aPeLH+FQK9K5/wCpFjA0gVfuAyeRMHw==",
-      "optional": true,
-      "requires": {
-        "node-addon-api": "^1.6.3",
-        "node-forge": "^0.8.5",
-        "tmp": "^0.1.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -63,6 +63,6 @@
     "typescript": "2.7.1"
   },
   "optionalDependencies": {
-    "zcrypto": "~1.0.0"
+    "keyring_js": "~1.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,12 @@
   "name": "zlux-server-framework",
   "version": "0.0.0-zlux.version.replacement",
   "description": "A Server for zLUX Plugins, Dataservices, and Proxying to other Servers.",
-  "license": "private",
+  "license": "EPL-2.0",
+  "homepage": "zowe.org",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/zowe/zlux-server-framework.git"
+  },
   "author": {
     "name": "Fyodor Kovin",
     "email": "fkovin@rocketsoftware.com"
@@ -56,5 +61,8 @@
     "chai": "~4.2.0",
     "chai-http": "~4.2.0",
     "typescript": "2.7.1"
+  },
+  "optionalDependencies": {
+    "zcrypto": "~1.0.0"
   }
 }


### PR DESCRIPTION
Release note: Key & certificate data for HTTPS can now be used from SAF keyrings as opposed to only unix files

How does it work?
We use the keyring_js library provided by @vit-tomica and have a special string format to tell when to use it for loading content as opposed to reading a file.
In our config JSON, we have:
```
node: {
  https: {
    keys: ['path1','path2'],
    certificates: ['path3', 'path4']
  }
}
```
The path strings used to always be unix file locations. However, now if the strings begin with "safkeyring://" and are in the format of "safkeyring://{user}/{keyringname}&{elementlabel}" then it will be interpreted as a path to find the content in a saf keyring. If the path begins with "file://" it will be treated as a file, and for backwards compatibility if there is no "://", then it will be treated as a file too.