### PR TITLE
Decrease duplicate and verbose logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This repo is part of the app-server Zowe Component, and the change logs here may
 
 - Enhancement: Plugins can push state out to the Caching Service for high availability storage via a improved storage API, available to dataservices as `context.storage`
 - Enhancement: Storage API V2 added which has parameters to specify whether plugin cache and state should be stored local to a worker, in the cluster, or remote for high availability
+- Enhancement: Decrease verbosity and duplication of startup logs. Log messages omitted have been moved to debug messaging.
 
 ## 1.21.0
 

--- a/lib/apiml.js
+++ b/lib/apiml.js
@@ -277,14 +277,28 @@ ApimlConnector.prototype = {
       ]};
       log.info(`ZWED0020I`, url); //log.info(`Registering at ${url}...`);
       log.debug("ZWED0145I", JSON.stringify(zluxProxyServerInstanceConfig)); //log.debug(`zluxProxyServerInstanceConfig ${JSON.stringify(zluxProxyServerInstanceConfig)}`)
-    const zluxServerEurekaClient = new eureka(zluxProxyServerInstanceConfig);
-    //zluxServerEurekaClient.logger.level('debug');
-    this.zluxServerEurekaClient = zluxServerEurekaClient;
+    const eurekaClient = new eureka(zluxProxyServerInstanceConfig);
+    //this library has a very simple logger that has the same function names as ours, so why not just use ours for better formatting
+    eurekaClient.logger = log;
+    let errorHandler = log.error;
+    let lastErrorMessage;
+    let hideTimingError = (...args) => {
+      if (args[0] == 'Problem making eureka request' || args[0] == 'Eureka request failed to endpoint') {
+        lastErrorMessage = args;
+      } else {
+        errorHandler(...args);
+      }
+    };
+    log.error = hideTimingError;
+    this.eurekaClient = eurekaClient;
     const ipAddr = this.ipAddr;
     const appServerUrl = `https://${this.apimlHost}:${this.apimlPort}/ui/v1/${zluxProxyServerInstanceConfig.instance.app}/`;
-    return new Promise(function (resolve, reject) {
-      zluxServerEurekaClient.start(function (error) {
+    return new Promise((resolve, reject) => {
+      eurekaClient.start((error) => {
+        //suppress expected errors (due to timing) by substituting logger temporarily, but capture last seen error and log it after restoring error logger on connect
+        log.error = errorHandler;
         if (error) {
+          log.error(lastErrorMessage);
           log.warn('ZWED0005W', error); //log.warn(error);
           reject(error);
         } else {

--- a/lib/index.js
+++ b/lib/index.js
@@ -148,7 +148,10 @@ Server.prototype = {
     this.userConfig.node.allowInvalidTLSProxy = allowInvalidTLSProxy;
     
     const firstWorker = !(process.clusterManager && process.clusterManager.getIndexInCluster() != 0);
-    
+    if (!firstWorker) {
+      this.suppressDuplicateLogging();
+    }
+
     if (this.userConfig.node.childProcesses) {
       for (const proc of this.userConfig.node.childProcesses) {
         if (!process.clusterManager || process.clusterManager.getIndexInCluster() == 0 || !proc.once) {
@@ -404,10 +407,25 @@ Server.prototype = {
 
   pluginLoadingFinished(adr, percent, loaded, total) {
     if (!process.clusterManager || process.clusterManager.getIndexInCluster() == 0) {    
+    if (process.clusterManager && process.clusterManager.getIndexInCluster() != 0) {
+      this.restoreWorkerLogging();
+    } else {
       installLogger.info(`ZWED0031I`, adr, percent, loaded, total);
       //Server is ready at ${adr}, Plugins successfully loaded: ${percent}% (${loaded}/${total})`);
     }
     this.pluginLoader.enablePluginScanner(this.userConfig.node.pluginScanIntervalSec);
+  },
+
+  suppressDuplicateLogging() {
+    global.COM_RS_COMMON_LOGGER.setLogLevelForComponentPattern("_zsf\..*",1);
+  },
+
+  restoreWorkerLogging() {
+    global.COM_RS_COMMON_LOGGER.setLogLevelForComponentPattern("_zsf\..*",2);
+    let keys = Object.keys(this.userConfig.logLevels);
+    keys.forEach((key)=> {
+      global.COM_RS_COMMON_LOGGER.setLogLevelForComponentName(key, this.userConfig.logLevels[key]);
+    });
   },
 
   newPluginSubmitted(pluginDef) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -406,7 +406,6 @@ Server.prototype = {
   },
 
   pluginLoadingFinished(adr, percent, loaded, total) {
-    if (!process.clusterManager || process.clusterManager.getIndexInCluster() == 0) {    
     if (process.clusterManager && process.clusterManager.getIndexInCluster() != 0) {
       this.restoreWorkerLogging();
     } else {

--- a/lib/plugin-loader.js
+++ b/lib/plugin-loader.js
@@ -150,14 +150,14 @@ NodeService.prototype = {
       var operatingSystem = process.platform;
       var osDelim = operatingSystem === "win32" ? ";" : ":"; 
 
-      bootstrapLogger.info("ZWED0116I", serverModuleLocation, clientModuleLocation); //bootstrapLogger.log(bootstrapLogger.INFO,
+      bootstrapLogger.debug("ZWED0116I", serverModuleLocation, clientModuleLocation); //bootstrapLogger.log(bootstrapLogger.INFO,
         //`The LOCATIONS are ${serverModuleLocation} and ${clientModuleLocation}`);
       nodePathAdd = `${process.env.NODE_PATH}${serverModuleLocation}${osDelim}${clientModuleLocation}${osDelim}.`
       process.env.NODE_PATH = nodePathAdd;
       require("module").Module._initPaths();    
-      bootstrapLogger.info("ZWED0117I", fileLocation); //bootstrapLogger.log(bootstrapLogger.INFO, `The fileLocation is ${fileLocation}`);
+      bootstrapLogger.debug("ZWED0117I", fileLocation); //bootstrapLogger.log(bootstrapLogger.INFO, `The fileLocation is ${fileLocation}`);
 
-      bootstrapLogger.info("ZWED0118I", process.env.NODE_PATH); //bootstrapLogger.log(bootstrapLogger.INFO,
+      bootstrapLogger.debug("ZWED0118I", process.env.NODE_PATH); //bootstrapLogger.log(bootstrapLogger.INFO,
         //`The NODE_PATH is ${process.env.NODE_PATH}`);
 
       const nodeModule = require(fileLocation);
@@ -585,7 +585,7 @@ PluginLoader.prototype = {
   _readPluginDef(pluginDescriptorFilename) {
     const pluginPtrPath = this.options.relativePathResolver(pluginDescriptorFilename,
                                                  this.options.pluginsDir);
-    bootstrapLogger.info(`ZWED0044I`, pluginPtrPath); //bootstrapLogger.info(`Processing plugin reference ${pluginPtrPath}...`);
+    bootstrapLogger.debug(`ZWED0044I`, pluginPtrPath); //bootstrapLogger.info(`Processing plugin reference ${pluginPtrPath}...`);
     if (!fs.existsSync(pluginPtrPath)) {
       throw new Error(`ZWED0021E - ${pluginPtrPath} is missing`);
     }
@@ -833,7 +833,7 @@ PluginLoader.prototype = {
           const plugin = makePlugin(pluginDef, pluginConfiguration, pluginContext,
                                     false, this.options.langManagers);
           if (plugin) {
-            bootstrapLogger.info("ZWED0124I", plugin.identifier, plugin.location); //bootstrapLogger.log(bootstrapLogger.INFO,
+            bootstrapLogger.debug("ZWED0124I", plugin.identifier, plugin.location); //bootstrapLogger.log(bootstrapLogger.INFO,
               //`Plugin ${plugin.identifier} at path=${plugin.location} loaded.\n`);
               bootstrapLogger.debug("ZWED0164I", plugin.toString()); //bootstrapLogger.debug(' Content:\n' + plugin.toString());
             let frozen = zluxUtil.deepFreeze(plugin);

--- a/lib/util.js
+++ b/lib/util.js
@@ -387,7 +387,7 @@ module.exports.normalizePath = function(oldPath, relativeTo) {
   if (normalized.endsWith(path.sep)) {
     normalized = normalized.substring(0,normalized.length-1);
   }
-  loggers.utilLogger.info(`ZWED0051I`, oldPath, normalized);   //loggers.utilLogger.info(`Resolved path: ${oldPath} -> ${normalized}`);  
+  loggers.utilLogger.debug(`ZWED0051I`, oldPath, normalized);   //loggers.utilLogger.info(`Resolved path: ${oldPath} -> ${normalized}`);  
   return normalized;
 }
 

--- a/lib/webapp.js
+++ b/lib/webapp.js
@@ -1602,11 +1602,11 @@ WebApp.prototype = {
             serviceConfiguration, pluginContext, this);
         if (!service.routerFactory) {
           router = yield service.nodeModule(dataserviceContext);
-          installLog.info("ZWED0057I", plugin.identifier, service.name, router); //installLog.info("Loaded Router for plugin=" + plugin.identifier + ", service="+service.name + ". Router="+router);
+          installLog.debug("ZWED0057I", plugin.identifier, service.name, router); //installLog.info("Loaded Router for plugin=" + plugin.identifier + ", service="+service.name + ". Router="+router);
         } else {
           router = yield service.nodeModule[service.routerFactory](
               dataserviceContext);
-              installLog.info("ZWED0058I", plugin.identifier, service.name, service.routerFactory); //installLog.info("Loaded Router from factory for plugin=" + plugin.identifier + ", service=" + service.name + ". Factory="+service.routerFactory);
+              installLog.debug("ZWED0058I", plugin.identifier, service.name, service.routerFactory); //installLog.info("Loaded Router from factory for plugin=" + plugin.identifier + ", service=" + service.name + ". Factory="+service.routerFactory);
         }
       }
       break;
@@ -1673,7 +1673,7 @@ WebApp.prototype = {
     if (!plugin.dataServicesGrouped) {
       return;
     }
-    installLog.info(`ZWED0060I`, plugin.identifier) //installLog.info(`${plugin.identifier}: installing data services`)
+    installLog.debug(`ZWED0060I`, plugin.identifier) //installLog.info(`${plugin.identifier}: installing data services`)
     const serviceHandleMap = this._makeServiceHandleMap(plugin, urlBase);
     if (plugin.pluginType === 'nodeAuthentication') {
       //hack for pseudo-SSO
@@ -1688,7 +1688,7 @@ WebApp.prototype = {
       pluginRouters = this.routers[plugin.identifier] = {};
     }
     for (const serviceName of Object.keys(plugin.dataServicesGrouped)) {
-      installLog.info(`ZWED0061I`,plugin.identifier, serviceName) //installLog.info(`${plugin.identifier}: installing service ${serviceName}`)
+      installLog.debug(`ZWED0061I`,plugin.identifier, serviceName) //installLog.info(`${plugin.identifier}: installing service ${serviceName}`)
       let serviceRouters = pluginRouters[serviceName];
       if (!serviceRouters) {
         serviceRouters = pluginRouters[serviceName] = {};
@@ -1717,7 +1717,7 @@ WebApp.prototype = {
       return;
     }
     for (const localName of Object.keys(plugin.importsGrouped)) {
-      installLog.info(`ZWED0063I`, plugin.identifier, localName) //installLog.info(`${plugin.identifier}: importing service ${localName}`)
+      installLog.debug(`ZWED0063I`, plugin.identifier, localName) //installLog.info(`${plugin.identifier}: importing service ${localName}`)
       const group = plugin.importsGrouped[localName];
       for (const version of Object.keys(group.versions)) {
         const importedService = group.versions[version];
@@ -1754,7 +1754,7 @@ WebApp.prototype = {
 
 
   _installPluginStaticHandlers(plugin, urlBase) {
-    installLog.info(`ZWED0065I`, plugin.identifier); //installLog.info(`${plugin.identifier}: installing static file handlers...`);
+    installLog.debug(`ZWED0065I`, plugin.identifier); //installLog.info(`${plugin.identifier}: installing static file handlers...`);
     if (plugin.webContent && plugin.location) {
       let url = `${urlBase}/web`;
       installLog.info(`ZWED0066I`, plugin.identifier, url); //installLog.info(`${plugin.identifier}: serving static files at ${url}`);


### PR DESCRIPTION
This PR moves some info logs to debug, due to being annoying and never having been useful in our troubleshooting.
Many are duplicate in purpose, or possible to derive from other logs.

And when it comes to duplicate logs, we also have a startup problem in cluster mode.
During init, all workers in a cluster do the same tasks in parallel, resulting in many log messages that say the same thing times the number of workers running.
After init, worker logging stops being duplicated due to requests being dispatched to individual workers, so duplication is only a startup problem.

To prevent duplication, I thought it would be good to reduce server core logger verbosity at startup for all workers except the first. Then when startup is finished, restore the verbosity to the requested level.

Another log I hope to eliminate is the warning we get when trying to connect to apiml when it is not yet loaded. I attempt to eliminate this by substituting the eureka client library logger with ours, and suppress the warning during connection.
Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>