### PR TITLE
Add nonce csp capability

### DIFF
--- a/lib/webapp.js
+++ b/lib/webapp.js
@@ -199,6 +199,10 @@ function getPresetHeader(name, preset, req) {
       return `default-src 'self' ${req.hostname};`;
     } else if (preset == 'frame-strict') {
       return `frame-src 'self' ${req.hostname};`;
+    } else if (preset == 'script-nonce') {
+      let nonce=crypto.randomBytes(16).toString('hex');
+      req.nonce=nonce;
+      return `script-src 'nonce-${nonce}' 'strict-dynamic' 'unsafe-eval'`;
     }
     break;
   }
@@ -1425,7 +1429,9 @@ WebApp.prototype = {
         res.redirect(rootPage);
       });
     }
-    this.expressApp.use(rootPage, express.static(webdir));
+    if (fs.existsSync(webdir)) {
+      this.expressApp.use(rootPage, express.static(webdir));
+    }
   },
 
   installCommonMiddleware() {
@@ -1840,9 +1846,28 @@ WebApp.prototype = {
         }
         middleware.push(commonMiddleware.customHeaderInjection(headersArray));
       }
-      middleware.push(expressStaticGzip(path.join(plugin.location, '/web'),
+      let webMiddleware = middleware.slice();
+      webMiddleware.push(expressStaticGzip(path.join(plugin.location, '/web'),
                                         {enableBrotli: true, orderPreference: ['br', 'gzip']}));
-      this.pluginRouter.use(url, middleware);
+
+      //Used to replace nonce template with server value
+      if (fs.existsSync(path.join(plugin.location, 'web', 'index.html')) && plugin.webContent.headers) {
+        let indexMiddleware = middleware.slice();
+        indexMiddleware.push((req,res,next)=>{
+          console.log(`nonce=${req.nonce} and path=${req.path}`);
+          if (req.nonce && (req.path == '/' || req.path == '/index.html')) {
+            fs.readFile(path.join(plugin.location, 'web', 'index.html'), {encoding: 'utf8'}, (err, data)=> {
+              res.status(200).send(data.replace('nonce="{{nonce}}', 'nonce="'+req.nonce));
+            });
+          } else { next() }
+        });
+        indexMiddleware.push(expressStaticGzip(path.join(plugin.location, '/web'),
+                                               {enableBrotli: true, orderPreference: ['br', 'gzip']}));
+        this.pluginRouter.use(url, indexMiddleware);
+      //but if no template candidate, skip that for performance.
+      } else {
+        this.pluginRouter.use(url, webMiddleware);
+      }
     }
     if (plugin.pluginType === "library") {
       if (plugin.libraryVersion) {


### PR DESCRIPTION
This PR adds the ability for plugins to request use of a csp nonce and have their primary html be a template in which the nonce value is filled in when sent. This should allow plugins such as the desktop to be able to use a nonce in csp rules. Alternative CSP settings could be added in the future to use nonce in more situations.