### PR TITLE
Fix for plugin rest api request hang

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This repo is part of the app-server Zowe Component, and the change logs here may
 
 ## Recent Changes
 
+- Bugfix: When trying to dynamically load a plugin with unmet dependencies, the response from the server would hang
 - Support for reading keys, certificates, and certificate authority content from SAF keyrings via safkeyring:// specification in the node.https configuration object
 - App server will now reattempt to connect to zss if it doesn't initially
 

--- a/lib/plugin-loader.js
+++ b/lib/plugin-loader.js
@@ -688,7 +688,7 @@ PluginLoader.prototype = {
             });
           }
         } else {
-          bootstrapLogger.warn('Could not read plugins dir, e=',e);
+          bootstrapLogger.warn('Could not read plugins dir, e=',err);
         }
       });
     });
@@ -735,10 +735,12 @@ PluginLoader.prototype = {
       return !this.pluginMap[plugin.identifier];
     });
     for (const rejectedPlugin of sortedAndRejectedPlugins.rejects) {
-      bootstrapLogger.warn(`ZWED0033W`, rejectedPlugin.pluginId, zluxUtil.formatErrorStatus(rejectedPlugin.validationError, DependencyGraph.statuses)); //bootstrapLogger.warn(`Could not initialize plugin` 
+      const rejectionError = zluxUtil.formatErrorStatus(rejectedPlugin.validationError, DependencyGraph.statuses);
+      bootstrapLogger.warn(`ZWED0033W`, rejectedPlugin.pluginId, rejectionError); //bootstrapLogger.warn(`Could not initialize plugin` 
           //+ ` ${rejectedPlugin.pluginId}: `  
           //+ zluxUtil.formatErrorStatus(rejectedPlugin.validationError, 
               //DependencyGraph.statuses));
+      newPlugins.push(Object.assign(rejectedPlugin, {error: rejectionError}));
     }
 
     let isFirstRun = Object.keys(this.pluginMap).length === 0;


### PR DESCRIPTION
Plugin api would not respond in the case that a plugin could not load due to a dependency not being met, because that plugin would not get into an array used to check when the processing has finished, so a response would never be generated.

Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>