### PR TITLE
refactor makeRemoteUrl, add ZOWE_EXPLORER_HOST option

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -341,9 +341,22 @@ module.exports.getRemoteIframeTemplate = function(remoteUrl) {
 }
 
 module.exports.makeRemoteUrl = function(destination,req) {
+
+  let zoweExternalHost;
+  if(destination.includes('ZOWE_EXTERNAL_HOST')) {
+    let referer = req.get('Referer');
+    loggers.utilLogger.info(`referer: ${referer}`);  
+    if( referer > '') {
+      zoweExternalHost = referer.split(':')[1].substring(2); 
+    } else {
+      zoweExternalHost = process.env.ZOWE_EXPLORER_HOST;
+    }
+  }
+
   return destination
-          .replace('${ZOWE_EXTERNAL_HOST}', req.hostname)
-          .replace('${GATEWAY_PORT}', process.env.GATEWAY_PORT);
+          .replace('${ZOWE_EXTERNAL_HOST}', zoweExternalHost)
+          .replace('${GATEWAY_PORT}', process.env.GATEWAY_PORT)
+          .replace('${ZOWE_EXPLORER_HOST}', process.env.ZOWE_EXPLORER_HOST);
 }
 
 module.exports.DataserviceStorage = function(id) {


### PR DESCRIPTION
Signed-off-by: Nakul Manchanda <nakul.manchanda@ibm.com>

Added new option for using `ZOWE_EXPLORER_HOST`
and parsing `Referer` now, instead of `req.hostname`