### PR TITLE
Present component and port data to web for dependency checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to the Zlux Server Framework package will be documented in this file.
 This repo is part of the app-server Zowe Component, and the change logs here may appear on Zowe.org in that section.
 
+## 1.15.0
+
+- [D] Feature: Expose GET /server/environment endpoint with minimal data when RBAC is off, to share only environment details that are required to do dependency checks and more accurate server-to-server communication (#237)
+
 ## 1.14.0
 
 - Bugfix: Plugin default server config could not exist in plugins own directory, and had to exist in the instance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,13 @@ This repo is part of the app-server Zowe Component, and the change logs here may
 
 ## 1.16.0
 
+- [D] Feature: Expose GET /server/environment endpoint with minimal data when RBAC is off, to share only environment details that are required to do dependency checks and more accurate server-to-server communication (#237)
 - Add support for PKCS#12 certificates and certificate authorities
 - Enhancement: Added JSON plugin environment checks for App server and Agent components that verify if plugin requirements, specified in
 the plugin definition, for OS, CPU, endpoints are satisfied.
 
 ## 1.15.0
 
-- [D] Feature: Expose GET /server/environment endpoint with minimal data when RBAC is off, to share only environment details that are required to do dependency checks and more accurate server-to-server communication (#237)
 - Bugfix: Fixed desktop prompting for session renewal and failure due to sso-auth plugin incorrectly stating that session refresh is possible when using Zowe SSO. In reality, the SSO tokens are non-renewable with expiration after several hours, leading to a prompt to re-authenticate to continue using the Desktop. This bugfix should now allow for that behavior.
 
 ## 1.14.0

--- a/lib/webapp.js
+++ b/lib/webapp.js
@@ -245,25 +245,52 @@ const release = os.release();
 const cpus = os.cpus();
 const hostname = os.hostname();
 
-function getUserEnv(){
+function getUserEnv(rbac){
   var date = new Date();
   return new Promise(function(resolve, reject){
-    resolve({
-      "timestamp": date.toUTCString(),
-      "args": process.argv,
-      "nodeArgs": process.execArgv,
-      "platform": process.platform,
-      "arch": arch,
-      "osRelease": release,
-      "cpus": cpus,
-      "freeMemory": os.freemem(),
-      "hostname": hostname,
-      "userEnvironment": process.env,
-      "PID": process.pid,
-      "PPID": process.ppid,
-      "nodeVersion": process.version,
-      "nodeRelease": process.release,
-    })
+    if (rbac) {
+      resolve({
+        "timestamp": date.toUTCString(),
+        "args": process.argv,
+        "nodeArgs": process.execArgv,
+        "platform": process.platform,
+        "arch": arch,
+        "osRelease": release,
+        "cpus": cpus,
+        "freeMemory": os.freemem(),
+        "hostname": hostname,
+        "userEnvironment": process.env,
+        "PID": process.pid,
+        "PPID": process.ppid,
+        "nodeVersion": process.version,
+        "nodeRelease": process.release,
+      })
+    } else { //shorter list for security. limit exposure.
+      resolve({
+        //needed for sync check
+        "timestamp": date.toUTCString(),
+        //needed to do dependency checks
+        "platform": process.platform,
+        "arch": arch,
+        //needed for any cross-server communication requirements
+        "userEnvironment": {
+          "EXTERNAL_COMPONENTS": process.env.EXTERNAL_COMPONENTS,
+          "LAUNCH_COMPONENT_GROUPS": process.env.LAUNCH_COMPONENT_GROUPS,
+          "ZWED_node_mediationLayer_enabled": process.env.ZWED_node_mediationLayer_enabled,
+
+          //expected to be identical
+          "ZOWE_EXPLORER_HOST": process.env.ZOWE_EXPLORER_HOST,
+          "ZWED_node_mediationLayer_server_hostname": process.env.ZWED_node_mediationLayer_server_hostname,
+
+          //may diverge from above
+          "ZWE_EXTERNAL_HOSTS": process.env.ZWE_EXTERNAL_HOSTS,
+          
+          //expected to be identical
+          "ZWED_node_mediationLayer_server_gatewayPort": process.env.ZWED_node_mediationLayer_server_gatewayPort,
+          "GATEWAY_PORT": process.env.GATEWAY_PORT
+        }
+      })
+    }
   });
 }
 
@@ -462,7 +489,14 @@ const staticHandlers = {
     const dataserviceAuth = options.serverConfig["dataserviceAuthentication"];
     const rbac = (dataserviceAuth == undefined) ? false : dataserviceAuth.rbac === true;
     if(!rbac){
-      router.use('/*', (req, res) => {
+      router.get('/environment', function(req, res){
+        getUserEnv(rbac).then(result => {
+          
+          res.status(200).json(result);
+        });
+      }).all('/environment', function (req, res) {
+        return res.status(405).json({error: 'ZWED0130E - Only GET method supported'});
+      }).all('/*', (req, res) => {
         return res.status(506).send("Set dataserviceAuthentication.rbac to true in server configuration");
       })
       return router;
@@ -655,7 +689,7 @@ const staticHandlers = {
         return res.status(405).json({error: 'ZWED0129E - Only POST method supported'});
       });
       router.get('/environment', function(req, res){
-        getUserEnv().then(result => {
+        getUserEnv(rbac).then(result => {
           res.status(200).json(result);
         });
       }).all('/environment', function (req, res) {

--- a/lib/webapp.js
+++ b/lib/webapp.js
@@ -490,15 +490,18 @@ const staticHandlers = {
     });
     const dataserviceAuth = options.serverConfig["dataserviceAuthentication"];
     const rbac = (dataserviceAuth == undefined) ? false : dataserviceAuth.rbac === true;
-    if(!rbac){
-      router.get('/environment', function(req, res){
-        getUserEnv(rbac).then(result => {
-          
-          res.status(200).json(result);
-        });
-      }).all('/environment', function (req, res) {
+    //endpoints that handle rbac decision-making within
+    router.get('/environment', function(req, res){
+      getUserEnv(rbac).then(result => {
+        res.status(200).json(result);
+      });
+    }).all('/environment', function (req, res) {
         return res.status(405).json({error: 'ZWED0130E - Only GET method supported'});
-      }).all('/*', (req, res) => {
+    });
+
+    //per-endpoint rbac behavior follows
+    if(!rbac){
+      router.all('/*', (req, res) => {
         return res.status(506).send("Set dataserviceAuthentication.rbac to true in server configuration");
       })
       return router;
@@ -689,13 +692,6 @@ const staticHandlers = {
         }
       }).all('/logLevels/name/:componentName/level/:level', function (req, res) {
         return res.status(405).json({error: 'ZWED0129E - Only POST method supported'});
-      });
-      router.get('/environment', function(req, res){
-        getUserEnv(rbac).then(result => {
-          res.status(200).json(result);
-        });
-      }).all('/environment', function (req, res) {
-        return res.status(405).json({error: 'ZWED0130E - Only GET method supported'});
       });
       return router;
     }


### PR DESCRIPTION
Allow a subset of env info out to the browser for dependency checks and improved server-to-server communication
To get all environment details, rbac must be on and the person must effectively be an admin, but this change is for much less info for non-admins.
Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>