### PR TITLE
Hotfix: Provide correct tlsOptions when RBAC is enabled

### DIFF
--- a/lib/webapp.js
+++ b/lib/webapp.js
@@ -545,7 +545,7 @@ const staticHandlers = {
         addProxyAuthorizations: options.auth.addProxyAuthorizations,
         allowInvalidTLSProxy: options.allowInvalidTLSProxy
       };
-      proxyOptions = Object.assign(proxyOptions, getAgentProxyOptions(options, options.serverConfig.agent, this.options.tlsOptions));
+      proxyOptions = Object.assign(proxyOptions, getAgentProxyOptions(options, options.serverConfig.agent, options.tlsOptions));
       router.get('/agent*', proxy.makeSimpleProxy(options.proxiedHost, options.proxiedPort,
         proxyOptions));
       router.get('/reload', function(req, res){


### PR DESCRIPTION
This a is a hotfix for an error during app-server startup when RBAC is enabled:
```
ZWED5019E - Could not start the server:  TypeError: Cannot read property 'tlsOptions' of undefined
    at Object.server (/u/ts3215/zlux-test/share/zlux-server-framework/lib/webapp.js:548:121)
    at WebApp.installRootServices (/u/ts3215/zlux-test/share/zlux-server-framework/lib/webapp.js:1460:63)
    at WebApp.init (/u/ts3215/zlux-test/share/zlux-server-framework/lib/webapp.js:1926:10)
    at Server.<anonymous> (/u/ts3215/zlux-test/share/zlux-server-framework/lib/index.js:224:17)
    at Generator.next (<anonymous>)
    at Generator.tryCatcher (/u/ts3215/zlux-test/share/zlux-server-framework/node_modules/bluebird/js/release/util.js:16:23)
    at PromiseSpawn._promiseFulfilled (/u/ts3215/zlux-test/share/zlux-server-framework/node_modules/bluebird/js/release/generators.js:97:49)
    at _drainQueueStep (/u/ts3215/zlux-test/share/zlux-server-framework/node_modules/bluebird/js/release/async.js:142:12)
    at _drainQueue (/u/ts3215/zlux-test/share/zlux-server-framework/node_modules/bluebird/js/release/async.js:131:9)
    at Async._drainQueues (/u/ts3215/zlux-test/share/zlux-server-framework/node_modules/bluebird/js/release/async.js:147:5)
    at Immediate.Async.drainQueues [as _onImmediate] (/u/ts3215/zlux-test/share/zlux-server-framework/node_modules/bluebird/js/release/async.js:17:14)
    at processImmediate (internal/timers.js:461:21)
``` 