### PR TITLE
Bugfix to use lower casing for all referrer use

### DIFF
--- a/lib/webapp.js
+++ b/lib/webapp.js
@@ -1215,16 +1215,16 @@ WebApp.prototype = {
 
   setValidReferrers(options) {
     if (process.env.ZWE_REFERRER_HOSTS) {
-      this.validDomains = process.env.ZWE_REFERRER_HOSTS.split(',');
+      this.validDomains = process.env.ZWE_REFERRER_HOSTS.toLowerCase().split(',');
     } else if (process.env.ZWE_REFERER_HOSTS) {
-      this.validDomains = process.env.ZWE_REFERER_HOSTS.split(',');
+      this.validDomains = process.env.ZWE_REFERER_HOSTS.toLowerCase().split(',');
     } else {
-      let validDomains = [os.hostname()];
+      let validDomains = [os.hostname().toLowerCase()];
       if (process.env.ZOWE_EXPLORER_HOST && (validDomains[0] != process.env.ZOWE_EXPLORER_HOST)) {
-        validDomains.push(process.env.ZOWE_EXPLORER_HOST);
+        validDomains.push(process.env.ZOWE_EXPLORER_HOST.toLowerCase());
       }
       if (process.env.ZWE_EXTERNAL_HOSTS) {
-        const externalHosts = process.env.ZWE_EXTERNAL_HOSTS.split(',');
+        const externalHosts = process.env.ZWE_EXTERNAL_HOSTS.toLowerCase().split(',');
         externalHosts.forEach(host=> {
           if (validDomains.indexOf(host) == -1) {
             validDomains.push(host);
@@ -1234,14 +1234,14 @@ WebApp.prototype = {
       if (options.http && options.http.ipAddresses) {
         options.http.ipAddresses.forEach(addr => {
           if (validDomains.indexOf(addr) == -1) {
-            validDomains.push(addr);
+            validDomains.push(addr.toLowerCase());
           }
         });
       }
       if (options.https && options.https.ipAddresses) {
         options.https.ipAddresses.forEach(addr => {
           if (validDomains.indexOf(addr) == -1) {
-            validDomains.push(addr);
+            validDomains.push(addr.toLowerCase());
           }
         });
       }


### PR DESCRIPTION
Browsers attempt to correct capitalization in hostnames, so making the server match this lower case should give protection against different casing in user input.
Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>