### PR TITLE
Inject root services into all proxied root services that require auth

### DIFF
--- a/lib/webapp.js
+++ b/lib/webapp.js
@@ -1368,6 +1368,7 @@ WebApp.prototype = {
   
   installRootServices() {
     const serviceHandleMap = {};
+    const rootServicesMiddleware = commonMiddleware.injectServiceHandles(serviceHandleMap, true);
     for (const proxiedRootService of this.options.rootServices || []) {
       const name = proxiedRootService.name || proxiedRootService.url.replace("/", "");
       installLog.info(`ZWED0055I`, proxiedRootService.url); //installLog.info(`installing root service proxy at ${proxiedRootService.url}`);
@@ -1387,13 +1388,12 @@ WebApp.prototype = {
         const _router = this.makeProxy(proxiedRootService.url, false,
                                        getAgentProxyOptions(this.options, this.options.serverConfig.agent));
         middlewareArray.push(_router);
-        this.expressApp.use(proxiedRootService.url, this.auth.middleware, middlewareArray);
+        this.expressApp.use(proxiedRootService.url, rootServicesMiddleware, this.auth.middleware, middlewareArray);
       }
       serviceHandleMap[name] = new WebServiceHandle(proxiedRootService.url, 
           this.wsEnvironment);
     }
-    this.expressApp.use(commonMiddleware.injectServiceHandles(serviceHandleMap,
-        true));
+    this.expressApp.use(rootServicesMiddleware);
     
     this._installRootService('/auth', 'post', this.auth.doLogin, 
         {needJson: true, needAuth: false, isPseudoSso: true});


### PR DESCRIPTION
When RBAC enabled there is a need to call `saf-auth` root service from auth handlers. This PR injects root services into all proxied root services that require auth just before the auth middleware. 