### PR TITLE
Catch errors that occur before header is set up

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -80,54 +80,62 @@ function makeSimpleProxy(host, port, options, pluginID, serviceName) {
     } else {
       proxyLog.debug('ZWED0172I'); //proxyLog.debug('Callservice: no auth helper');
     }
-    const req2 = httpApi.request(requestOptions, (res2) => {
-      proxyLog.debug("ZWED0173I", res2.statusCode); //proxyLog.debug("status code" + res2.statusCode);
-      res1.status(res2.statusCode);
-      const headers = processProxiedHeaders ? 
-            processProxiedHeaders(req1, res2.headers) :
-            res2.headers;
-      
-      for (const header of Object.keys(headers)) {
-        if (header == 'location') {
-          const location = headers[header];
-          let pattern = /^http.+\/ZLUX\/plugins\/.+/;
-          if (!pattern.test(headers[header])) {
-            if (location.startsWith('/')) {
-	            res1.set(header, `${req1.protocol}://${req1.get('host')}/ZLUX/plugins/${pluginID}/services/${serviceName}/_current${location}`);
-            }
-            else if (location.startsWith('http')) {
-	            const locationParts = location.split(":");
-              let part;
-	            if (locationParts.length > 2) {
-	              part = locationParts[2];
-              } else {
-                part = locationParts[1]
+    try {
+      const req2 = httpApi.request(requestOptions, (res2) => {
+        proxyLog.debug("ZWED0173I", res2.statusCode); //proxyLog.debug("status code" + res2.statusCode);
+        res1.status(res2.statusCode);
+        const headers = processProxiedHeaders ? 
+              processProxiedHeaders(req1, res2.headers) :
+              res2.headers;
+        
+        for (const header of Object.keys(headers)) {
+          if (header == 'location') {
+            const location = headers[header];
+            let pattern = /^http.+\/ZLUX\/plugins\/.+/;
+            if (!pattern.test(headers[header])) {
+              if (location.startsWith('/')) {
+  	            res1.set(header, `${req1.protocol}://${req1.get('host')}/ZLUX/plugins/${pluginID}/services/${serviceName}/_current${location}`);
               }
-              const t = part.indexOf('/');
-              const newEnd = part.substring(t);
-              const newRedirect = req1.protocol + '://' + req1.get('host') + "/ZLUX/plugins/" + pluginID + "/services/_current" + serviceName + newEnd; 
-              proxyLog.debug('ZWED0174I', newRedirect); //proxyLog.debug('Redirecting to: ' + newRedirect);
-              res1.set(header, newRedirect);
-            }            
+              else if (location.startsWith('http')) {
+  	            const locationParts = location.split(":");
+                let part;
+  	            if (locationParts.length > 2) {
+  	              part = locationParts[2];
+                } else {
+                  part = locationParts[1]
+                }
+                const t = part.indexOf('/');
+                const newEnd = part.substring(t);
+                const newRedirect = req1.protocol + '://' + req1.get('host') + "/ZLUX/plugins/" + pluginID + "/services/_current" + serviceName + newEnd; 
+                proxyLog.debug('ZWED0174I', newRedirect); //proxyLog.debug('Redirecting to: ' + newRedirect);
+                res1.set(header, newRedirect);
+              }            
+            }
+          }
+          else {
+            res1.set(header, headers[header])
           }
         }
-        else {
-          res1.set(header, headers[header])
-        }
+        res2.pipe(res1);
+      });
+      req2.on('error', (e) => {
+        proxyLog.warn('ZWED0040W', e); //proxyLog.warn('Callservice: Service call failed.');
+        res1.status(500).send(`ZWED0040W - Unable to complete network request to ${host}:${port}: `
+            + e.message, null, null);
+      });
+      if ((req1.method == 'POST') || (req1.method == 'PUT')) {
+        proxyLog.debug('ZWED0175I'); //proxyLog.debug('Callservice: Forwarding request body to service');
+        req1.pipe(req2);
+      } else {
+        proxyLog.debug('ZWED0176I'); //proxyLog.debug('Callservice: Issuing request to service');
+        req2.end();
       }
-      res2.pipe(res1);
-    });
-    req2.on('error', (e) => {
+    // Node API states that errors are thrown when no error handler attached.
+    // Node has a timing issue around errors that occur before the error handler can be assigned, hence this catch
+    } catch (e) { 
       proxyLog.warn('ZWED0040W', e); //proxyLog.warn('Callservice: Service call failed.');
       res1.status(500).send(`ZWED0040W - Unable to complete network request to ${host}:${port}: `
-          + e.message, null, null);
-    });
-    if ((req1.method == 'POST') || (req1.method == 'PUT')) {
-      proxyLog.debug('ZWED0175I'); //proxyLog.debug('Callservice: Forwarding request body to service');
-      req1.pipe(req2);
-    } else {
-      proxyLog.debug('ZWED0176I'); //proxyLog.debug('Callservice: Issuing request to service');
-      req2.end();
+                            + e.message, null, null);      
     }
   }
 }


### PR DESCRIPTION
Actually a small code change, this is nearly all whitespace difference.
Simply this duplicates the catching of errors upon http client request because
Node API states that errors are thrown when no error handler attached.
Node has a timing issue around errors that occur before the error handler can be assigned, hence this catch
Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>