### PR TITLE
Resolve when apiml is not in use

### DIFF
--- a/plugins/sso-auth/lib/ssoAuth.js
+++ b/plugins/sso-auth/lib/ssoAuth.js
@@ -133,6 +133,8 @@ SsoAuthenticator.prototype = {
             }).catch((e) => {
               resolve(this._insertHandlerStatus({success: false, reason: e.message}));
             });
+          } else { //only zss?
+            resolve(this._insertHandlerStatus({success: (zssResult.success), cookies: zssResult.cookies}));
           }
         }).catch((e) => {
           resolve(this._insertHandlerStatus({success: false, reason: e.message}));


### PR DESCRIPTION
Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>
Related to https://github.com/zowe/zlux-app-server/pull/126
This is the case in which the plugin does not detect apiml, but does detect zss. The conditional never resolved, so the user was never shown the logout screen.
