### PR TITLE
Remove unused metadata header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This repo is part of the app-server Zowe Component, and the change logs here may
 
 - Bugfix: Removed warning ZWED0144W about failure to read keyrings by having terminal proxy read the tls options loaded by the server instead of loading twice
 - Bugfix: Dynamic plugins could not be loaded due to parameter mismatch
+- Cleanup: Removed 'x-powered-by' header
 
 ## 1.22.0
 

--- a/lib/webapp.js
+++ b/lib/webapp.js
@@ -1252,6 +1252,7 @@ function WebApp(options){
   if (!cookieSecret) {
     cookieSecret = process.env.expressSessionSecret ? process.env.expressSessionSecret : 'whatever';
   }
+  this.expressApp.disable('x-powered-by');
   this.expressApp.use(cookieParser());
   this.expressApp.use(session({
     //TODO properly generate this secret


### PR DESCRIPTION

## Proposed changes
Removes 'x-powered-by' header as it is recommended not to disclose this sever info in general.

## Type of change
Please delete options that are not relevant.
- [x] Chore, repository cleanup, updates the dependencies.

## PR Checklist
Please delete options that are not relevant.
- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zlux/blob/master/CONTRIBUTING.md))
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [ ] video or image is included if visual changes are made
- [x] Relevant update to CHANGELOG.md
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works, or describe a test method below

## Testing
You can see if responses from the app-server do or do not contain the header 'x-powered-by' from before and after this patch. this patch should have the header missing.