### PR TITLE
Add loopback ip to referrer check if it is not bound to app server

### DIFF
--- a/lib/webapp.js
+++ b/lib/webapp.js
@@ -1263,6 +1263,11 @@ WebApp.prototype = {
           }
         });
       }
+      if(process.env.BIND_TO_LOOPBACK &&
+          (process.env.BIND_TO_LOOPBACK == false || process.env.BIND_TO_LOOPBACK == "false") &&
+          process.env.ZOWE_LOOPBACK_IP){
+        validDomains.push(process.env.ZOWE_LOOPBACK_IP.toLowerCase())
+      }
       if (options.http && options.http.ipAddresses) {
         options.http.ipAddresses.forEach(addr => {
           if (validDomains.indexOf(addr) == -1) {

--- a/lib/webapp.js
+++ b/lib/webapp.js
@@ -1168,13 +1168,13 @@ function makeLoopbackConfig(nodeConfig) {
     return {
       port: nodeConfig.https.port,
       isHttps: true,
-      host: zluxUtil.getLoopbackAddress(nodeConfig.https.ipAddresses)
+      host: nodeConfig.loopbackAddress ? nodeConfig.loopbackAddress : zluxUtil.getLoopbackAddress(nodeConfig.https.ipAddresses)
     }
   } else {
     return {
       port: nodeConfig.http.port,
       isHttps: false,
-      host: zluxUtil.getLoopbackAddress(nodeConfig.http.ipAddresses)
+      host: nodeConfig.loopbackAddress ? nodeConfig.loopbackAddress : zluxUtil.getLoopbackAddress(nodeConfig.http.ipAddresses)
     }
   }
 }

--- a/lib/webapp.js
+++ b/lib/webapp.js
@@ -1263,11 +1263,6 @@ WebApp.prototype = {
           }
         });
       }
-      if(process.env.BIND_TO_LOOPBACK &&
-          (process.env.BIND_TO_LOOPBACK == false || process.env.BIND_TO_LOOPBACK == "false") &&
-          process.env.ZOWE_LOOPBACK_IP){
-        validDomains.push(process.env.ZOWE_LOOPBACK_IP.toLowerCase())
-      }
       if (options.http && options.http.ipAddresses) {
         options.http.ipAddresses.forEach(addr => {
           if (validDomains.indexOf(addr) == -1) {


### PR DESCRIPTION
This pull request implements the following feature:
- Add loopback ip to referrer check if it exists but is not set to bind to the app servers IP array

Related: https://github.com/zowe/zlux-app-server/pull/143

Signed-off-by: Timothy Gerstel <tgerstel@rocketsoftware.com>