### PR TITLE
Bugfix for zss refresh not being issued

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to the Zlux Server Framework package will be documented in this file.
 This repo is part of the app-server Zowe Component, and the change logs here may appear on Zowe.org in that section.
 
+## 1.14.0
+
+- Bugfix: Fix for regression where session would expire prematurely because app server would not request a refresh from ZSS
+
 ## 1.12.0
 
 - Bugfix: Server handles if implementationDefaults or mediationLayer objects are missing

--- a/plugins/sso-auth/lib/ssoAuth.js
+++ b/plugins/sso-auth/lib/ssoAuth.js
@@ -72,7 +72,7 @@ function SsoAuthenticator(pluginDef, pluginConf, serverConf, context) {
     "canGetStatus": true,
     "canGetCategories": true,
     //when zosmf cookie becomes invalid, we can purge zss cookie even if it is valid to be consistent
-    "canRefresh": this.usingApiml ? false : true, 
+    "canRefresh": this.usingZss ? true : false, 
     "canAuthenticate": true,
     "canAuthorize": true,
     "canLogout": true,


### PR DESCRIPTION
Fix for regression where session would expire prematurely because app server would not request a refresh from ZSS

The problem: if apiml was being used, plugin would report refresh isnt supported, even though it's partially supported. This meant that the session would expire when the shorted session timer (zss, 1 hour) expired, rather than allowing it to renew until hitting the non-expiring, longer apiml one.

This issue did not occur with sso, but did occur when using non-sso apiml+zss.