### PR TITLE
Adding code to conditionally contact zss thru apiml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This repo is part of the app-server Zowe Component, and the change logs here may
 
 - Bugfix: Use hostname given by zowe config in order to avoid errors from the hostname certificate matching when accessing the app server through APIML
 - Enhancement: app-server will contact zss through apiml if apiml is enabled and app-server finds that zss is accessible from apiml
+- sso-auth plugin no longer keeps zss cookie within app-server; the cookie will now be sent to and used from the browser, to facilitate high availability
 
 ## 1.19.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This repo is part of the app-server Zowe Component, and the change logs here may
 ## 1.21.0
 
 - Bugfix: Use hostname given by zowe config in order to avoid errors from the hostname certificate matching when accessing the app server through APIML
+- Enhancement: app-server will contact zss through apiml if apiml is enabled and app-server finds that zss is accessible from apiml
 
 ## 1.19.0
 

--- a/lib/apiml.js
+++ b/lib/apiml.js
@@ -11,6 +11,7 @@
 const Promise = require("bluebird");
 const eureka = require('eureka-js-client').Eureka;
 const zluxUtil = require('./util');
+const https = require('https');
 
 const log = zluxUtil.loggers.apiml;
 
@@ -100,6 +101,48 @@ ApimlConnector.prototype = {
       return this.ipAddr;
     }
   }),
+
+  checkAgent(timeout, serviceName) {
+    return new Promise((resolve, reject) => {
+      const options = Object.assign({
+        host: this.apimlHost,
+        port: this.apimlPort,
+        method: 'GET',
+        path: `/eureka/apps/${serviceName}`,
+        headers: {'accept':'application/json'}
+      }, this.tlsOptions);
+      
+      let data = [];
+      const req = https.request(options, (res) => {
+        res.on('data', (chunk) => data.push(chunk));
+        res.on('end', () => {
+          this.logger.debug(`Query rc=`,res.statusCode);
+          if (res.statusCode == 200) {
+            resolve();
+          } else {
+            let dataJson;
+            try {
+              if (data.length > 0) {
+                dataJson = JSON.parse(Buffer.concat(data).toString());
+              }
+            } catch (e) {
+              //leave undefined
+            }
+            this.logger.warn(`Could not find agent on apiml. Apiml code=${res.statusCode}. Body=${dataJson}`);
+            reject(new Error(`APIML error: code=${res.statusCode}, body=${dataJson}`));
+          }
+        });
+      });
+      req.setTimeout(timeout,()=> {
+        reject(new Error(`Call timeout when fetching agent status from APIML`));
+      });
+      req.on('error', (error) => {
+        this.logger.warn("APIML query error:", error.message);
+        reject(error);
+      });
+      req.end();
+    });
+  },
   
   _makeMainInstanceProperties(overrides) {
     const instance = Object.assign({}, MEDIATION_LAYER_INSTANCE_DEFAULTS);

--- a/lib/apiml.js
+++ b/lib/apiml.js
@@ -147,7 +147,7 @@ ApimlConnector.prototype = {
               } catch (e) {
                 //leave undefined
               }
-              log.warn(`Could not find agent on APIML. Trying again in ${AGENT_CHECK_RECONNECT_DELAY}ms. Code=${res.statusCode}. Body=${dataJson}`);
+              log.debug(`Could not find agent on APIML. Trying again in ${AGENT_CHECK_RECONNECT_DELAY}ms. Code=${res.statusCode}. Body=${dataJson}`);
               setTimeout(issueRequest, AGENT_CHECK_RECONNECT_DELAY);
             }
           });

--- a/lib/apiml.js
+++ b/lib/apiml.js
@@ -15,6 +15,10 @@ const https = require('https');
 
 const log = zluxUtil.loggers.apiml;
 
+const DEFAULT_AGENT_CHECK_TIMEOUT = 30000;
+const AGENT_CHECK_RECONNECT_DELAY = 5000;
+
+
 const MEDIATION_LAYER_EUREKA_DEFAULTS = {
   "preferSameZone": false,
   "maxRetries": 100,
@@ -102,7 +106,11 @@ ApimlConnector.prototype = {
     }
   }),
 
+  
   checkAgent(timeout, serviceName) {
+    let timer = timeout ? timeout : DEFAULT_AGENT_CHECK_TIMEOUT;
+    const end = Date.now() + timer;
+    
     return new Promise((resolve, reject) => {
       const options = Object.assign({
         host: this.apimlHost,
@@ -111,38 +119,46 @@ ApimlConnector.prototype = {
         path: `/eureka/apps/${serviceName}`,
         headers: {'accept':'application/json'}
       }, this.tlsOptions);
-      
-      let data = [];
-      const req = https.request(options, (res) => {
-        res.on('data', (chunk) => data.push(chunk));
-        res.on('end', () => {
-          log.debug(`Query rc=`,res.statusCode);
-          if (res.statusCode == 200) {
-            resolve();
-          } else {
-            let dataJson;
-            try {
-              if (data.length > 0) {
-                dataJson = JSON.parse(Buffer.concat(data).toString());
+
+      const issueRequest = () => {
+        if (Date.now() > end) {
+          log.warn(`ZWED0045`, this.apimlHost, this.apimlPort);
+          return reject(new Error(`Call timeout when fetching agent status from APIML`));
+        }
+        
+        let data = [];
+        
+        const req = https.request(options, (res) => {
+          res.on('data', (chunk) => data.push(chunk));
+          res.on('end', () => {
+            log.debug(`Query rc=`,res.statusCode);
+            if (res.statusCode == 200) {
+              resolve();
+            } else {
+              let dataJson;
+              try {
+                if (data.length > 0) {
+                  dataJson = JSON.parse(Buffer.concat(data).toString());
+                }
+              } catch (e) {
+                //leave undefined
               }
-            } catch (e) {
-              //leave undefined
+              log.warn(`Could not find agent on APIML. Trying again in ${AGENT_CHECK_RECONNECT_DELAY}ms. Code=${res.statusCode}. Body=${dataJson}`);
+              setTimeout(issueRequest, AGENT_CHECK_RECONNECT_DELAY);
             }
-            log.warn(`Could not find agent on apiml. Apiml code=${res.statusCode}. Body=${dataJson}`);
-            reject(new Error(`APIML error: code=${res.statusCode}, body=${dataJson}`));
-          }
+          });
         });
-      });
-      if (timeout) {
-        req.setTimeout(timeout,()=> {
+        req.setTimeout(timer,()=> {
           reject(new Error(`Call timeout when fetching agent status from APIML`));
         });
-      }
-      req.on('error', (error) => {
-        log.warn("APIML query error:", error.message);
-        reject(error);
-      });
-      req.end();
+        req.on('error', (error) => {
+          log.warn("APIML query error:", error.message);
+          setTimeout(issueRequest, AGENT_CHECK_RECONNECT_DELAY);
+        });
+        req.end();
+      };
+      
+      issueRequest();
     });
   },
   

--- a/lib/apiml.js
+++ b/lib/apiml.js
@@ -119,7 +119,11 @@ ApimlConnector.prototype = {
         path: `/eureka/apps/${serviceName}`,
         headers: {'accept':'application/json'}
       }, this.tlsOptions);
+      //dont need client auth, apiml will reject if these are unknown to apiml anyway.
+      delete options.cert;
+      delete options.key;
 
+      
       const issueRequest = () => {
         if (Date.now() > end) {
           log.warn(`ZWED0045`, this.apimlHost, this.apimlPort);

--- a/lib/apiml.js
+++ b/lib/apiml.js
@@ -116,7 +116,7 @@ ApimlConnector.prototype = {
       const req = https.request(options, (res) => {
         res.on('data', (chunk) => data.push(chunk));
         res.on('end', () => {
-          this.logger.debug(`Query rc=`,res.statusCode);
+          log.debug(`Query rc=`,res.statusCode);
           if (res.statusCode == 200) {
             resolve();
           } else {
@@ -128,16 +128,18 @@ ApimlConnector.prototype = {
             } catch (e) {
               //leave undefined
             }
-            this.logger.warn(`Could not find agent on apiml. Apiml code=${res.statusCode}. Body=${dataJson}`);
+            log.warn(`Could not find agent on apiml. Apiml code=${res.statusCode}. Body=${dataJson}`);
             reject(new Error(`APIML error: code=${res.statusCode}, body=${dataJson}`));
           }
         });
       });
-      req.setTimeout(timeout,()=> {
-        reject(new Error(`Call timeout when fetching agent status from APIML`));
-      });
+      if (timeout) {
+        req.setTimeout(timeout,()=> {
+          reject(new Error(`Call timeout when fetching agent status from APIML`));
+        });
+      }
       req.on('error', (error) => {
-        this.logger.warn("APIML query error:", error.message);
+        log.warn("APIML query error:", error.message);
         reject(error);
       });
       req.end();

--- a/lib/index.js
+++ b/lib/index.js
@@ -141,6 +141,12 @@ Server.prototype = {
   },
   
   start: Promise.coroutine(function*() {
+    //this parameter has been duplicated all over the code, trying to consolidate.
+    const allowInvalidTLSProxy = this.startUpConfig.allowInvalidTLSProxy || this.userConfig.node.allowInvalidTLSProxy;
+    this.userConfig.node.allowInvalidTLSProxy = allowInvalidTLSProxy;
+    
+    const firstWorker = !(process.clusterManager && process.clusterManager.getIndexInCluster() != 0);
+    
     if (this.userConfig.node.childProcesses) {
       for (const proc of this.userConfig.node.childProcesses) {
         if (!process.clusterManager || process.clusterManager.getIndexInCluster() == 0 || !proc.once) {
@@ -181,7 +187,6 @@ Server.prototype = {
           //+ ' JSON format');
       throw new Error("ZWED0028E - Config invalid")
     }
-    util.deepFreeze(this.userConfig);
     this.webServer.setConfig(wsConfig);
     const httpPort = wsConfig.http ? wsConfig.http.port : undefined;
     const httpsPort = wsConfig.https ? wsConfig.https.port : undefined;
@@ -194,7 +199,7 @@ Server.prototype = {
       productDir: this.userConfig.productDir,
       proxiedHost: this.startUpConfig.proxiedHost,
       proxiedPort: this.startUpConfig.proxiedPort,
-      allowInvalidTLSProxy: this.startUpConfig.allowInvalidTLSProxy,
+      allowInvalidTLSProxy: allowInvalidTLSProxy,
       rootRedirectURL: this.appConfig.rootRedirectURL,
       rootServices: this.appConfig.rootServices,
       serverConfig: this.userConfig,
@@ -209,16 +214,68 @@ Server.prototype = {
       langManagers: this.langManagers,
       tlsOptions: this.webServer.getTlsOptions()
     };
-    /*
-      if either proxiedHost or proxiedPort were specified, then there is intent to connect to an agent.
-      However, zlux may be run without one, so if both are undefined then don't check for connection.
-    */
-    if (process.platform !== 'os390' &&
-        ((this.startUpConfig.proxiedHost !== undefined) || (this.startUpConfig.proxiedPort !== undefined))) {
-      const host = this.startUpConfig.proxiedHost;
-      const port = this.startUpConfig.proxiedPort;
-      yield checkProxiedHost(host, port, this.userConfig.agent.handshakeTimeout);
+    if (this.userConfig.node.mediationLayer &&
+        this.userConfig.node.mediationLayer.server &&
+        !this.userConfig.node.mediationLayer.server.gatewayHostname) {
+      this.userConfig.node.mediationLayer.server.gatewayHostname = this.userConfig.node.mediationLayer.server.hostname;
+    }   
+    
+    if (this.userConfig.node.mediationLayer && this.userConfig.node.mediationLayer.enabled) {
+      const apimlConfig = this.userConfig.node.mediationLayer;
+      if (firstWorker) {
+        let apimlTlsOptions;
+        if (apimlConfig.tlsOptions != null) {
+          apimlTlsOptions = {};
+          WebServer.readTlsOptionsFromConfig(apimlConfig.tlsOptions, apimlTlsOptions); 
+        } else {
+          apimlTlsOptions = this.webServer.getTlsOptions();
+        }
+        installLogger.debug('ZWED0033I', JSON.stringify(webAppOptions.httpPort), JSON.stringify(webAppOptions.httpsPort), JSON.stringify(apimlConfig)); //installLogger.info('The http port given to the APIML is: ', webAppOptions.httpPort);
+        //installLogger.info('The https port given to the APIML is: ', webAppOptions.httpsPort);
+        //installLogger.info('The zlux-apiml config are: ', apimlConfig);
+        this.apiml = new ApimlConnector({
+          hostName: webAppOptions.hostname,
+          httpPort: webAppOptions.httpPort, 
+          httpsPort: webAppOptions.httpsPort, 
+          apimlHost: apimlConfig.server.hostname,
+          apimlPort: apimlConfig.server.port,
+          tlsOptions: apimlTlsOptions,
+          eurekaOverrides: apimlConfig.eureka
+        });
+        yield this.apiml.setBestIpFromConfig(webAppOptions.serverConfig.node);
+        yield this.apiml.registerMainServerInstance();
+      }
+      
+      if (this.userConfig.agent
+         && this.userConfig.agent.mediationLayer
+         && this.userConfig.agent.mediationLayer.enabled
+         && this.userConfig.agent.mediationLayer.serviceName
+         && this.userConfig.node.mediationLayer.gatewayPort) {
+        //at this point, we expect zss to also be attached to the mediation layer, so lets adjust.
+        webAppOptions.proxiedHost = apimlConfig.server.hostname;
+        webAppOptions.proxiedPort = this.userConfig.node.mediationLayer.gatewayPort;
+        if (firstWorker) {
+          yield this.apiml.checkAgent(this.userConfig.agent.handshakeTimeout,
+                                      this.userConfig.agent.mediationLayer.serviceName);
+        }
+      }
+    } else if (this.userConfig.agent) {
+      if (this.userConfig.agent.mediationLayer && this.userConfig.agent.mediationLayer.enabled) {
+        this.userConfig.agent.mediationLayer.enabled = false;
+      }
+      if (firstWorker &&
+          (process.platform !== 'os390') &&
+          ((this.startUpConfig.proxiedHost !== undefined) || (this.startUpConfig.proxiedPort !== undefined))){
+          /*
+            if either proxiedHost or proxiedPort were specified, then there is intent to connect to an agent.
+            However, zlux may be run without one, so if both are undefined then don't check for connection.
+          */
+          yield checkProxiedHost(webAppOptions.proxiedHost,
+                                 webAppOptions.proxiedPort,
+                                 this.userConfig.agent.handshakeTimeout);
+      }
     }
+    util.deepFreeze(this.userConfig);
     this.webApp = makeWebApp(webAppOptions);
     yield this.webServer.startListening(this.webApp);
     this.webApp.init();
@@ -310,31 +367,6 @@ Server.prototype = {
     }.bind(this));
     for (let i = 0; i < this.langManagers.length; i++) {
       yield this.langManagers[i].startAll();
-    }
-    if ((this.userConfig.node.mediationLayer && this.userConfig.node.mediationLayer.enabled)
-      && (!process.clusterManager || process.clusterManager.getIndexInCluster() == 0)) {
-      const apimlConfig = this.userConfig.node.mediationLayer;
-      let apimlTlsOptions;
-      if (apimlConfig.tlsOptions != null) {
-        apimlTlsOptions = {};
-        WebServer.readTlsOptionsFromConfig(apimlConfig.tlsOptions, apimlTlsOptions); 
-      } else {
-        apimlTlsOptions = this.webServer.getTlsOptions();
-      }
-      installLogger.debug('ZWED0033I', JSON.stringify(webAppOptions.httpPort), JSON.stringify(webAppOptions.httpsPort), JSON.stringify(apimlConfig)); //installLogger.info('The http port given to the APIML is: ', webAppOptions.httpPort);
-      //installLogger.info('The https port given to the APIML is: ', webAppOptions.httpsPort);
-      //installLogger.info('The zlux-apiml config are: ', apimlConfig);
-      this.apiml = new ApimlConnector({
-        hostName: webAppOptions.hostname,
-        httpPort: webAppOptions.httpPort, 
-        httpsPort: webAppOptions.httpsPort, 
-        apimlHost: apimlConfig.server.hostname,
-        apimlPort: apimlConfig.server.port,
-        tlsOptions: apimlTlsOptions,
-        eurekaOverrides: apimlConfig.eureka
-      });
-      yield this.apiml.setBestIpFromConfig(webAppOptions.serverConfig.node);
-      yield this.apiml.registerMainServerInstance();
     }
   }),
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -219,8 +219,8 @@ Server.prototype = {
         !this.userConfig.node.mediationLayer.server.gatewayHostname) {
       this.userConfig.node.mediationLayer.server.gatewayHostname = this.userConfig.node.mediationLayer.server.hostname;
     }   
-    
-    if (this.userConfig.node.mediationLayer && this.userConfig.node.mediationLayer.enabled) {
+    let usingApiml = this.userConfig.node.mediationLayer && this.userConfig.node.mediationLayer.enabled;
+    if (usingApiml) {
       const apimlConfig = this.userConfig.node.mediationLayer;
       if (firstWorker) {
         let apimlTlsOptions;
@@ -258,9 +258,14 @@ Server.prototype = {
           yield this.apiml.checkAgent(this.userConfig.agent.handshakeTimeout,
                                       this.userConfig.agent.mediationLayer.serviceName);
         }
+      } else if (this.userConfig.agent && this.userConfig.agent.mediationLayer) {
+        this.userConfig.agent.mediationLayer.enabled = false;        
       }
-    } else if (this.userConfig.agent) {
-      if (this.userConfig.agent.mediationLayer && this.userConfig.agent.mediationLayer.enabled) {
+    }
+    if (!usingApiml && this.userConfig.agent &&
+        (!this.userConfig.agent.mediationLayer ||
+         (this.userConfig.agent.mediationLayer && !this.userConfig.agent.mediationLayer.enabled))) {
+      if (this.userConfig.agent.mediationLayer) {
         this.userConfig.agent.mediationLayer.enabled = false;
       }
       if (firstWorker &&

--- a/lib/index.js
+++ b/lib/index.js
@@ -259,13 +259,11 @@ Server.prototype = {
                                       this.userConfig.agent.mediationLayer.serviceName);
         }
       } else if (this.userConfig.agent && this.userConfig.agent.mediationLayer) {
-        this.userConfig.agent.mediationLayer.enabled = false;        
+        this.userConfig.agent.mediationLayer.enabled = false;
       }
     }
-    if (!usingApiml && this.userConfig.agent &&
-        (!this.userConfig.agent.mediationLayer ||
-         (this.userConfig.agent.mediationLayer && !this.userConfig.agent.mediationLayer.enabled))) {
-      if (this.userConfig.agent.mediationLayer) {
+    if (this.userConfig.agent && !usingApiml) {
+      if (this.userConfig.agent.mediationLayer && this.userConfig.agent.mediationLayer.enabled) {
         this.userConfig.agent.mediationLayer.enabled = false;
       }
       if (firstWorker &&

--- a/lib/index.js
+++ b/lib/index.js
@@ -250,10 +250,10 @@ Server.prototype = {
          && this.userConfig.agent.mediationLayer
          && this.userConfig.agent.mediationLayer.enabled
          && this.userConfig.agent.mediationLayer.serviceName
-         && this.userConfig.node.mediationLayer.gatewayPort) {
+         && this.userConfig.node.mediationLayer.server.gatewayPort) {
         //at this point, we expect zss to also be attached to the mediation layer, so lets adjust.
         webAppOptions.proxiedHost = apimlConfig.server.hostname;
-        webAppOptions.proxiedPort = this.userConfig.node.mediationLayer.gatewayPort;
+        webAppOptions.proxiedPort = this.userConfig.node.mediationLayer.server.gatewayPort;
         if (firstWorker) {
           yield this.apiml.checkAgent(this.userConfig.agent.handshakeTimeout,
                                       this.userConfig.agent.mediationLayer.serviceName);

--- a/lib/plugin-loader.js
+++ b/lib/plugin-loader.js
@@ -866,35 +866,17 @@ PluginLoader.prototype = {
     return new Promise((complete, fail)=> {
       let appServerComp = {};
       let agentComp = {};
-      let host;
-      let port;
-
+      const requestOptions = zluxUtil.getAgentRequestOptions(config, this.tlsOptions);
       appServerComp.os = process.platform; // Operating system
       appServerComp.cpu = process.arch; // CPU architecture
 
-      let isHttps = false;
-      if (config && config.agent && config.agent.host) {
-        host = config.agent.host;
-        if (config.agent.https) {
-          port = config.agent.https.port;
-          isHttps = true;
-        } else if (config.agent.http) {
-          port = config.agent.http.port;
-        }
-      }
-      if (!host || !port) {
+      if (!requestOptions) {
         complete();
       } else {
-        const httpApi = isHttps ? https : http;
-        const requestOptions = {
-          hostname: host,
-          port: port,
-          path: '/server/agent/environment',
-          method: 'GET'
-        };
-        Object.assign(requestOptions, isHttps ? this.tlsOptions : {});
+        const httpApi = requestOptions.protocol == 'https:' ? https : http;
+        requestOptions.path = '/server/agent/environment';
         return new Promise((resolve, reject) => { /* Obtains and stores environment information from agent */
-          httpApi.request(requestOptions, (res) => {
+          httpApi.get(requestOptions, (res) => {
             const { statusCode } = res; // TODO: Check status code for bad status
             const contentType = res.headers['content-type'];
 
@@ -926,19 +908,12 @@ PluginLoader.prototype = {
           }).on('error', (e) => {
             bootstrapLogger.severe(e.message);
             resolve();
-          }).end();
+          });
           
         }).then(() => { /* Obtains and stores the endpoints exposed by the agent */
-
-          const requestOptions = {
-            hostname: host,
-            port: port,
-            path: '/server/agent/services',
-            method: 'GET'
-          };
-          Object.assign(requestOptions, isHttps ? this.tlsOptions : {});
+          requestOptions.path = '/server/agent/services';
           return new Promise((resolve, reject) => { 
-            httpApi.request(requestOptions, (res) => {
+            httpApi.get(requestOptions, (res) => {
               const { statusCode } = res; // TODO: Check status code for bad status
               const contentType = res.headers['content-type'];
               
@@ -965,7 +940,7 @@ PluginLoader.prototype = {
             }).on('error', (e) => {
               bootstrapLogger.severe(e.message);
               resolve(); // We don't want to reject here. Error gets caught down stream
-            }).end();
+            });
           }).then(() => {
             /* TODO: before checking if dependencies are met, we must learn about the components that exist. doing this is not formalized
                currently, so we currently have a block per component to learn about their capabilities, version, environment, etc. perhaps in the 

--- a/lib/plugin-loader.js
+++ b/lib/plugin-loader.js
@@ -866,7 +866,8 @@ PluginLoader.prototype = {
     return new Promise((complete, fail)=> {
       let appServerComp = {};
       let agentComp = {};
-      const requestOptions = zluxUtil.getAgentRequestOptions(config, this.tlsOptions);
+      const requestOptions = zluxUtil.getAgentRequestOptions(config, this.tlsOptions, false);
+
       appServerComp.os = process.platform; // Operating system
       appServerComp.cpu = process.arch; // CPU architecture
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -98,7 +98,7 @@ function getPrefixForService(serviceName, type, version) {
   return `/${typePath}/v${versionPath}/${serviceName}`;
 };
 
-module.exports.getAgentRequestOptions = function(serverConfig, tlsOptions, path) {
+module.exports.getAgentRequestOptions = function(serverConfig, tlsOptions, includeCert, path) {
   if (serverConfig && serverConfig.node && serverConfig.agent) {
     const agentConfig = serverConfig.agent;
     const useApiml = !!(agentConfig.mediationLayer &&
@@ -133,7 +133,12 @@ module.exports.getAgentRequestOptions = function(serverConfig, tlsOptions, path)
       }
     }
     if ((typeof tlsOptions == 'object') && isHttps) {
-      return Object.assign(options, tlsOptions);
+      options = Object.assign(options, tlsOptions);
+      delete options.key;
+      if (!includeCert) {
+        delete options.cert;
+      }
+      return options;
     }
     if (options.port && options.host) {
       return options;

--- a/lib/util.js
+++ b/lib/util.js
@@ -91,6 +91,57 @@ module.exports.initLoggerMessages = function initLoggerMessages(logLanguage) {
   }
 };
 
+//maybe better in apiml.js but there would be a circular dependency around the logger init.
+function getPrefixForService(serviceName, type, version) {
+  let typePath = type || 'api';
+  let versionPath = version || '1';
+  return `/${typePath}/v${versionPath}/${serviceName}`;
+};
+
+module.exports.getAgentRequestOptions = function(serverConfig, tlsOptions, path) {
+  if (serverConfig && serverConfig.node && serverConfig.agent) {
+    const agentConfig = serverConfig.agent;
+    const useApiml = !!(agentConfig.mediationLayer &&
+                        agentConfig.mediationLayer.enabled &&
+                        serverConfig.node.mediationLayer &&
+                        serverConfig.node.mediationLayer.server);
+    
+    const isHttps = useApiml ||
+          (agentConfig.https && agentConfig.https.port) ||
+          (agentConfig.http && agentConfig.http.port && agentConfig.http.attls);
+    if (isHttps && !tlsOptions) {
+      return undefined;
+    }
+    let options;
+    if (useApiml) {
+      const apimlPrefix = getPrefixForService(agentConfig.mediationLayer.serviceName)
+      options = {
+        host: serverConfig.node.mediationLayer.server.gatewayHostname,
+        port: serverConfig.node.mediationLayer.server.gatewayPort,
+        protocol: isHttps ? 'https:' : 'http:',
+        rejectUnauthorized: !serverConfig.node.allowInvalidTLSProxy,
+        apimlPrefix: apimlPrefix,
+        path: path ? apimlPrefix + path : undefined
+      }
+    } else {
+      options = {
+        host: agentConfig.host,
+        port: agentConfig.https && agentConfig.https.port ? agentConfig.https.port : agentConfig.http.port,
+        protocol: isHttps ? 'https:' : 'http:',
+        rejectUnauthorized: !serverConfig.node.allowInvalidTLSProxy,
+        path: path
+      }
+    }
+    if ((typeof tlsOptions == 'object') && isHttps) {
+      return Object.assign(options, tlsOptions);
+    }
+    if (options.port && options.host) {
+      return options;
+    }
+  }
+  return undefined;
+}
+
 module.exports.resolveRelativePaths = function resolveRelativePaths(root, resolver, relativeTo) {
   for (const key of Object.keys(root)) {
     const value = root[key];

--- a/lib/webapp.js
+++ b/lib/webapp.js
@@ -33,6 +33,7 @@ const constants = require('./unp-constants');
 const installApp = require('../utils/install-app');
 const translationUtils = require('./translation-utils');
 const expressStaticGzip = require("express-static-gzip");
+const apiml = require('./apiml');
 const os = require('os');
 const semver = require('semver');
 const ipaddr = require('ipaddr.js');
@@ -545,7 +546,7 @@ const staticHandlers = {
         addProxyAuthorizations: options.auth.addProxyAuthorizations,
         allowInvalidTLSProxy: options.allowInvalidTLSProxy
       };
-      proxyOptions = Object.assign(proxyOptions, getAgentProxyOptions(options, options.serverConfig.agent, options.tlsOptions));
+      proxyOptions = Object.assign(proxyOptions, getAgentProxyOptions(options.serverConfig, options.tlsOptions));
       router.get('/agent*', proxy.makeSimpleProxy(options.proxiedHost, options.proxiedPort,
         proxyOptions));
       router.get('/reload', function(req, res){
@@ -1188,18 +1189,17 @@ function makeLoopbackConfig(nodeConfig) {
   }
 }
 
-function getAgentProxyOptions(serverConfig, agentConfig, tlsOptions) {
-  if (!agentConfig) return null;
-  let options = {};
-  if ((agentConfig.https && typeof agentConfig.https.port === 'number') || (agentConfig.http && agentConfig.http.attls === true)) {
-    options.isHttps = true;
-    if (serverConfig.allowInvalidTLSProxy) {
-      options.allowInvalidTLSProxy = serverConfig.allowInvalidTLSProxy
-    } else {
-      options.tlsOptions = tlsOptions;
-    }
+function getAgentProxyOptions(serverConfig, tlsOptions) {
+  const requestOptions = zluxUtil.getAgentRequestOptions(serverConfig, tlsOptions);
+  if (!requestOptions) return null;
+
+  let options = {
+    isHttps: requestOptions.protocol == 'https:' ? true : false,
+    allowInvalidTLSProxy: !requestOptions.rejectUnauthorized
   }
-  return options;
+  if (options.isHttps && !serverConfig.allowInvalidTLSProxy) {
+    options.tlsOptions = tlsOptions;
+  }
 }
 
 function WebApp(options){
@@ -1325,28 +1325,28 @@ WebApp.prototype = {
   
   makeProxy(urlPrefix, noAuth, overrideOptions, host, port) {
     const r = express.Router();
-    let proxiedHost;
-    let proxiedPort;
-    if (host && port) {
-      proxiedHost = host;
-      proxiedPort = port;
-    } else {
-      proxiedHost = this.options.proxiedHost;
-      proxiedPort = this.options.proxiedPort;
-    }
     let options = {
-      urlPrefix, 
+      urlPrefix,
       isHttps: false, 
       addProxyAuthorizations: (noAuth? null : this.auth.addProxyAuthorizations),
       processProxiedHeaders: (noAuth? null: this.auth.processProxiedHeaders),
       allowInvalidTLSProxy: this.options.allowInvalidTLSProxy
     };
+    if (!(host && port)) {
+      //destined for agent rather than 3rd party server
+      const requestOptions = zluxUtil.getAgentRequestOptions(this.options.serverConfig, this.options.tlsOptions, urlPrefix);
+      host = requestOptions.host;
+      port = requestOptions.port;
+      options.urlPrefix = requestOptions.path;
+      options.isHttps = requestOptions.protocol == 'https:';
+    }
+    
     if (overrideOptions) {
       options = Object.assign(options, overrideOptions);
     }
-    r.use(proxy.makeSimpleProxy(proxiedHost, proxiedPort,
+    r.use(proxy.makeSimpleProxy(host, port,
                                 options));
-    r.ws('/', proxy.makeWsProxy(proxiedHost, proxiedPort, 
+    r.ws('/', proxy.makeWsProxy(host, port,
                                 urlPrefix, options));
     return r;
   },
@@ -1423,12 +1423,12 @@ WebApp.prototype = {
       }
       if (proxiedRootService.requiresAuth === false) {
         const _router = this.makeProxy(proxiedRootService.url, true,
-                                       getAgentProxyOptions(this.options, this.options.serverConfig.agent, this.options.tlsOptions));
+                                       getAgentProxyOptions(this.options.serverConfig, this.options.tlsOptions));
         middlewareArray.push(_router);
         this.expressApp.use(proxiedRootService.url, middlewareArray);
       } else {
         const _router = this.makeProxy(proxiedRootService.url, false,
-                                       getAgentProxyOptions(this.options, this.options.serverConfig.agent, this.options.tlsOptions));
+                                       getAgentProxyOptions(this.options.serverConfig, this.options.tlsOptions));
         middlewareArray.push(_router);
         this.expressApp.use(proxiedRootService.url, rootServicesMiddleware, this.auth.middleware, middlewareArray);
       }
@@ -1589,7 +1589,7 @@ WebApp.prototype = {
         : zLuxUrl.makePluginURL(this.options.productCode, plugin.identifier)
           + zLuxUrl.makeServiceSubURL(service, false, true),
         false,
-        getAgentProxyOptions(this.options, this.options.serverConfig.agent, this.options.tlsOptions));
+        getAgentProxyOptions(this.options.serverConfig, this.options.tlsOptions));
       break;
     case "nodeService":
       //installLog.info(

--- a/lib/webapp.js
+++ b/lib/webapp.js
@@ -1196,7 +1196,7 @@ function makeLoopbackConfig(nodeConfig) {
 }
 
 function getAgentProxyOptions(serverConfig, tlsOptions) {
-  const requestOptions = zluxUtil.getAgentRequestOptions(serverConfig, tlsOptions);
+  const requestOptions = zluxUtil.getAgentRequestOptions(serverConfig, tlsOptions, false);
   if (!requestOptions) return null;
 
   let options = {
@@ -1340,7 +1340,7 @@ WebApp.prototype = {
     };
     if (!(host && port)) {
       //destined for agent rather than 3rd party server
-      const requestOptions = zluxUtil.getAgentRequestOptions(this.options.serverConfig, this.options.tlsOptions, urlPrefix);
+      const requestOptions = zluxUtil.getAgentRequestOptions(this.options.serverConfig, this.options.tlsOptions, false, urlPrefix);
       host = requestOptions.host;
       port = requestOptions.port;
       options.urlPrefix = requestOptions.path;

--- a/lib/webapp.js
+++ b/lib/webapp.js
@@ -246,7 +246,7 @@ const release = os.release();
 const cpus = os.cpus();
 const hostname = os.hostname();
 
-function getUserEnv(rbac){
+function getUserEnv(rbac, serverConfig){
   var date = new Date();
   return new Promise(function(resolve, reject){
     if (rbac) {
@@ -261,6 +261,9 @@ function getUserEnv(rbac){
         "freeMemory": os.freemem(),
         "hostname": hostname,
         "userEnvironment": process.env,
+        "agent": {
+          "mediationLayer": serverConfig.agent ? serverConfig.agent.mediationLayer : undefined
+        },
         "PID": process.pid,
         "PPID": process.ppid,
         "nodeVersion": process.version,
@@ -289,6 +292,9 @@ function getUserEnv(rbac){
           //expected to be identical
           "ZWED_node_mediationLayer_server_gatewayPort": process.env.ZWED_node_mediationLayer_server_gatewayPort,
           "GATEWAY_PORT": process.env.GATEWAY_PORT
+        },
+        "agent": {
+          "mediationLayer": serverConfig.agent ? serverConfig.agent.mediationLayer : undefined
         }
       })
     }
@@ -493,7 +499,7 @@ const staticHandlers = {
     const rbac = (dataserviceAuth == undefined) ? false : dataserviceAuth.rbac === true;
     //endpoints that handle rbac decision-making within
     router.get('/environment', function(req, res){
-      getUserEnv(rbac).then(result => {
+      getUserEnv(rbac, options.serverConfig).then(result => {
         res.status(200).json(result);
       });
     }).all('/environment', function (req, res) {

--- a/plugins/sso-auth/lib/ssoAuth.js
+++ b/plugins/sso-auth/lib/ssoAuth.js
@@ -87,8 +87,7 @@ function SsoAuthenticator(pluginDef, pluginConf, serverConf, context) {
     "canLogout": true,
     "canResetPassword": this.usingZss ? true : false,
     "proxyAuthorizations": true,
-    //TODO do we need to process proxy headers for both?
-    "processesProxyHeaders": this.usingZss ? true: false
+    "processesProxyHeaders": false
   };
 }
 
@@ -303,14 +302,6 @@ SsoAuthenticator.prototype = {
     if (this.usingZss && !this.usingSso) {
       this.zssHandler.addProxyAuthorizations(req1, req2Options, sessionState);
     }
-  },
-
-  processProxiedHeaders(req, headers, sessionState) {
-    if (this.usingZss) {
-      headers = this.zssHandler.processProxiedHeaders(req, headers, sessionState);
-    }
-    //TODO does apiml need this too?
-    return headers;
   }
 };
 

--- a/plugins/sso-auth/lib/zssHandler.js
+++ b/plugins/sso-auth/lib/zssHandler.js
@@ -16,6 +16,8 @@ const DEFAULT_CLASS = "ZOWE";
 const ZSS_SESSION_TIMEOUT_HEADER = "session-expires-seconds";
 const DEFAULT_EXPIRATION_MS = 3600000 //hour;
 const HTTP_STATUS_PRECONDITION_REQUIRED = 428;
+const COOKIE_NAME = 'jedHTTPSession';
+const COOKIE_NAME_LENGTH = COOKIE_NAME.length;
 
 class ZssHandler {
   constructor(pluginDef, pluginConf, serverConf, context) {
@@ -42,6 +44,7 @@ class ZssHandler {
         for(let i = 0; i < bypassUrls.length; i++){
           if(request.originalUrl.startsWith(bypassUrls[i])){
             result.authorized = true;
+            this.setCookieFromRequest(request, sessionState);
             return result;
           }
         }
@@ -52,6 +55,7 @@ class ZssHandler {
         request.username = sessionState.username;
         if (options.bypassAuthorizatonCheck) {
           result.authorized = true;
+          this.setCookieFromRequest(request, sessionState);
           return result;
         }
         if (request.originalUrl.startsWith("/saf-auth")) {
@@ -62,6 +66,9 @@ class ZssHandler {
           // 2. They can run the request agains the ZSS host itself. The firewall
           //    would allow that. So, simply go back to item 1
           this._allowIfLoopback(request, result);
+          if (result.authorized === true) {
+            this.setCookieFromRequest(request, sessionState);
+          }
           return result;
         }
         const resourceName = this._makeProfileName(request.originalUrl, 
@@ -73,6 +80,7 @@ class ZssHandler {
                    `Allowing ${sessionState.username} access to ${resourceName} ` +
                    'unconditinally');
           result.authorized = true;
+          this.setCookieFromRequest(request, sessionState);
           return result;
         }
         const httpResponse = yield this._callAgent(request.zluxData, 
@@ -96,13 +104,12 @@ class ZssHandler {
       delete sessionState.zssUsername;
       let options = {
         method: 'GET',
-        headers: {'cookie': sessionState.zssCookies+''}
+        headers: {'cookie': `${COOKIE_NAME}=${request.cookies[COOKIE_NAME]}`}
       };
-      delete sessionState.zssCookies;
       request.zluxData.webApp.callRootService("logout", options).then((response) => {
         //did logout or already logged out
         if (response.statusCode === 200 || response.statusCode === 401) {
-          resolve({ success: true });
+          resolve({ success: true, cookies: this.deleteClientCookie()});
         } else {
           resolve({ success: false, reason: response.statusCode });
         }
@@ -132,7 +139,19 @@ class ZssHandler {
   }
   
   cleanupSession(sessionState) {
+    delete sessionState.zssUsername;
+    //TODO zssCookies probably isnt needed anymore as they are sent to client, but continuing to manage it in case extenders were using it somehow
     delete sessionState.zssCookies;
+  }
+
+  deleteClientCookie() {
+    return [
+      {name:COOKIE_NAME,
+       value:'non-token',
+       options: {httpOnly: true,
+                 secure: true,
+                 expires: new Date(1)}}
+    ]
   }
 
   refreshStatus(request, sessionState) {
@@ -145,13 +164,17 @@ class ZssHandler {
 
   _authenticateOrRefresh(request, sessionState, isRefresh) {
     return new Promise((resolve, reject) => {
-      if (isRefresh && !sessionState.zssCookies) {
+      let clientCookie;
+      if (request.cookies) {
+        clientCookie = request.cookies[COOKIE_NAME];
+      }
+      if (isRefresh && !clientCookie) {
         resolve({success: false, error: {message: 'No cookie given for refresh or check'}});
         return;
       }
       let options = isRefresh ? {
         method: 'GET',
-        headers: {'cookie': sessionState.zssCookies}
+        headers: {'cookie': `${COOKIE_NAME}=${clientCookie}`}
       } : {
         method: 'POST',
         body: request.body
@@ -160,33 +183,33 @@ class ZssHandler {
         this.logger.debug(`Login rc=`,response.statusCode);
         if (response.statusCode == HTTP_STATUS_PRECONDITION_REQUIRED) {
           sessionState.authenticated = false;
-          delete sessionState.zssUsername;
-          delete sessionState.zssCookies;
-          resolve({ success: false, reason: 'Expired Password'});
+          this.cleanupSession();
+          resolve({ success: false, reason: 'Expired Password', cookies: this.deleteClientCookie()});
         }
-        let zssCookie;
+        let serverCookie, cookieValue;
         if (typeof response.headers['set-cookie'] === 'object') {
           for (const cookie of response.headers['set-cookie']) {
             const content = cookie.split(';')[0];
-            //TODO proper manage cookie expiration
-            if (content.indexOf('jedHTTPSession') >= 0) {
-              zssCookie = content;
+            let index = content.indexOf(COOKIE_NAME);
+            if (index >= 0) {
+              serverCookie = content;
+              cookieValue = content.substring(index+1+COOKIE_NAME_LENGTH);
             }
           }
         }
-        if (zssCookie) {
+        if (serverCookie) {
           if (!isRefresh) {
             sessionState.username = request.body.username.toUpperCase();
           }
           //intended to be known as result of network call
-          sessionState.zssCookies = zssCookie;
+          sessionState.zssCookies = serverCookie;
           let expiresSec = response.headers[ZSS_SESSION_TIMEOUT_HEADER];
           let expiresMs = DEFAULT_EXPIRATION_MS;
           if (expiresSec) {
             expiresMs = expiresSec == -1 ? expiresSec : Number(expiresSec)*1000;
           }
-          resolve({ success: true, username: sessionState.username,
-                    expms: expiresMs});
+          resolve({ success: true, username: sessionState.username, expms: expiresMs,
+                    cookies: [{name:COOKIE_NAME, value:cookieValue, options: {httpOnly: true, secure: true, encode: String}}]});
         } else {
           let res = { success: false, error: {message: `ZSS ${response.statusCode} ${response.statusMessage}`}};
           if (response.statusCode === 500) {
@@ -201,15 +224,17 @@ class ZssHandler {
       });
     });
   }
+  
+  setCookieFromRequest(req, sessionState) {
+    if (req.cookies && req.cookies[COOKIE_NAME]) {
+      sessionState.zssCookies = `${COOKIE_NAME}=${req.cookies[COOKIE_NAME]}`;
+    }
+  }
 
   addProxyAuthorizations(req1, req2Options, sessionState) {
-    if (req1.cookies) {
-      delete req1.cookies['jedHTTPSession'];
+    if (req1.cookies && req1.cookies[COOKIE_NAME]) {
+      req2Options.headers['cookie'] = req1.headers['cookie'];
     }
-    if (!sessionState.zssCookies) {
-      return;
-    }
-    req2Options.headers['cookie'] = sessionState.zssCookies;
   }
 
   passwordReset(request, sessionState) {
@@ -229,25 +254,6 @@ class ZssHandler {
       });
     });
   }
-
-  processProxiedHeaders(req, headers, sessionState) {
-    let cookies = headers['set-cookie'];
-    if (cookies) {
-      let modifiedCookies = [];
-      for (let i = 0; i < cookies.length; i++) {
-        if (cookies[i].startsWith('jedHTTPSession')) {
-          let zssCookie = cookies[i];
-          let semiIndex = zssCookie.indexOf(';');
-          sessionState.zssCookies = semiIndex != -1 ? zssCookie.substring(0,semiIndex) : zssCookie;
-          
-        } else {
-          modifiedCookies.push(cookies[i]);
-        }
-      }
-      headers['set-cookie']=modifiedCookies;
-    }
-    return headers;
-  }  
   
   _allowIfLoopback(request, result) {
     const requestIP = ipaddr.process(request.ip);


### PR DESCRIPTION
This code cleans up a lot of code related to how to contact zss, in order to enhance the calling to call through apiml if zss is available through apiml.

This seems to work, but it might need additionally a loop to retry contacting apiml like we do with zss directly, to avoid timing errors. But, we do at elast wait until we register with apiml to try to find zss there.
Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>