### PR TITLE
Set cookies to be samesite rather than using referrer check

### DIFF
--- a/lib/webapp.js
+++ b/lib/webapp.js
@@ -73,8 +73,9 @@ const ZLUX_LOOPBACK_HEADER = 'X-ZLUX-Loopback';
 const proxyMap = new Map();
 
 
-
-const SHOULD_CHECK_REFERRER = process.env.ZWE_CHECK_REFERRER !== undefined ? (process.env.ZWE_CHECK_REFERRER != "false") : true;
+//Referrer check used to be done for security, but the same thing can be accomplished in a much less obtrusive way
+// via samesite attribute of cookies, which all supported browsers support
+const SHOULD_CHECK_REFERRER = process.env.ZWE_CHECK_REFERRER !== undefined ? (process.env.ZWE_CHECK_REFERRER == "true") : false;
 
 function DataserviceContext(serviceDefinition, serviceConfiguration, 
     pluginContext, webapp) {
@@ -1266,7 +1267,8 @@ function WebApp(options){
     store: require("./sessionStore").sessionStore,
     resave: true, saveUninitialized: false,
     cookie: {
-      secure: 'auto'
+      secure: 'auto',
+      sameSite: true
     }
   }));
   this.loopbackSecret = process.env.loopbackSecret ? process.env.loopbackSecret : 'different';

--- a/lib/webauth.js
+++ b/lib/webauth.js
@@ -253,6 +253,7 @@ module.exports = function(authManager, cookiePort, isSecurePort) {
       req.session.id = null;
       res.clearCookie(cookieName, { path: '/',
                                                    httpOnly: true,
+                                                   sameSite: true,
                                                    secure: isSecurePort});
     }
 

--- a/plugins/sso-auth/lib/zssHandler.js
+++ b/plugins/sso-auth/lib/zssHandler.js
@@ -150,6 +150,7 @@ class ZssHandler {
        value:'non-token',
        options: {httpOnly: true,
                  secure: true,
+                 sameSite: true,
                  expires: new Date(1)}}
     ]
   }
@@ -209,7 +210,7 @@ class ZssHandler {
             expiresMs = expiresSec == -1 ? expiresSec : Number(expiresSec)*1000;
           }
           resolve({ success: true, username: sessionState.username, expms: expiresMs,
-                    cookies: [{name:COOKIE_NAME, value:cookieValue, options: {httpOnly: true, secure: true, encode: String}}]});
+                    cookies: [{name:COOKIE_NAME, value:cookieValue, options: {httpOnly: true, secure: true, sameSite: true, encode: String}}]});
         } else {
           let res = { success: false, error: {message: `ZSS ${response.statusCode} ${response.statusMessage}`}};
           if (response.statusCode === 500) {


### PR DESCRIPTION
Referrer-based checking has been annoying when external host names dont match what is expected, and with all supported browsers now supporting samesite cookie attribute, it seems to be a more elegant way to do the same thing so that users do not need to mess with their config to have proper checks being done.
