### PR TITLE
Make requests to zss work through APIML Gateway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This repo is part of the app-server Zowe Component, and the change logs here may
 - Enhancement: Decrease verbosity and duplication of startup logs. Log messages omitted have been moved to debug messaging.
 - Enhancement: Change missing swagger warning message to debug as it is a warning for developers, not for end users.
 - Bugfix: Fix /server/agent route when using APIML
+- Bugfix: Fix issue with CORS rejection when accessing zss through APIML gateway 
 
 ## 1.21.0
 

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -27,14 +27,18 @@ const proxyLog = util.loggers.proxyLogger;
 const RECONNECT_DELAY = 5000;
 const DEFAULT_HANDSHAKE_TIMEOUT = 30000;
 
-function convertOptions(request, realHost, realPort, urlPrefix) {
+function convertOptions(request, realHost, realPort, urlPrefix, requestProcessingOptions) {
   var options = {};
   proxyLog.debug("ZWED0166I", request.headers.host); //proxyLog.debug("request host " + request.headers.host);
   var headers = request.headers;
   var newHeaders = {};
+  const headersToRemove = requestProcessingOptions && Array.isArray(requestProcessingOptions.headersToRemove) ? requestProcessingOptions.headersToRemove : undefined;
   for (var propName in headers) {
     if (headers.hasOwnProperty(propName)) {
       proxyLog.debug("ZWED0167I", propName, headers[propName]); //proxyLog.debug("header["+propName+"]="+headers[propName]);
+      if (headersToRemove && headersToRemove.indexOf(propName) !== -1) {
+        continue;
+      }
       if (propName == "host"){
         newHeaders[propName] = realHost+":"+realPort;
       } else if (propName == "origin") {
@@ -63,12 +67,12 @@ function makeSimpleProxy(host, port, options, pluginID, serviceName) {
                     + `For information on how to configure a proxy service, see the Zowe wiki on dataservices `
                     + `(https://github.com/zowe/zlux/wiki/ZLUX-Dataservices)`);
   }
-  const {urlPrefix, isHttps, addProxyAuthorizations, processProxiedHeaders, allowInvalidTLSProxy, tlsOptions} = 
+  const {urlPrefix, isHttps, addProxyAuthorizations, processProxiedHeaders, allowInvalidTLSProxy, tlsOptions, requestProcessingOptions} = 
     options;
   const httpApi = isHttps? https : http;
   return function(req1, res1) {
     proxyLog.debug("ZWED0169I", req1.protocol, req1.get('host'), req1.url); //proxyLog.debug("Request: " + req1.protocol + '://' + req1.get('host') + req1.url);
-    const requestOptions = convertOptions(req1, host, port, urlPrefix);
+    const requestOptions = convertOptions(req1, host, port, urlPrefix, requestProcessingOptions);
     if (isHttps) {
       requestOptions.rejectUnauthorized = !allowInvalidTLSProxy;
       if (tlsOptions) {

--- a/lib/util.js
+++ b/lib/util.js
@@ -121,7 +121,10 @@ module.exports.getAgentRequestOptions = function(serverConfig, tlsOptions, inclu
         protocol: isHttps ? 'https:' : 'http:',
         rejectUnauthorized: !serverConfig.node.allowInvalidTLSProxy,
         apimlPrefix: apimlPrefix,
-        path: path ? apimlPrefix + path : undefined
+        path: path ? apimlPrefix + path : undefined,
+        requestProcessingOptions: {
+          headersToRemove: [ 'origin' ] // fixes issue with CORS in APIML
+        }
       }
     } else {
       options = {

--- a/lib/webapp.js
+++ b/lib/webapp.js
@@ -1188,7 +1188,8 @@ function getAgentProxyOptions(serverConfig, tlsOptions, includePrefix) {
 
   let options = {
     isHttps: requestOptions.protocol == 'https:' ? true : false,
-    allowInvalidTLSProxy: !requestOptions.rejectUnauthorized
+    allowInvalidTLSProxy: !requestOptions.rejectUnauthorized,
+    requestProcessingOptions: requestOptions.requestProcessingOptions
   }
   if (options.isHttps && !serverConfig.allowInvalidTLSProxy) {
     options.tlsOptions = tlsOptions;
@@ -1340,6 +1341,7 @@ WebApp.prototype = {
       port = requestOptions.port;
       options.urlPrefix = requestOptions.path;
       options.isHttps = requestOptions.protocol == 'https:';
+      options.requestProcessingOptions = requestOptions.requestProcessingOptions;
     }
     
     if (overrideOptions) {


### PR DESCRIPTION
## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->
This PR makes requests to zss work through APIML Gateway. The fix removes `origin` header from the HTTP request when accessing ZSS via APIML Gateway.

This PR addresses Issue: https://github.com/zowe/zlux/issues/640

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## PR Checklist
- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline]-
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Relevant update to CHANGELOG.md
- [x] My changes generate no new warnings

## Testing
```
ZWED_agent_mediationLayer_enabled=true
```


