### PR TITLE
Bugfix for session renewal error when using SSO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to the Zlux Server Framework package will be documented in this file.
 This repo is part of the app-server Zowe Component, and the change logs here may appear on Zowe.org in that section.
 
+## 1.15.0
+
+- Bugfix: Fixed desktop prompting for session renewal and failure due to sso-auth plugin incorrectly stating that session refresh is possible when using Zowe SSO. In reality, the SSO tokens are non-renewable with expiration after several hours, leading to a prompt to re-authenticate to continue using the Desktop. This bugfix should now allow for that behavior.
+
 ## 1.14.0
 
 - Bugfix: Plugin default server config could not exist in plugins own directory, and had to exist in the instance

--- a/plugins/sso-auth/lib/ssoAuth.js
+++ b/plugins/sso-auth/lib/ssoAuth.js
@@ -72,7 +72,7 @@ function SsoAuthenticator(pluginDef, pluginConf, serverConf, context) {
     "canGetStatus": true,
     "canGetCategories": true,
     //when zosmf cookie becomes invalid, we can purge zss cookie even if it is valid to be consistent
-    "canRefresh": this.usingZss ? true : false, 
+    "canRefresh": (this.usingZss && !this.usingSso) ? true : false,
     "canAuthenticate": true,
     "canAuthorize": true,
     "canLogout": true,


### PR DESCRIPTION
See changelog for details.
sso-auth incorrectly identified refresh as being supported when using zss, but in reality it's only supported when using zss AND NOT sso, as the zss cookie is needed for this purpose, and not present in sso.
Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>