### PR TITLE
Fix for "TypeError: Cannot convert undefined or null to object" when logLevels is undefined

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -439,10 +439,12 @@ Server.prototype = {
 
   restoreWorkerLogging() {
     global.COM_RS_COMMON_LOGGER.setLogLevelForComponentPattern("_zsf\..*",2);
-    let keys = Object.keys(this.userConfig.logLevels);
-    keys.forEach((key)=> {
-      global.COM_RS_COMMON_LOGGER.setLogLevelForComponentName(key, this.userConfig.logLevels[key]);
-    });
+    if (this.userConfig.logLevels) {
+      let keys = Object.keys(this.userConfig.logLevels);
+      keys.forEach((key)=> {
+        global.COM_RS_COMMON_LOGGER.setLogLevelForComponentName(key, this.userConfig.logLevels[key]);
+      });
+    }
   },
 
   newPluginSubmitted(pluginDef) {


### PR DESCRIPTION
## Proposed changes
This PR fixes the error that appears in the log when `logLevels` is undefined:
```
ZWED0151W - unhandledRejection TypeError: Cannot convert undefined or null to object
        at Function.keys (<anonymous>)
        at Server.restoreWorkerLogging (/ZOWE/staging/zowe/components/app-server/share/zlux-server-framework/lib/index.js:442:23)
        at Server.pluginLoadingFinished (/ZOWE/staging/zowe/components/app-server/share/zlux-server-framework/lib/index.js:428:12)
        at pluginLoaded.then (/ZOWE/staging/zowe/components/app-server/share/zlux-server-framework/lib/index.js:362:20)
        at tryCatcher (/ZOWE/staging/zowe/components/app-server/share/zlux-server-framework/node_modules/bluebird/js/release/util.js:16:23)
        at Promise._settlePromiseFromHandler (/ZOWE/staging/zowe/components/app-server/share/zlux-server-framework/node_modules/bluebird/js/release/promise.js:517:31)
        at Promise._settlePromise (/ZOWE/staging/zowe/components/app-server/share/zlux-server-framework/node_modules/bluebird/js/release/promise.js:574:18)
        at Promise._settlePromiseCtx (/ZOWE/staging/zowe/components/app-server/share/zlux-server-framework/node_modules/bluebird/js/release/promise.js:611:10)
        at _drainQueueStep (/ZOWE/staging/zowe/components/app-server/share/zlux-server-framework/node_modules/bluebird/js/release/async.js:142:12)
        at _drainQueue (/ZOWE/staging/zowe/components/app-server/share/zlux-server-framework/node_modules/bluebird/js/release/async.js:131:9)
        at Async._drainQueues (/ZOWE/staging/zowe/components/app-server/share/zlux-server-framework/node_modules/bluebird/js/release/async.js:147:5)
        at Immediate.Async.drainQueues (/ZOWE/staging/zowe/components/app-server/share/zlux-server-framework/node_modules/bluebird/js/release/async.js:17:14)
        at runCallback (timers.js:810:20)
        at tryOnImmediate (timers.js:768:5)
        at processImmediate [as _immediateCallback] (timers.js:745:5)
```


## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

