### PR TITLE
Use 'spdy' library for HTTP 2

### DIFF
--- a/lib/webserver.js
+++ b/lib/webserver.js
@@ -326,14 +326,17 @@ WebServer.prototype = {
             
             /**
              * TODO:
-             * There should be more options, but some of them
-             * cause IZSME website not to load at all, 
-             * so for now using just essential ones - 'key' and 'cert'.
+             * For now 'ciphers' is excluded from options, because 
+             * it causes Zowe website to not load at all.
              */
             httpsServer = spdy.createServer(
               {
                 key: httpsOptions.key,
-                cert: httpsOptions.cert
+                cert: httpsOptions.cert,
+                ca: httpsOptions.ca,
+                rejectUnauthorized: httpsOptions.rejectUnauthorized,
+                secureOptions: httpsOptions.secureOptions,
+                //ciphers: httpsOptions.ciphers
               }, 
               webapp.expressApp
             );

--- a/lib/webserver.js
+++ b/lib/webserver.js
@@ -16,6 +16,7 @@ const Promise = require('bluebird');
 const fs = require('fs');
 const http = require('http');
 const https = require('https');
+const spdy = require('spdy');
 const url = require('url');
 const WebSocket = require('ws');
 const expressWs = require('@rocketsoftware/express-ws');
@@ -322,7 +323,20 @@ WebServer.prototype = {
         const httpsOptions = this.getTlsOptions();
         while (!listening) {
           try {
-            httpsServer = https.createServer(httpsOptions, webapp.expressApp);
+            
+            /**
+             * TODO:
+             * There should be more options, but some of them
+             * cause IZSME website not to load at all, 
+             * so for now using just essential ones - 'key' and 'cert'.
+             */
+            httpsServer = spdy.createServer(
+              {
+                key: httpsOptions.key,
+                cert: httpsOptions.cert
+              }, 
+              webapp.expressApp
+            );
             this._setErrorLogger(httpsServer, 'HTTPS', ipAddress, port);
             this.httpsServers.push(httpsServer);
             webapp.expressWs = expressWs(webapp.expressApp, httpsServer, {maxPayload: 50000});

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "require-from-string": "~2.0.2",
     "rimraf": "~2.6.3",
     "semver": "~5.5.1",
+    "spdy": "^4.0.2",
     "swagger-parser": "~6.0.5",
     "ws": "^6.0.0",
     "yauzl": "~2.10.0"


### PR DESCRIPTION
This change enables the use of HTTP 2. One problem I've noticed is that IZSME app takes a few minutes to load now, instead of a second (like it used to). That is because loginHistory takes ~4 minutes to fetch for some reason.