### PR TITLE
Testing effect of client cert on zss through apiml status check

### DIFF
--- a/lib/apiml.js
+++ b/lib/apiml.js
@@ -119,9 +119,10 @@ ApimlConnector.prototype = {
         path: `/eureka/apps/${serviceName}`,
         headers: {'accept':'application/json'}
       }, this.tlsOptions);
-      //dont need client auth, apiml will reject if these are unknown to apiml anyway.
-      delete options.cert;
-      delete options.key;
+      //dont need client auth, apiml will reject if these are unknown to apiml anyway, so delete cert&key
+      //but, if you see a 403, then you may need client auth here. more investigation needed.
+      //delete options.cert;
+      //delete options.key;
 
       
       const issueRequest = () => {

--- a/lib/apiml.js
+++ b/lib/apiml.js
@@ -107,7 +107,7 @@ ApimlConnector.prototype = {
   }),
 
   
-  checkAgent(timeout, serviceName) {
+  checkAgent(timeout, serviceName, useClientCert) {
     let timer = timeout ? timeout : DEFAULT_AGENT_CHECK_TIMEOUT;
     const end = Date.now() + timer;
     
@@ -119,11 +119,12 @@ ApimlConnector.prototype = {
         path: `/eureka/apps/${serviceName}`,
         headers: {'accept':'application/json'}
       }, this.tlsOptions);
-      //dont need client auth, apiml will reject if these are unknown to apiml anyway, so delete cert&key
-      //but, if you see a 403, then you may need client auth here. more investigation needed.
-      //delete options.cert;
-      //delete options.key;
 
+      if (!useClientCert) {
+        //dont need client auth, apiml will reject if these are unknown to apiml anyway, so delete cert&key
+        delete options.cert;
+        delete options.key;
+      } //else you will see a 403 if missing cert
       
       const issueRequest = () => {
         if (Date.now() > end) {

--- a/lib/apiml.js
+++ b/lib/apiml.js
@@ -120,7 +120,7 @@ ApimlConnector.prototype = {
         headers: {'accept':'application/json'}
       }, this.tlsOptions);
 
-      if (!process.env.KEYSTORE_DIRECTORY) {
+      if (!process.env['KEYSTORE_DIRECTORY']) {
         //Keeping these certs causes an openssl error 46, unknown cert error in a dev environment
         delete options.cert;
         delete options.key;
@@ -254,8 +254,13 @@ ApimlConnector.prototype = {
   },*/
   
   registerMainServerInstance() {
-    const overrideOptions = this.tlsOptions.rejectUnauthorized === false
-          ? {rejectUnauthorized: false} : this.tlsOptions;
+    const overrideOptions = Object.assign({},this.tlsOptions);
+    if (!process.env['KEYSTORE_DIRECTORY']) {
+      //Keeping these certs causes an openssl error 46, unknown cert error in a dev environment
+      delete overrideOptions.cert;
+      delete overrideOptions.key;
+    } //else, apiml expects a cert and will give a 403.
+
     const zluxProxyServerInstanceConfig = {
       instance: this._makeMainInstanceProperties(),
       eureka: Object.assign({}, MEDIATION_LAYER_EUREKA_DEFAULTS, this.eurekaOverrides),

--- a/lib/apiml.js
+++ b/lib/apiml.js
@@ -107,7 +107,7 @@ ApimlConnector.prototype = {
   }),
 
   
-  checkAgent(timeout, serviceName, useClientCert) {
+  checkAgent(timeout, serviceName) {
     let timer = timeout ? timeout : DEFAULT_AGENT_CHECK_TIMEOUT;
     const end = Date.now() + timer;
     
@@ -120,11 +120,11 @@ ApimlConnector.prototype = {
         headers: {'accept':'application/json'}
       }, this.tlsOptions);
 
-      if (!useClientCert) {
-        //dont need client auth, apiml will reject if these are unknown to apiml anyway, so delete cert&key
+      if (!process.env.KEYSTORE_DIRECTORY) {
+        //Keeping these certs causes an openssl error 46, unknown cert error in a dev environment
         delete options.cert;
         delete options.key;
-      } //else you will see a 403 if missing cert
+      } //else, apiml expects a cert and will give a 403.
       
       const issueRequest = () => {
         if (Date.now() > end) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -256,8 +256,7 @@ Server.prototype = {
         webAppOptions.proxiedPort = this.userConfig.node.mediationLayer.server.gatewayPort;
         if (firstWorker) {
           yield this.apiml.checkAgent(this.userConfig.agent.handshakeTimeout,
-                                      this.userConfig.agent.mediationLayer.serviceName,
-                                      !this.userConfig.node.allowInvalidTLSProxy);
+                                      this.userConfig.agent.mediationLayer.serviceName);
         }
       } else if (this.userConfig.agent && this.userConfig.agent.mediationLayer) {
         this.userConfig.agent.mediationLayer.enabled = false;

--- a/lib/index.js
+++ b/lib/index.js
@@ -256,7 +256,8 @@ Server.prototype = {
         webAppOptions.proxiedPort = this.userConfig.node.mediationLayer.server.gatewayPort;
         if (firstWorker) {
           yield this.apiml.checkAgent(this.userConfig.agent.handshakeTimeout,
-                                      this.userConfig.agent.mediationLayer.serviceName);
+                                      this.userConfig.agent.mediationLayer.serviceName,
+                                      !this.userConfig.node.allowInvalidTLSProxy);
         }
       } else if (this.userConfig.agent && this.userConfig.agent.mediationLayer) {
         this.userConfig.agent.mediationLayer.enabled = false;


### PR DESCRIPTION
Testing a theory from Jack in Slack about that the failure to check zss through apiml as tested in https://github.com/zowe/zowe-install-packaging/pull/2098  may be due to the presence or absence of client certificates.