### PR TITLE
Pass logger to PluginStorageFactory

### DIFF
--- a/lib/webapp.js
+++ b/lib/webapp.js
@@ -81,7 +81,7 @@ function DataserviceContext(serviceDefinition, serviceConfiguration,
   this.serviceDefinition = serviceDefinition;
   this.serviceConfiguration = serviceConfiguration;
   this.plugin = pluginContext;
-  this.storage = pluginStorage.PluginStorageFactory(this.plugin.pluginDef.identifier);
+  this.storage = pluginStorage.PluginStorageFactory(this.plugin.pluginDef.identifier, utilLog);
   this.logger = createDataserviceLogger(pluginContext, serviceDefinition);
   this.wsRouterPatcher = webapp.expressWs.applyTo;
 }

--- a/test/storage/apimlStorageViaUnified.js
+++ b/test/storage/apimlStorageViaUnified.js
@@ -13,6 +13,7 @@ const expect = chai.expect;
 const pluginStorage = require('../../lib/pluginStorage');
 const apimlStorage = require('../../lib/apimlStorage');
 const fs = require('fs');
+const utilLog = require('../../lib/util').loggers.utilLogger;
 
 describe('APIML Storage via Unified interface', function () {
   let storage = null;
@@ -36,7 +37,7 @@ describe('APIML Storage via Unified interface', function () {
         }
       };
       apimlStorage.configure(settings);
-      storage = pluginStorage.PluginStorageFactory(pluginId);
+      storage = pluginStorage.PluginStorageFactory(pluginId, utilLog);
     } else {
       console.log(`Required environment variables not found. Set these env vars to run tests:`);
       console.log(`  export GATEWAY_HOST=<gateway-host>`);


### PR DESCRIPTION
## Proposed changes
This PR passes missing `logger` arg to `PluginStorageFactory`. The arg is mandatory.

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

