### PR TITLE
Use fully qualified hostname for eureka if available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to the Zlux Server Framework package will be documented in this file.
 This repo is part of the app-server Zowe Component, and the change logs here may appear on Zowe.org in that section.
 
+## 1.21.0
+
+- Bugfix: Use hostname given by zowe config in order to avoid errors from the hostname certificate matching when accessing the app server through APIML
+
 ## 1.19.0
 
 - Increased default retry attempts to connect to api discovery server from 3 to 100, for a total retry duration of a little over 15 minutes.

--- a/lib/index.js
+++ b/lib/index.js
@@ -187,6 +187,7 @@ Server.prototype = {
     const httpsPort = wsConfig.https ? wsConfig.https.port : undefined;
     const cookiePort = httpsPort ? httpsPort : httpPort;
     const webAppOptions = {
+      hostname: this.userConfig.node.hostname ? this.userConfig.node.hostname : os.hostname(),
       httpPort: httpPort,
       httpsPort: httpsPort,
       productCode: this.appConfig.productCode,
@@ -322,7 +323,7 @@ Server.prototype = {
       //installLogger.info('The https port given to the APIML is: ', webAppOptions.httpsPort);
       //installLogger.info('The zlux-apiml config are: ', apimlConfig);
       this.apiml = new ApimlConnector({
-        hostName: os.hostname(),
+        hostName: webAppOptions.hostname,
         httpPort: webAppOptions.httpPort, 
         httpsPort: webAppOptions.httpsPort, 
         apimlHost: apimlConfig.server.hostname,


### PR DESCRIPTION
Resolves https://github.com/zowe/zlux/issues/566 
Depends upon https://github.com/zowe/zlux-app-server/pull/153
Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>