### PR TITLE
Support for DER (binary) encoded X.509 Certificates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to the Zlux Server Framework package will be documented in this file.
 This repo is part of the app-server Zowe Component, and the change logs here may appear on Zowe.org in that section.
 
+## 1.17.0
+
+- Add support for DER encoded X.509 certificates
+
 ## 1.16.0
 
 - [D] Feature: Expose GET /server/environment endpoint with minimal data when RBAC is off, to share only environment details that are required to do dependency checks and more accurate server-to-server communication (#237)

--- a/lib/util.js
+++ b/lib/util.js
@@ -182,7 +182,15 @@ module.exports.readFilesToArray = function(fileList, type) {
           }
         }
       } else {
-        contentArray.push(content);
+        if(!content.toString().includes('-----BEGIN')){
+          let der = forge.util.decode64(content.toString('base64'));
+          var derAsn1 = forge.asn1.fromDer(der);
+          var asn1Cert = forge.pki.certificateFromAsn1(derAsn1);
+          let pem = forge.pki.certificateToPem(asn1Cert);
+          contentArray.push(Buffer.from(pem, 'utf8'));
+        } else {
+          contentArray.push(content);
+        }
       }
     } catch (e) {
       loggers.bootstrapLogger.warn("ZWED0052W", filePath, e.message); //loggers.bootstrapLogger.warn('Error when reading file='+filePath+'. Error='+e.message);

--- a/lib/util.js
+++ b/lib/util.js
@@ -184,10 +184,16 @@ module.exports.readFilesToArray = function(fileList, type) {
       } else {
         if(!content.toString().includes('-----BEGIN')){
           let der = forge.util.decode64(content.toString('base64'));
-          var derAsn1 = forge.asn1.fromDer(der);
-          var asn1Cert = forge.pki.certificateFromAsn1(derAsn1);
-          let pem = forge.pki.certificateToPem(asn1Cert);
-          contentArray.push(Buffer.from(pem, 'utf8'));
+          let derAsn1 = forge.asn1.fromDer(der);
+          if(type == 1){
+            let privateKeyInfo = forge.pki.wrapRsaPrivateKey(derAsn1);
+            let privateKeyPem = forge.pki.privateKeyInfoToPem(privateKeyInfo);
+            contentArray.push(Buffer.from(privateKeyPem, 'utf8'));
+          } else {
+            let asn1Cert = forge.pki.certificateFromAsn1(derAsn1);
+            let pem = forge.pki.certificateToPem(asn1Cert);
+            contentArray.push(Buffer.from(pem, 'utf8'));
+          }
         } else {
           contentArray.push(content);
         }


### PR DESCRIPTION
This pull request adds the following feature:
- Add support for DER (binary) encoded X.509 certificates. This feature is based upon file content not file extension.

Signed-off-by: Timothy Gerstel <tgerstel@rocketsoftware.com>