### PR TITLE
Fix lease info for APIML

### DIFF
--- a/lib/apiml.js
+++ b/lib/apiml.js
@@ -38,8 +38,8 @@ const MEDIATION_LAYER_INSTANCE_DEFAULTS = {
     name: 'MyOwn'
   },
   leaseInfo: {
-    durationInSecs: 10,
-    renewalIntervalInSecs: 10
+    durationInSecs: 90, // 3 * heartbeatInterval
+    renewalIntervalInSecs: 30 // heartbeatInterval
   },
   metadata: {
     "routed-services.1.gateway-url": "/api/v1",


### PR DESCRIPTION
This is a fix for "eureka heartbeat FAILED, Re-registering app" issue. Eureka evicted zlux from the registry because `leaseInfo` was incorrect.