### PR TITLE
Forward server response up to browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This repo is part of the app-server Zowe Component, and the change logs here may
 - Bugfix: Fixed issue where server could not bind to a hostname value for node.https.ipAddresses
 - Bugfix: Fixed issue where if the server started slowly, a timeout at cluster storage setup could be encountered.
 - Enhancement: Add ciphers for use with TLS 1.3
+- Enhancement: sso-auth plugin now sends error.body containing a server's error response so that it can be shown in browser if appropriate
 
 ## 1.23.0
 

--- a/plugins/sso-auth/lib/apimlHandler.js
+++ b/plugins/sso-auth/lib/apimlHandler.js
@@ -89,7 +89,8 @@ class ApimlHandler {
       }
 
       const req = https.request(options, (res) => {
-        res.on('data', (d) => {});
+        let data = [];
+        res.on('data', (d) => {data.push(d)});
         res.on('end', () => {
           let apimlCookie;
           if (res.statusCode >= 200 && res.statusCode < 300) {
@@ -104,7 +105,8 @@ class ApimlHandler {
               success: false,
               reason: 'Unknown',
               error: {
-                message: `APIML ${res.statusCode} ${res.statusMessage}`
+                message: `APIML ${res.statusCode} ${res.statusMessage}`,
+                body: Buffer.concat(data).toString()
               }
             };
             //Seems that when auth is first called, it may not be loaded yet, so you get a 405.

--- a/plugins/sso-auth/lib/zssHandler.js
+++ b/plugins/sso-auth/lib/zssHandler.js
@@ -212,7 +212,8 @@ class ZssHandler {
           resolve({ success: true, username: sessionState.username, expms: expiresMs,
                     cookies: [{name:COOKIE_NAME, value:cookieValue, options: {httpOnly: true, secure: true, sameSite: true, encode: String}}]});
         } else {
-          let res = { success: false, error: {message: `ZSS ${response.statusCode} ${response.statusMessage}`}};
+          let res = { success: false, error: {message: `ZSS ${response.statusCode} ${response.statusMessage}`,
+                                              body: response.body}};
           if (response.statusCode === 500) {
             res.reason = 'ConnectionError';
           } else {


### PR DESCRIPTION
This will allow users in the desktop to see more about why a login failed, as currently we hide the server message. With this PR, servers are responsible for how much info they disclose as it can be seen in the desktop, but this should have been their responsibility from the beginning, and I don't see any info coming out of zss or apiml that are security risks to forward.
Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>