### PR TITLE
Utilize session timeout info when zss provides it

### DIFF
--- a/plugins/sso-auth/lib/zssHandler.js
+++ b/plugins/sso-auth/lib/zssHandler.js
@@ -13,6 +13,7 @@ const ipaddr = require('ipaddr.js');
 const url = require('url');
 const makeProfileNameForRequest = require('./safprofile').makeProfileNameForRequest;
 const DEFAULT_CLASS = "ZOWE";
+const ZSS_SESSION_TIMEOUT_HEADER = "session-expires-seconds";
 const DEFAULT_EXPIRATION_MS = 3600000 //hour;
 const HTTP_STATUS_PRECONDITION_REQUIRED = 428;
 
@@ -179,8 +180,13 @@ class ZssHandler {
           }
           //intended to be known as result of network call
           sessionState.zssCookies = zssCookie;
+          let expiresSec = response.headers[ZSS_SESSION_TIMEOUT_HEADER];
+          let expiresMs = DEFAULT_EXPIRATION_MS;
+          if (expiresSec) {
+            expiresMs = expiresSec == -1 ? expiresSec : Number(expiresSec)*1000;
+          }
           resolve({ success: true, username: sessionState.username,
-                    expms: DEFAULT_EXPIRATION_MS})
+                    expms: expiresMs});
         } else {
           let res = { success: false, error: {message: `ZSS ${response.statusCode} ${response.statusMessage}`}};
           if (response.statusCode === 500) {


### PR DESCRIPTION
This PR makes use of https://github.com/zowe/zowe-common-c/pull/194 for sso-auth

since sso-auth also uses apiml, the behavior will be:

if apiml is used and zss is used but the zss expiration is shorter than apiml: zss expiration info is sent to desktop

if apiml is used and zss is used but the zss expiration is longer than apiml: apiml expiration info is sent to desktop

if apiml is used and zss is used but the zss never expires: apiml expiration info is sent to desktop

if only zss is used: zss expiration info is sent to desktop

sso-auth used to have a default value for expiration, but practically speaking it should never need to use it now that zss can send the header. but in case someone has an out of date zss, we'll still use the default for compatibility.

keep in mind both zlux-server-framework and zlux-app-manager both already had the notion that expiration time -1 means there is no expiration, so this code did not need to be changed.