### PR TITLE
Add tlsOptions from server to security plugin context, for reuse

### DIFF
--- a/lib/auth-manager.js
+++ b/lib/auth-manager.js
@@ -28,8 +28,9 @@ const acceptAllHandler = {
 }
 
 class AuthPluginContext {
-  constructor(plugin) {
+  constructor(plugin, tlsOptions) {
     this.logger = global.COM_RS_COMMON_LOGGER.makeComponentLogger(plugin.identifier);
+    this.tlsOptions = tlsOptions;
   }
 }
 
@@ -83,7 +84,7 @@ AuthManager.prototype = {
   },
   
   
-  loadAuthenticators: Promise.coroutine(function*(config) {
+  loadAuthenticators: Promise.coroutine(function*(config, tlsOptions) {
     let plugin;
     while ((plugin = this.pendingPlugins.pop()) !== undefined) {
       try {
@@ -91,7 +92,7 @@ AuthManager.prototype = {
                                               plugin,
                                               this.configuration,
                                               config,
-                                              new AuthPluginContext(plugin));
+                                              new AuthPluginContext(plugin, tlsOptions));
         // at this time we should have resolved plugin configuration to have a 
         // nice list of info about what we are using to authenticate against
         if ((typeof authenticationHandler.authenticate) !== 'function') {

--- a/lib/index.js
+++ b/lib/index.js
@@ -300,7 +300,7 @@ Server.prototype = {
       }
     }, installLogger));
     this.pluginLoader.loadPlugins();
-    yield this.authManager.loadAuthenticators(this.userConfig);
+    yield this.authManager.loadAuthenticators(this.userConfig, Object.assign({},this.webServer.getTlsOptions()));
     this.authManager.validateAuthPluginList();
     this.processManager.addCleanupFunction(function() {
       this.webServer.close();

--- a/plugins/sso-auth/lib/apimlHandler.js
+++ b/plugins/sso-auth/lib/apimlHandler.js
@@ -65,7 +65,7 @@ class ApimlHandler {
     } else {
       this.httpsAgent = new https.Agent({
         rejectUnauthorized: true,
-        ca: readUtf8FilesToArray(serverConf.node.https.certificateAuthorities)
+        ca: context.tlsOptions.ca
       });
     }
   }


### PR DESCRIPTION
sso-auth was re-reading CA files, and this was wrong because CA can be in a keyring instead of a file. The server loads the CA content correctly, but the plugin did not.
So, it seems best to give the server output to the security plugins so that they can re-use it. This should fix sso-auth use with keyrings.
Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>