### PR TITLE
APIML cert bugfixes

### DIFF
--- a/lib/apiml.js
+++ b/lib/apiml.js
@@ -119,10 +119,12 @@ ApimlConnector.prototype = {
         path: `/eureka/apps/${serviceName}`,
         headers: {'accept':'application/json'}
       }, this.tlsOptions);
-      //dont need client auth, apiml will reject if these are unknown to apiml anyway.
-      delete options.cert;
-      delete options.key;
 
+      if (!process.env['KEYSTORE_DIRECTORY']) {
+        //Keeping these certs causes an openssl error 46, unknown cert error in a dev environment
+        delete options.cert;
+        delete options.key;
+      } //else, apiml expects a cert and will give a 403.
       
       const issueRequest = () => {
         if (Date.now() > end) {
@@ -252,8 +254,13 @@ ApimlConnector.prototype = {
   },*/
   
   registerMainServerInstance() {
-    const overrideOptions = this.tlsOptions.rejectUnauthorized === false
-          ? {rejectUnauthorized: false} : this.tlsOptions;
+    const overrideOptions = Object.assign({},this.tlsOptions);
+    if (!process.env['KEYSTORE_DIRECTORY']) {
+      //Keeping these certs causes an openssl error 46, unknown cert error in a dev environment
+      delete overrideOptions.cert;
+      delete overrideOptions.key;
+    } //else, apiml expects a cert and will give a 403.
+
     const zluxProxyServerInstanceConfig = {
       instance: this._makeMainInstanceProperties(),
       eureka: Object.assign({}, MEDIATION_LAYER_EUREKA_DEFAULTS, this.eurekaOverrides),


### PR DESCRIPTION
This commit either includes or does not include the app-servers certificate when contacting the apiml /eureka endpoints, either for finding zss or for registering the app-server.
We found issues, either openssl protocol ones, or apiml rejecting requests with a 403, depending upon whether the app-server did/didnt send certs, and whether the certs were in the same keystore as what apiml was reading, and if the app-server used the same keystore as apiml. This code essentially sends certs in all normal circumstances except a dev environment, which it detects by checking for the env var KEYSTORE_DIRECTORY.
It has been tested with https://github.com/zowe/zowe-install-packaging/pull/2098 both through automation and through setting it up on z/os, and using a dev app-server outside z/os to see how the eureka communication succeeds or fails.