### PR TITLE
Use gatewayHostname to configure Caching Service

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -385,16 +385,16 @@ Server.prototype = {
       apimlConfig.cachingService &&
       apimlConfig.cachingService.enabled &&
       apimlConfig.server &&
-      apimlConfig.server.hostname &&
+      apimlConfig.server.gatewayHostname &&
       apimlConfig.server.gatewayPort;
   },
 
   configureApimlStorage(apimlConfig) {
-    const { hostname, gatewayPort } = apimlConfig.server;
+    const { gatewayHostname, gatewayPort } = apimlConfig.server;
     const tlsOptions = this.webServer.getTlsOptions();
     tlsOptions.rejectUnauthorized = !this.startUpConfig.allowInvalidTLSProxy;
     const settings = {
-      host: hostname,
+      host: gatewayHostname,
       port: gatewayPort,
       tlsOptions: tlsOptions
     };


### PR DESCRIPTION
## Proposed changes

Use `node.mediationLayer.server.gatewayHostname` to configure Caching Service


## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
