### PR TITLE
Load plugins from different relative paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This repo is part of the app-server Zowe Component, and the change logs here may
 
 ## Recent Changes
 
+- Add ability to state where a plugin path is relative to, instead of just where the server is running.
 - Bugfix: Logout now allows security plugins to clear cookies
 - Removed tokenInjector from sso-auth, since when SSO is being used token injection logic is not needed anymore.
 - Bugfix: When trying to dynamically load a plugin with unmet dependencies, the response from the server would hang

--- a/lib/assets/i18n/log/messages_en.json
+++ b/lib/assets/i18n/log/messages_en.json
@@ -352,5 +352,6 @@
   "ZWED0147E":"SAF keyring data was not found for \"%s\"",
   "ZWED0148E":"Exception thrown when reading SAF keyring, e=",
   "ZWED0149E":"SAF keyring reference missing userId \"%s\", keyringName \"%s\", or label \"%s\"",
-  "ZWED0150E":"Cannot load SAF keyring due to missing keyring_js library"
+  "ZWED0150E":"Cannot load SAF keyring due to missing keyring_js library",
+  "ZWED0151E":"RESERVED: Env var %s not found"
 }

--- a/lib/plugin-loader.js
+++ b/lib/plugin-loader.js
@@ -617,7 +617,22 @@ PluginLoader.prototype = {
         bootstrapLogger.log(bootstrapLogger.FINER, util.inspect(pluginPtrDef));
         let pluginBasePath = pluginPtrDef.pluginLocation;
         if (!path.isAbsolute(pluginBasePath)) {
-          pluginBasePath = this.options.relativePathResolver(pluginBasePath, process.cwd());
+          let relativeTo = process.cwd();
+          if (typeof pluginPtrDef.relativeTo == 'string') {
+            if (pluginPtrDef.relativeTo.startsWith('$')) {
+              const envVar = process.env[pluginPtrDef.relativeTo.substr(1)];
+              if (envVar) {
+                relativeTo = envVar;
+              } else {
+                return {location: pluginBasePath,
+                        identifier: pluginPtrDef.identifier,
+                        error: new Error(`ZWED0151E - Env var ${pluginPtrDef.relativeTo} not found`)};
+              }
+            } else {
+              relativeTo = pluginPtrDef.relativeTo;
+            }
+          }
+          pluginBasePath = this.options.relativePathResolver(pluginBasePath, relativeTo);
         }
         let pluginDefPath = path.join(pluginBasePath, 'pluginDefinition.json');
         jsonUtils.readJSONFileWithCommentsAsync(pluginDefPath).then(function(pluginDef){

--- a/lib/plugin-loader.js
+++ b/lib/plugin-loader.js
@@ -562,7 +562,22 @@ PluginLoader.prototype = {
     bootstrapLogger.debug("ZWED0121I", util.inspect(pluginPtrDef)); //bootstrapLogger.log(bootstrapLogger.FINER, util.inspect(pluginPtrDef));
     let pluginBasePath = pluginPtrDef.pluginLocation;
     if (!path.isAbsolute(pluginBasePath)) {
-      pluginBasePath = this.options.relativePathResolver(pluginBasePath, process.cwd());
+      let relativeTo = process.cwd();
+      if (typeof pluginPtrDef.relativeTo == 'string') {
+        if (pluginPtrDef.relativeTo.startsWith('$')) {
+          const envVar = process.env[pluginPtrDef.relativeTo.substr(1)];
+          if (envVar) {
+            relativeTo = envVar;
+          } else {
+            return {location: pluginBasePath,
+                    identifier: pluginPtrDef.identifier,
+                    error: new Error(`ZWED0151E - Env var ${pluginPtrDef.relativeTo} not found`)};
+          }
+        } else {
+          relativeTo = pluginPtrDef.relativeTo;
+        }
+      }
+      pluginBasePath = this.options.relativePathResolver(pluginBasePath, relativeTo);
     }
     if (!fs.existsSync(pluginBasePath)) {
       return {location: pluginBasePath,


### PR DESCRIPTION
Currently, to load a plugin you need a JSON file like this:
```
{"identifier":"org.zowe.configjs",
 "pluginLocation":"/zlux-server-framework/plugins/config"}
```

pluginLocation is either an absolute path, or one relative to where the server ran. 
But, it could be more flexible as regards to where something can be relative to.
I added a new attribute, relativeTo, which can be an environment variable if it begins with $, or otherwise a path.

Examples and how they showed up in the logs
```
{"identifier":"org.zowe.configjs",
 "pluginLocation":"zlux-server-framework/plugins/config",
 "relativeTo": "/me/zlux"}
```

```
2020-05-12 20:59:23.902 <ZWED:16425> me INFO (_zsf.utils,util.js:288) ZWED0051I - Resolved path: zlux-server-framework/plugins/config -> /me/zlux/zlux-server-framework/plugins/config
2020-05-12 20:59:23.902 <ZWED:16425> me INFO (_zsf.bootstrap,plugin-loader.js:605) ZWED0214I - Read /me/zlux/zlux-server-framework/plugins/config: found plugin id = org.zowe.configjs, type = application
```

```
{"identifier": "org.zowe.editor",
  "pluginLocation": "zlux/zlux-editor",
  "relativeTo": "$ROOT_DIR"}
```

```
2020-05-12 20:59:23.903 <ZWED:16425> me INFO (_zsf.utils,util.js:288) ZWED0051I - Resolved path: zlux/zlux-editor -> /me/zlux/zlux-editor
2020-05-12 20:59:23.903 <ZWED:16425> me INFO (_zsf.bootstrap,plugin-loader.js:605) ZWED0214I - Read /me/zlux/zlux-editor: found plugin id = org.zowe.editor, type = application
```

```
{"identifier": "org.zowe.terminal.vt",
  "pluginLocation": "vt-ng2",
  "relativeTo": "$MISSING"}
```

```
2020-05-12 20:59:23.905 <ZWED:16425> me INFO (_zsf.utils,util.js:288) ZWED0051I - Resolved path: org.zowe.terminal.vt.json -> /home/me/.zowe/workspace/app-server/plugins/org.zowe.terminal.vt.json
2020-05-12 20:59:23.906 <ZWED:16425> me INFO (_zsf.bootstrap,plugin-loader.js:557) ZWED0044I - Processing plugin reference /home/me/.zowe/workspace/app-server/plugins/org.zowe.terminal.vt.json...

2020-05-12 20:59:24.050 <ZWED:16425> me WARN (_zsf.install,index.js:241) ZWED0027W - Plugin (org.zowe.terminal.vt) loading failed. Message: "ZWED0151E - Env var $MISSING not found" Successful: 0% (0/17) Attempted: 6% (1/17)
```



Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>