### PR TITLE
Fix fallback password

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -159,7 +159,7 @@ module.exports.readFilesToArray = function(fileList, type) {
         let p12Asn1 = forge.asn1.fromDer(p12Der);
         let p12;
         try {
-          p12 = forge.pkcs12.pkcs12FromAsn1(p12Asn1, process.env.KEYSTORE_PASSWORD || "");
+          p12 = forge.pkcs12.pkcs12FromAsn1(p12Asn1, process.env.KEYSTORE_PASSWORD || "password");
         } catch (e1) {
           loggers.bootstrapLogger.warn("ZWED0173W", e1.message);
           p12 = forge.pkcs12.pkcs12FromAsn1(p12Asn1, "");


### PR DESCRIPTION
This pull request fixes this following issue:
- If env var is not present, attempt to use the default zowe keystore password when decoding pkcs#12 files

Signed-off-by: Timothy Gerstel <tgerstel@rocketsoftware.com>