### PR TITLE
Remove need for loopback when using callService, callRootService

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This repo is part of the app-server Zowe Component, and the change logs here may
 - Enhancement: Updated proxy utility to treat PATCH similarly to PUT and POST
 - Cleanup: Removed 'x-powered-by' header
 - Enhancement: Get list of Discovery Services using environment variable, and provide the list for Eureka JS Client, in order to have it failover connection to the next one on the list when the one its currently talking to fails.
+- Enhancement: dataservice command callRootService now calls agent directly if root service originated from the app-server agent. This should improve performance and reduce scenarios where loopback activity is needed.
 
 ## 1.22.0
 

--- a/lib/webapp.js
+++ b/lib/webapp.js
@@ -847,12 +847,13 @@ const staticHandlers = {
  *  This is passed to every other service of the plugin, so that 
  *  the service can be called by other services under the plugin
  */
-function WebServiceHandle(urlPrefix, environment) {
+function WebServiceHandle(urlPrefix, environment, isAgentService) {
   this.urlPrefix = urlPrefix;
   if (!environment.loopbackConfig.port) {
     installLog.severe(`ZWED0003E`, loopbackConfig); //installLog.severe(`loopback configuration not valid,`,loopbackConfig, `loopback calls will fail!`);
   }
   this.environment = environment;
+  this.isAgentService = isAgentService;
 }
 WebServiceHandle.prototype = {
   constructor: WebServiceHandle,
@@ -925,7 +926,24 @@ WebServiceHandle.prototype = {
       if (Object.getOwnPropertyNames(headers).length > 0) {
         requestOptions.headers = headers;
       }
-      let httpOrHttps = this.environment.loopbackConfig.isHttps ? https : http;
+
+      let httpOrHttps;
+      if (this.isAgentService) {
+        requestOptions.hostname = this.environment.agentRequestOptions.host;
+        requestOptions.port = this.environment.agentRequestOptions.port;
+        requestOptions.protocol = this.environment.agentRequestOptions.protocol;
+        requestOptions.rejectUnauthorized = this.environment.agentRequestOptions.rejectUnauthorized;
+        if (this.environment.agentRequestOptions.apimlPrefix) {
+          requestOptions.path = this.environment.agentRequestOptions.apimlPrefix + requestOptions.path;
+        }
+        httpOrHttps = requestOptions.protocol == 'http:' ? http : https;
+        console.log(`call agent direct`, requestOptions.path, requestOptions.hostname);
+
+      } else {
+        console.log(`call loopback`, requestOptions.path);
+        //loopback call to get to router
+        httpOrHttps = this.environment.loopbackConfig.isHttps ? https : http;
+      }
       const request = httpOrHttps.request(requestOptions, (response) => {
         var chunks = [];
         response.on('data',(chunk)=> {
@@ -977,7 +995,7 @@ const commonMiddleware = {
       	appData.webApp = Object.create(appData.webApp);
       }
       appData.webApp.callRootService = function callRootService(name, url, 
-          options) {
+                                                                options) {
         if (!this.rootServices[name]) {
           throw new Error(`ZWED0050E - Root service ${name} not found`);
         }
@@ -1279,7 +1297,8 @@ function WebApp(options){
   this.setValidReferrers(options.serverConfig.node);
 
   this.wsEnvironment = {
-    loopbackConfig: this.loopbackConfig
+    loopbackConfig: this.loopbackConfig,
+    agentRequestOptions: zluxUtil.getAgentRequestOptions(options.serverConfig, options.tlsOptions, false)
   }
   this.options = zluxUtil.makeOptionsObject(defaultOptions, options);
   this.auth = options.auth;
@@ -1485,7 +1504,7 @@ WebApp.prototype = {
         this.expressApp.use(proxiedRootService.url, rootServicesMiddleware, this.auth.middleware, middlewareArray);
       }
       serviceHandleMap[name] = new WebServiceHandle(proxiedRootService.url, 
-          this.wsEnvironment);
+                                                    this.wsEnvironment, true);
     }
     this.expressApp.use(rootServicesMiddleware);
     


### PR DESCRIPTION
Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>

<!-- Thank you for submitting a PR to Zowe! To help us understand, test, and give feedback on your code, please fill in the details below. -->

## Proposed changes
callService and callRootService currently do a loopback where there's a request from app-server to itself in order to reach the right part of the code to handle a request. This is overhead and causes ip config complications about how app-server reaches itself.
This PR fixes the problem in two ways.
1) agent-bound routes no longer need loopback, as the call is direct. This may solve situations such as https://github.com/zowe/zlux/issues/676
2) inter-server requests can be handled internally by mimicking a network request, providing the right url, method, headers and body to the router function attached to expressjs

*Note* 2, inter-server direct routing is disabled here for compatibility. It should be very compatible, but just dont want to disrupt behavior in v1. In zowe v2, we should switch this to enabled by default. The behavior can be enabled by setting the property `node.internalRouting=true` in the server config.

## Type of change
Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

## PR Checklist
Please delete options that are not relevant.
- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zlux/blob/master/CONTRIBUTING.md))
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [ ] video or image is included if visual changes are made
- [x] Relevant update to CHANGELOG.md
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works, or describe a test method below

## Testing
Case 1)
To test, you should be attempting login to desktop with and without apiml.
Without apiml, the code should contact zss directly. With apiml, it should contact apiml to contact zss.
If login succeeds in both cases, then this is working.

Case 2)
Test inter-plugin service calls using this PR https://github.com/zowe/sample-angular-app/pull/62
I sent a small message in postman and observed the following to prove it was working:
```
2021-08-02 13:00:58.826 <ZWED:2060> me DEBUG (_zsf.routing,webapp.js:1246) ZWED0198I - : Service called: org.zowe.zlux.sample.angular::callservice, POST /
2021-08-02 13:00:58.826 <ZWED:2060> me INFO (org.zowe.zlux.sample.angular:callservice,callService.js:19) Saw request, method=POST
2021-08-02 13:00:58.833 <ZWED:2060> me DEBUG (_zsf.routing,webapp.js:943) Call internally path=/ZLUX/plugins/org.zowe.zlux.sample.angular/services/hello/1.0.1
2021-08-02 13:00:58.834 <ZWED:2060> me DEBUG (_zsf.routing,webapp.js:1246) ZWED0198I - : Service called: org.zowe.zlux.sample.angular::hello, POST /
2021-08-02 13:00:58.834 <ZWED:2060> me INFO (org.zowe.zlux.sample.angular:hello,helloWorld.js:21) Saw request, method=POST
2021-08-02 13:00:58.835 <ZWED:2060> me INFO (org.zowe.zlux.sample.angular:callservice,callService.js:25) callService Returned: statusCode=200, statusMessage=OK, body length=288
```

![image](https://user-images.githubusercontent.com/30730276/127869992-8c993156-f64d-4908-b8e1-39b53ec0a89b.png)


## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, or if there are follow-up tasks and TODOs etc... -->
