### PR TITLE
Reject REST requests that have wrong referer header

### DIFF
--- a/lib/assets/i18n/log/messages_en.json
+++ b/lib/assets/i18n/log/messages_en.json
@@ -288,6 +288,8 @@
   "ZWED0168W":"RESERVED: Unable to retrieve storage value from cluster %s",
   "ZWED0169W":"RESERVED: Error deleting the storage with id: %s %s",
   "ZWED0170W":"Plugin (%s) loading failed. Message: \"%s\"",
+  "ZWED0171W":"Rejected undefined referrer for url=%s, ip=%s",
+  "ZWED0172W":"Rejected bad referrer=%s for url=%s, ip=%s",
   
   "ZWED0001E":"RESERVED: Error: %s",
   "ZWED0002E":"Could not stop language manager for types=%s",

--- a/lib/webapp.js
+++ b/lib/webapp.js
@@ -71,7 +71,7 @@ const proxyMap = new Map();
 
 
 
-const SHOULD_CHECK_REFERRER = true;
+const SHOULD_CHECK_REFERRER = process.env.ZWE_CHECK_REFERRER !== undefined ? (process.env.ZWE_CHECK_REFERRER != "false") : true;
 
 function DataserviceContext(serviceDefinition, serviceConfiguration, 
     pluginContext, webapp) {
@@ -1214,19 +1214,38 @@ WebApp.prototype = {
   authServiceHandleMaps: null,
 
   setValidReferrers(options) {
-    if (process.env.ZOWE_REFERRER_DOMAINS) {
-      this.validDomains = process.env.ZOWE_REFERRER_DOMAINS.split(',');
+    if (process.env.ZWE_REFERRER_HOSTS) {
+      this.validDomains = process.env.ZWE_REFERRER_HOSTS.split(',');
+    } else if (process.env.ZWE_REFERER_HOSTS) {
+      this.validDomains = process.env.ZWE_REFERER_HOSTS.split(',');
     } else {
-      this.validDomains = [os.hostname()];
-      if (process.env.ZOWE_EXPLORER_HOST) {
-        this.validDomains.push(process.env.ZOWE_EXPLORER_HOST);
+      let validDomains = [os.hostname()];
+      if (process.env.ZOWE_EXPLORER_HOST && (validDomains[0] != process.env.ZOWE_EXPLORER_HOST)) {
+        validDomains.push(process.env.ZOWE_EXPLORER_HOST);
+      }
+      if (process.env.ZWE_EXTERNAL_HOSTS) {
+        const externalHosts = process.env.ZWE_EXTERNAL_HOSTS.split(',');
+        externalHosts.forEach(host=> {
+          if (validDomains.indexOf(host) == -1) {
+            validDomains.push(host);
+          }
+        });
       }
       if (options.http && options.http.ipAddresses) {
-        options.http.ipAddresses.forEach(addr => this.validDomains.push(addr));
+        options.http.ipAddresses.forEach(addr => {
+          if (validDomains.indexOf(addr) == -1) {
+            validDomains.push(addr);
+          }
+        });
       }
       if (options.https && options.https.ipAddresses) {
-        options.https.ipAddresses.forEach(addr => this.validDomains.push(addr));
+        options.https.ipAddresses.forEach(addr => {
+          if (validDomains.indexOf(addr) == -1) {
+            validDomains.push(addr);
+          }
+        });
       }
+      this.validDomains = validDomains;
     }
   },
 
@@ -1237,21 +1256,21 @@ WebApp.prototype = {
       const address = ipaddr.process(req.ip)
       if (req.ip == this.loopbackConfig.host || address.range() == 'loopback'
           || req.originalUrl.endsWith('/.websocket')) { //ws internal url
-        console.log('ALLOWED INTERNAL');
+        routingLog.debug('Skip referrer on internal url');
         return next();
       }
-      
-      console.log('UNDEF FORBIDDEN: '+req.originalUrl+', ip='+req.ip);
+
+      routingLog.warn('ZWED0171W',req.originalUrl,req.ip);
       return res.status(403).send('Forbidden due to referrer');
     }
     for (let i = 0; i < this.validDomains.length; i++) {
       let url = 'https://'+this.validDomains[i];
       if (ref.startsWith(url) && (ref[url.length] == ':' || ref[url.length] == '/')) {
-        console.log('Match with URL='+url);
         return next();
       }
     }
-    console.log('REF FORBIDDEN: '+req.originalUrl);
+
+    routingLog.warn('ZWED0172W',ref,req.originalUrl,req.ip);
     return res.status(403).send('Forbidden due to referrer');
   },
 

--- a/lib/webapp.js
+++ b/lib/webapp.js
@@ -69,6 +69,10 @@ const urlencodedParser = bodyParser.urlencoded({ extended: false })
 const ZLUX_LOOPBACK_HEADER = 'X-ZLUX-Loopback';
 const proxyMap = new Map();
 
+
+
+const SHOULD_CHECK_REFERRER = true;
+
 function DataserviceContext(serviceDefinition, serviceConfiguration, 
     pluginContext, webapp) {
   this.serviceDefinition = serviceDefinition;
@@ -1176,6 +1180,8 @@ function WebApp(options){
   process.env.loopbackSecret = undefined;
 
   this.loopbackConfig = makeLoopbackConfig(options.serverConfig.node);
+  this.setValidReferrers(options.serverConfig.node);
+
   this.wsEnvironment = {
     loopbackConfig: this.loopbackConfig
   }
@@ -1206,6 +1212,48 @@ WebApp.prototype = {
   appData: null,
   //hack for pseudo-SSO
   authServiceHandleMaps: null,
+
+  setValidReferrers(options) {
+    if (process.env.ZOWE_REFERRER_DOMAINS) {
+      this.validDomains = process.env.ZOWE_REFERRER_DOMAINS.split(',');
+    } else {
+      this.validDomains = [os.hostname()];
+      if (process.env.ZOWE_EXPLORER_HOST) {
+        this.validDomains.push(process.env.ZOWE_EXPLORER_HOST);
+      }
+      if (options.http && options.http.ipAddresses) {
+        options.http.ipAddresses.forEach(addr => this.validDomains.push(addr));
+      }
+      if (options.https && options.https.ipAddresses) {
+        options.https.ipAddresses.forEach(addr => this.validDomains.push(addr));
+      }
+    }
+  },
+
+  checkReferrer(req, res, next) {
+    const ref = req.get('Referer');
+    
+    if (!ref) {
+      const address = ipaddr.process(req.ip)
+      if (req.ip == this.loopbackConfig.host || address.range() == 'loopback'
+          || req.originalUrl.endsWith('/.websocket')) { //ws internal url
+        console.log('ALLOWED INTERNAL');
+        return next();
+      }
+      
+      console.log('UNDEF FORBIDDEN: '+req.originalUrl+', ip='+req.ip);
+      return res.status(403).send('Forbidden due to referrer');
+    }
+    for (let i = 0; i < this.validDomains.length; i++) {
+      let url = 'https://'+this.validDomains[i];
+      if (ref.startsWith(url) && (ref[url.length] == ':' || ref[url.length] == '/')) {
+        console.log('Match with URL='+url);
+        return next();
+      }
+    }
+    console.log('REF FORBIDDEN: '+req.originalUrl);
+    return res.status(403).send('Forbidden due to referrer');
+  },
 
   toString() {
     return `[WebApp product: ${this.options.productCode}]`
@@ -1304,17 +1352,21 @@ WebApp.prototype = {
       installLog.info(`ZWED0055I`, proxiedRootService.url); //installLog.info(`installing root service proxy at ${proxiedRootService.url}`);
       //note that it has to be explicitly false. other falsy values like undefined
       //are treated as default, which is true
+      let middlewareArray = [commonMiddleware.logRootServiceCall(true, name)];
+      if (SHOULD_CHECK_REFERRER) {
+        middlewareArray.push((req,res,next)=> this.checkReferrer(req,res,next));
+      }
+
       if (proxiedRootService.requiresAuth === false) {
         const _router = this.makeProxy(proxiedRootService.url, true,
                                        getAgentProxyOptions(this.options, this.options.serverConfig.agent));
-        this.expressApp.use(proxiedRootService.url,
-            [commonMiddleware.logRootServiceCall(true, name), _router]);
+        middlewareArray.push(_router);
+        this.expressApp.use(proxiedRootService.url, middlewareArray);
       } else {
         const _router = this.makeProxy(proxiedRootService.url, false,
                                        getAgentProxyOptions(this.options, this.options.serverConfig.agent));
-        this.expressApp.use(proxiedRootService.url,
-            this.auth.middleware,
-            [commonMiddleware.logRootServiceCall(true, name), _router]);
+        middlewareArray.push(_router);
+        this.expressApp.use(proxiedRootService.url, this.auth.middleware, middlewareArray);
       }
       serviceHandleMap[name] = new WebServiceHandle(proxiedRootService.url, 
           this.wsEnvironment);
@@ -1588,6 +1640,7 @@ WebApp.prototype = {
         const router = yield* this._makeRouter(service, plugin, pluginContext, 
                                                pluginChain);
         installLog.info(`ZWED0062I`, plugin.identifier, subUrl); //installLog.info(`${plugin.identifier}: installing router at ${subUrl}`);
+        
         this.pluginRouter.use(subUrl, router);
         serviceRouters[version] = router;
         if (version === group.highestVersion) {
@@ -1724,8 +1777,12 @@ WebApp.prototype = {
     const urlBase = zLuxUrl.makePluginURL(this.options.productCode, 
         plugin.identifier);
     const nodeContext = pluginContext.server.config.user.node;
+
     try {
       //dataservices load first since in case of error, we want to skip the rest of the plugin load
+      if (SHOULD_CHECK_REFERRER) {
+        this.pluginRouter.use(zLuxUrl.join(urlBase, '/services/*'), (req,res,next)=> this.checkReferrer(req,res,next));
+      }
       yield *this._installDataServices(pluginContext, urlBase);
       this._installSwaggerCatalog(plugin, urlBase, nodeContext);
       this._installPluginStaticHandlers(plugin, urlBase);      

--- a/plugins/sso-auth/lib/zssHandler.js
+++ b/plugins/sso-auth/lib/zssHandler.js
@@ -144,7 +144,7 @@ class ZssHandler {
   _authenticateOrRefresh(request, sessionState, isRefresh) {
     return new Promise((resolve, reject) => {
       if (isRefresh && !sessionState.zssCookies) {
-        reject(new Error('No cookie given for refresh or check, skipping zss request'));
+        resolve({success: false, error: {message: 'No cookie given for refresh or check'}});
         return;
       }
       let options = isRefresh ? {


### PR DESCRIPTION
How it works:
By default, every request to a URL on the app server which can read or modify data as opposed to those which only send read-only content like image files, will be checked to see if the request contains an http "referer" header which matches one that is valid to the server. If the header is missing or does not match one of the acceptable values, the request is denied.

The acceptable values are controlled by environment variables.
The behavior is:

if ZWE_REFERRER_HOSTS exists, use it as a comma-separated list of values
else if ZWE_REFERER_HOSTS , use it instead
if neither exist, the set of values is a combination of:
system hostname, ZOWE_EXPLORER_HOST, and ZWE_EXTERNAL_HOSTS (ZWE, not ZOWE. another comma-separated list), and the value of all IPs the server is binding to.

In the event this does not work properly, it can be disabled if env var ZWE_CHECK_REFERER=false
However, this should not be documented to discourage its use.

Please not that Referer is a typo within the http spec, but is widely supported. So, we handle both referer and referrer.