### PR TITLE
Bugfix for plugin default config and terminal handler location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to the Zlux Server Framework package will be documented in this file.
 This repo is part of the app-server Zowe Component, and the change logs here may appear on Zowe.org in that section.
 
+## 1.14.0
+
+- Bugfix: Plugin default server config could not exist in plugins own directory, and had to exist in the instance
+- Bugfix: Terminal handlers had to exist within the root directory, rather than also being possible to exist within the instance directory
+
 ## 1.12.0
 
 - Bugfix: Server handles if implementationDefaults or mediationLayer objects are missing

--- a/plugins/config/lib/configService.js
+++ b/plugins/config/lib/configService.js
@@ -2315,13 +2315,15 @@ InternalConfiguration.prototype.getContents = function(attributeArray) {
   aggregation policy none at the moment
   relativeLocation excluses the scope path
 */
-function getJSONFromLocation(relativeLocation,directories,startScope,endScope) {
+function getJSONFromLocation(relativeLocation,directories,startScope,endScope,pluginId) {
   var scope = startScope;
   var configuration = {};
   while (scope) {
     const path = getScopeRootPath(scope,directories);
     if (path) {
-      var rootPath = pathModule.join(path,relativeLocation);
+      var rootPath = (scope == CONFIG_SCOPE_PLUGIN) && pluginId
+          ? pathModule.join(path,relativeLocation.substring(pluginId.length))
+          : pathModule.join(path,relativeLocation);
       var updatedConfiguration = addJSONFilesToJSON(rootPath,configuration);
       if (updatedConfiguration) {
         logger.debug("ZWED0256I", JSON.stringify(updatedConfiguration)); //logger.debug("Configuration is now = "+JSON.stringify(updatedConfiguration));
@@ -2343,7 +2345,7 @@ function getServiceConfiguration(pluginIdentifier, pluginLocation, serviceName,s
   var policy = AGGREGATION_POLICY_NONE;
   var directories = makeConfigurationDirectoriesStructInner(serverSettings,productCode, undefined, pluginLocation);
   var relativeLocation = pluginIdentifier+'/_internal/services/'+serviceName;
-  var configuration = getJSONFromLocation(relativeLocation,directories,CONFIG_SCOPE_PLUGIN,CONFIG_SCOPE_INSTANCE);
+  var configuration = getJSONFromLocation(relativeLocation,directories,CONFIG_SCOPE_PLUGIN,CONFIG_SCOPE_INSTANCE,pluginIdentifier);
   return new InternalConfiguration(configuration);
 }
 exports.getServiceConfiguration = getServiceConfiguration;
@@ -2354,7 +2356,7 @@ function getPluginConfiguration(identifier, pluginLocation, serverSettings,produ
   var policy = AGGREGATION_POLICY_NONE;
   var directories = makeConfigurationDirectoriesStructInner(serverSettings,productCode, undefined, pluginLocation);
   var relativeLocation = identifier+'/_internal/plugin';
-  var configuration = getJSONFromLocation(relativeLocation,directories,CONFIG_SCOPE_PLUGIN,CONFIG_SCOPE_INSTANCE);
+  var configuration = getJSONFromLocation(relativeLocation,directories,CONFIG_SCOPE_PLUGIN,CONFIG_SCOPE_INSTANCE,identifier);
   return new InternalConfiguration(configuration);
 };
 exports.getPluginConfiguration = getPluginConfiguration;

--- a/plugins/terminal-proxy/lib/assets/i18n/log/messages_en.json
+++ b/plugins/terminal-proxy/lib/assets/i18n/log/messages_en.json
@@ -9,7 +9,7 @@
   "ZWED0102I":"Total TN3270 terminals connected: %d",
   "ZWED0103I":"Total TN5250 terminals connected: %d",
   "ZWED0104I":"Total VT terminals connected: %d",
-  "ZWED0105I":"Found and loaded compatible handler file /lib/%s",
+  "ZWED0105I":"Found and loaded compatible handler file %s",
   "ZWED0106I":"Saw Websocket request, method=%s",
   "ZWED0107I":"Saw Websocket request, method=%s",
   "ZWED0108I":"Saw Websocket request, method=%s",
@@ -53,5 +53,5 @@
   "ZWED0142W":"Error: Host not found",
   "ZWED0143W":"Host communication error=%s",
   "ZWED0144W":"Error when reading file=%s. Error=%s",
-  "ZWED0145W":"Could not load a handler from file /lib/%s"
+  "ZWED0145W":"Could not load a handler from file %s"
 }


### PR DESCRIPTION
Fixes to reduce need to copy files during installation, and to bugfix an edge case where there was no instance_dir equivalent to a root_dir setting file

Previously, terminal handlers could only exist within ROOT_DIR. This was just overlooked during CUPIDS work, now it can live in the workspace dir of the plugin within the app-server.

Previously, serverside plugin config had to exist within the instance directory, meaning plugins had to perform a copy operation during installation. Now, this should be able to exist within the plugins own folder, like other configuration files.

Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>