### PR TITLE
Use log.severe instead of log.error for Eureka JS logger

### DIFF
--- a/lib/apiml.js
+++ b/lib/apiml.js
@@ -281,7 +281,7 @@ ApimlConnector.prototype = {
     const eurekaClient = new eureka(zluxProxyServerInstanceConfig);
     //this library has a very simple logger that has the same function names as ours, so why not just use ours for better formatting
     eurekaClient.logger = log;
-    let errorHandler = log.error;
+    let errorHandler = log.severe;
     let lastErrorMessage;
     let hideTimingError = (...args) => {
       if (args[0] == 'Problem making eureka request' || args[0] == 'Eureka request failed to endpoint') {


### PR DESCRIPTION
## Proposed changes
This PR fixes the logger that we provide for Eureka Node JS client. The `error` method on the logger was linked to non-exsting `error` method on zlux logger. `severe` is correct method name to use. 

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Change in a documentation
- [ ] Refactor the code 
- [ ] Chore, repository cleanup, updates the dependencies.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## PR Checklist
Please delete options that are not relevant.
- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zlux/blob/master/CONTRIBUTING.md))
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
- [ ] video or image is included if visual changes are made
- [ ] Relevant update to CHANGELOG.md
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works, or describe a test method below

