### PR TITLE
direct routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to the Zlux Server Framework package will be documented in this file.
 This repo is part of the app-server Zowe Component, and the change logs here may appear on Zowe.org in that section.
 
+## 1.25.0
+
+- Enhancement: Improved callRootService when targeting agents such as ZSS to issue the request direct to the destination rather than using an additional loopback request to the app-server first. This should improve performance, reduce the need for the app-server being a client of itself, and allow for more request options when calling the agent.
+- Enhancement: Allow timeout parameter to be specified in a callService or callRootService command, such as when needing a long timeout to request an agent response.
+- Enhancement: Removed need for app-server to be a client of itself when using the callService API, by adding the option for requests to this API to be executed internal to app-server. This option is very compatible with pre-existing use of callService but is disabled by default to avoid disruption. You can enable it by setting the server configuration property `node.internalRouting=true`
+
 ## 1.24.0
 
 - Bugfix: Fixed issue where server could not bind to a hostname value for node.https.ipAddresses

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This repo is part of the app-server Zowe Component, and the change logs here may
 - Enhancement: Updated proxy utility to treat PATCH similarly to PUT and POST
 - Cleanup: Removed 'x-powered-by' header
 - Enhancement: Get list of Discovery Services using environment variable, and provide the list for Eureka JS Client, in order to have it failover connection to the next one on the list when the one its currently talking to fails.
+- Enhancement: dataservice command callRootService now calls agent directly if root service originated from the app-server agent. This should improve performance and reduce scenarios where loopback activity is needed.
 
 ## 1.22.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,6 @@ This repo is part of the app-server Zowe Component, and the change logs here may
 - Enhancement: Updated proxy utility to treat PATCH similarly to PUT and POST
 - Cleanup: Removed 'x-powered-by' header
 - Enhancement: Get list of Discovery Services using environment variable, and provide the list for Eureka JS Client, in order to have it failover connection to the next one on the list when the one its currently talking to fails.
-- Enhancement: dataservice command callRootService now calls agent directly if root service originated from the app-server agent. This should improve performance and reduce scenarios where loopback activity is needed.
 
 ## 1.22.0
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -218,6 +218,7 @@ Server.prototype = {
       hostname: this.userConfig.node.hostname ? this.userConfig.node.hostname : os.hostname(),
       httpPort: httpPort,
       httpsPort: httpsPort,
+      internalRouting: this.userConfig.node.internalRouting,
       productCode: this.appConfig.productCode,
       productDir: this.userConfig.productDir,
       proxiedHost: this.startUpConfig.proxiedHost,

--- a/lib/webapp.js
+++ b/lib/webapp.js
@@ -847,12 +847,13 @@ const staticHandlers = {
  *  This is passed to every other service of the plugin, so that 
  *  the service can be called by other services under the plugin
  */
-function WebServiceHandle(urlPrefix, environment) {
+function WebServiceHandle(urlPrefix, environment, isAgentService) {
   this.urlPrefix = urlPrefix;
   if (!environment.loopbackConfig.port) {
     installLog.severe(`ZWED0003E`, loopbackConfig); //installLog.severe(`loopback configuration not valid,`,loopbackConfig, `loopback calls will fail!`);
   }
   this.environment = environment;
+  this.isAgentService = isAgentService;
 }
 WebServiceHandle.prototype = {
   constructor: WebServiceHandle,
@@ -925,7 +926,24 @@ WebServiceHandle.prototype = {
       if (Object.getOwnPropertyNames(headers).length > 0) {
         requestOptions.headers = headers;
       }
-      let httpOrHttps = this.environment.loopbackConfig.isHttps ? https : http;
+
+      let httpOrHttps;
+      if (this.isAgentService) {
+        requestOptions.hostname = this.environment.agentRequestOptions.host;
+        requestOptions.port = this.environment.agentRequestOptions.port;
+        requestOptions.protocol = this.environment.agentRequestOptions.protocol;
+        requestOptions.rejectUnauthorized = this.environment.agentRequestOptions.rejectUnauthorized;
+        if (this.environment.agentRequestOptions.apimlPrefix) {
+          requestOptions.path = this.environment.agentRequestOptions.apimlPrefix + requestOptions.path;
+        }
+        httpOrHttps = requestOptions.protocol == 'http:' ? http : https;
+        console.log(`call agent direct`, requestOptions.path, requestOptions.hostname);
+
+      } else {
+        console.log(`call loopback`, requestOptions.path);
+        //loopback call to get to router
+        httpOrHttps = this.environment.loopbackConfig.isHttps ? https : http;
+      }
       const request = httpOrHttps.request(requestOptions, (response) => {
         var chunks = [];
         response.on('data',(chunk)=> {
@@ -977,7 +995,7 @@ const commonMiddleware = {
       	appData.webApp = Object.create(appData.webApp);
       }
       appData.webApp.callRootService = function callRootService(name, url, 
-          options) {
+                                                                options) {
         if (!this.rootServices[name]) {
           throw new Error(`ZWED0050E - Root service ${name} not found`);
         }
@@ -1279,7 +1297,8 @@ function WebApp(options){
   this.setValidReferrers(options.serverConfig.node);
 
   this.wsEnvironment = {
-    loopbackConfig: this.loopbackConfig
+    loopbackConfig: this.loopbackConfig,
+    agentRequestOptions: zluxUtil.getAgentRequestOptions(options.serverConfig, options.tlsOptions, false)
   }
   this.options = zluxUtil.makeOptionsObject(defaultOptions, options);
   this.auth = options.auth;
@@ -1485,7 +1504,7 @@ WebApp.prototype = {
         this.expressApp.use(proxiedRootService.url, rootServicesMiddleware, this.auth.middleware, middlewareArray);
       }
       serviceHandleMap[name] = new WebServiceHandle(proxiedRootService.url, 
-          this.wsEnvironment);
+                                                    this.wsEnvironment, true);
     }
     this.expressApp.use(rootServicesMiddleware);
     

--- a/lib/webapp.js
+++ b/lib/webapp.js
@@ -938,9 +938,9 @@ WebServiceHandle.prototype = {
           requestOptions.path = this.environment.agentRequestOptions.apimlPrefix + requestOptions.path;
         }
         httpOrHttps = requestOptions.protocol == 'http:' ? http : https;
-        routingLog.info(`Call agent host=%s path=%s`,requestOptions.hostname, requestOptions.path);
+        routingLog.debug(`Call agent host=%s path=%s`,requestOptions.hostname, requestOptions.path);
       } else if (options.internalRouting) {
-        routingLog.info(`Call internally path=%s`, requestOptions.path);
+        routingLog.debug(`Call internally path=%s`, requestOptions.path);
         //clone done to prevent original request alteration, but shallow so hope attributes arent altered
         let req = Object.assign({},originalRequest);
         let res = Object.assign({},originalRes);
@@ -980,7 +980,7 @@ WebServiceHandle.prototype = {
         }
         expressApp._router.handle(req, res);
       } else {
-        routingLog.info(`Call loopback path=%s`, requestOptions.path);
+        routingLog.debug(`Call loopback path=%s`, requestOptions.path);
         //loopback call to get to router
         if (options.zluxLoopbackSecret) {
           //TODO use secret in a crypto scheme

--- a/lib/webapp.js
+++ b/lib/webapp.js
@@ -14,6 +14,9 @@
 const express = require('express');
 const expressApp = express();
 
+//for internal routing fill
+const status = require('statuses');
+
 const fs = require('fs');
 const util = require('util');
 const url = require('url');
@@ -867,7 +870,7 @@ WebServiceHandle.prototype = {
   port: 0,
   urlPrefix: null,
 
-  call(path, options, originalRequest) {
+  call(path, options, originalRequest, originalRes) {
     return new Promise((resolve, reject) => {
       if (typeof path === "object") {
         options = path;
@@ -893,6 +896,7 @@ WebServiceHandle.prototype = {
         protocol: protocol,
         path: url,
         auth: options.auth,
+        timeout: options.timeout,
         rejectUnauthorized: rejectUnauthorized
       };
       const headers = {};
@@ -906,8 +910,10 @@ WebServiceHandle.prototype = {
       if (options.body) {
         if (typeof options.body === "string") {
           if (options.contentType) {
+            console.log('case1');
             headers["Content-Type"] = options.contentType;
           } else {
+            console.log('case2');
             headers["Content-Type"] = "application/json";
           }
           headers["Content-Length"] =  options.body.length;
@@ -917,10 +923,8 @@ WebServiceHandle.prototype = {
           headers["Content-Length"] =  json.length;
           options.body = json;
         }
-      }
-      if (options.zluxLoopbackSecret) {
-        //TODO use secret in a crypto scheme
-        headers[ZLUX_LOOPBACK_HEADER] = options.zluxLoopbackSecret;
+      } else {
+        console.log('no body');
       }
       //console.log("headers: ", headers)
       if (Object.getOwnPropertyNames(headers).length > 0) {
@@ -937,36 +941,90 @@ WebServiceHandle.prototype = {
           requestOptions.path = this.environment.agentRequestOptions.apimlPrefix + requestOptions.path;
         }
         httpOrHttps = requestOptions.protocol == 'http:' ? http : https;
-        console.log(`call agent direct`, requestOptions.path, requestOptions.hostname);
+        routingLog.info(`Call agent host=%s path=%s`,requestOptions.hostname, requestOptions.path);
+      } else if (options.internalRouting) {
+        routingLog.info(`Call internally path=%s`, requestOptions.path);
+        //hope shallow clone doesnt matter here
+        let req = Object.assign({},originalRequest);
+        req.url = req.originalUrl = requestOptions.path;
+        req.headers = requestOptions.headers;
+        req.rawHeaders=[];
+        let keys = Object.keys(req.headers);
+        for (let i = 0; i < keys.length; i++) {
+          let k = keys[i];
+          let v = req.headers[keys[i]];
+          req.rawHeaders.push(k);
+          req.rawHeaders.push(v);
+          delete req.headers[k];
+          req.headers[k.toLowerCase()]=v;
+          
+        }
+        console.log('headers in=',req.headers);
+        req.body = options.body;
+        delete req._body;
+        if (!req.headers['content-length']) {
+          req.headers['content-length']='0';
+        }
+        console.log('reqlen=',req.length);
+        
+        req.method = requestOptions.method;
+        let res = Object.assign({},originalRes);
+//        let originalSetHeader = res.setHeader;
 
+        /*
+        res.headers = {};
+        res.setHeader = (k,v) => {
+          res.headers[k]=v;
+        }
+        */
+
+        res.end = (body)=> {
+          utilLog.debug('router returned with body=',body.length);
+          res.body = body;
+          if (!res.statusMessage) {
+            res.statusMessage = status[res.statusCode];
+          }
+          resolve(res);
+        }
+        expressApp._router.handle(req, res);
+//        req.write(body);
+//        req.end()
       } else {
-        console.log(`call loopback`, requestOptions.path);
+        routingLog.info(`Call loopback path=%s`, requestOptions.path);
         //loopback call to get to router
+        if (options.zluxLoopbackSecret) {
+          //TODO use secret in a crypto scheme
+          headers[ZLUX_LOOPBACK_HEADER] = options.zluxLoopbackSecret;
+        }
+
         httpOrHttps = this.environment.loopbackConfig.isHttps ? https : http;
       }
-      const request = httpOrHttps.request(requestOptions, (response) => {
-        var chunks = [];
-        response.on('data',(chunk)=> {
-          utilLog.debug('ZWED0194I'); //utilLog.debug('Callservice: Data received');
-          chunks.push(chunk);
+      //if not internal routing
+      if (httpOrHttps) {
+        const request = httpOrHttps.request(requestOptions, (response) => {
+          var chunks = [];
+          response.on('data',(chunk)=> {
+            utilLog.debug('ZWED0194I'); //utilLog.debug('Callservice: Data received');
+            chunks.push(chunk);
+          });
+          response.on('end',() => {
+            utilLog.debug('ZWED0195I'); //utilLog.debug('Callservice: Service call completed.');
+            response.body = Buffer.concat(chunks).toString();
+            resolve(response);
+          });
+        }
+                                           );
+        request.on('error', (e) => {
+          utilLog.warn('ZWED0061W'); //utilLog.warn('Callservice: Service call failed.');
+          reject(e);
         });
-        response.on('end',() => {
-          utilLog.debug('ZWED0195I'); //utilLog.debug('Callservice: Service call completed.');
-          response.body = Buffer.concat(chunks).toString();
-          resolve(response);
-        });
+        if (options.body) {
+          request.write(options.body);
+        }
+        utilLog.debug('ZWED0196I', JSON.stringify(requestOptions, null, 2)); //utilLog.debug('Callservice: Issuing request to service: ' 
+        //+ JSON.stringify(requestOptions, null, 2));
+        request.end();
       }
-      );
-      request.on('error', (e) => {
-        utilLog.warn('ZWED0061W'); //utilLog.warn('Callservice: Service call failed.');
-        reject(e);
-      });
-      if (options.body) {
-        request.write(options.body);
-      }
-      utilLog.debug('ZWED0196I', JSON.stringify(requestOptions, null, 2)); //utilLog.debug('Callservice: Issuing request to service: ' 
-          //+ JSON.stringify(requestOptions, null, 2));
-      request.end();
     }
     );
   }
@@ -982,7 +1040,7 @@ const commonMiddleware = {
    * authentication data on: we'll do that
    */
   
-  addAppSpecificDataToRequest(globalAppData, loopbackSecret) {
+  addAppSpecificDataToRequest(globalAppData, loopbackSecret, internalRouting) {
     return function addAppSpecificData(req, res, next) {
       const appData = Object.create(globalAppData);
       if (!req[`${constants.APP_NAME}Data`]) {
@@ -1022,7 +1080,8 @@ const commonMiddleware = {
           const service = allHandles[version];
           options = options || {};
           options.zluxLoopbackSecret = loopbackSecret;
-          return service.call(url, options, req);
+          options.internalRouting = internalRouting;
+          return service.call(url, options, req, res);
         } catch (e) {
           return Promise.reject(e);
         }
@@ -1452,7 +1511,7 @@ WebApp.prototype = {
 
   installCommonMiddleware() {
     this.expressApp.use(commonMiddleware.addAppSpecificDataToRequest(
-      this.appData, this.loopbackSecret));
+      this.appData, this.loopbackSecret, this.options.internalRouting));
   },
 
   _installRootService(url, method, handler, {needJson, needAuth, authType, isPseudoSso}) {

--- a/lib/webapp.js
+++ b/lib/webapp.js
@@ -16,6 +16,7 @@ const expressApp = express();
 
 //for internal routing fill
 const status = require('statuses');
+const iconv = require('iconv-lite');
 
 const fs = require('fs');
 const util = require('util');
@@ -910,10 +911,8 @@ WebServiceHandle.prototype = {
       if (options.body) {
         if (typeof options.body === "string") {
           if (options.contentType) {
-            console.log('case1');
             headers["Content-Type"] = options.contentType;
           } else {
-            console.log('case2');
             headers["Content-Type"] = "application/json";
           }
           headers["Content-Length"] =  options.body.length;
@@ -923,8 +922,6 @@ WebServiceHandle.prototype = {
           headers["Content-Length"] =  json.length;
           options.body = json;
         }
-      } else {
-        console.log('no body');
       }
       //console.log("headers: ", headers)
       if (Object.getOwnPropertyNames(headers).length > 0) {
@@ -944,9 +941,12 @@ WebServiceHandle.prototype = {
         routingLog.info(`Call agent host=%s path=%s`,requestOptions.hostname, requestOptions.path);
       } else if (options.internalRouting) {
         routingLog.info(`Call internally path=%s`, requestOptions.path);
-        //hope shallow clone doesnt matter here
+        //clone done to prevent original request alteration, but shallow so hope attributes arent altered
         let req = Object.assign({},originalRequest);
+        let res = Object.assign({},originalRes);
+
         req.url = req.originalUrl = requestOptions.path;
+        req.method = requestOptions.method;
         req.headers = requestOptions.headers;
         req.rawHeaders=[];
         let keys = Object.keys(req.headers);
@@ -959,36 +959,26 @@ WebServiceHandle.prototype = {
           req.headers[k.toLowerCase()]=v;
           
         }
-        console.log('headers in=',req.headers);
-        req.body = options.body;
-        delete req._body;
+
+        if (options.body) {
+          req._body=options.body;
+        } else {
+          delete req._body;
+        }
         if (!req.headers['content-length']) {
           req.headers['content-length']='0';
         }
-        console.log('reqlen=',req.length);
         
-        req.method = requestOptions.method;
-        let res = Object.assign({},originalRes);
-//        let originalSetHeader = res.setHeader;
-
-        /*
-        res.headers = {};
-        res.setHeader = (k,v) => {
-          res.headers[k]=v;
-        }
-        */
 
         res.end = (body)=> {
           utilLog.debug('router returned with body=',body.length);
-          res.body = body;
+          res.body = iconv.decode(body,'utf8');
           if (!res.statusMessage) {
             res.statusMessage = status[res.statusCode];
           }
           resolve(res);
         }
         expressApp._router.handle(req, res);
-//        req.write(body);
-//        req.end()
       } else {
         routingLog.info(`Call loopback path=%s`, requestOptions.path);
         //loopback call to get to router


### PR DESCRIPTION
Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>

<!-- Thank you for submitting a PR to Zowe! To help us understand, test, and give feedback on your code, please fill in the details below. -->

## Proposed changes
callService and callRootService currently do a loopback where there's a request from app-server to itself in order to reach the right part of the code to handle a request. This is overhead and causes ip config complications about how app-server reaches itself.
This PR fixes the problem in two ways.
1) agent-bound routes no longer need loopback, as the call is direct. This may solve situations such as https://github.com/zowe/zlux/issues/676
2) inter-server requests can be handled internally by mimicking a network request, providing the right url, method, headers and body to the router function attached to expressjs

*Note* 2, inter-server direct routing is disabled here for compatibility. It should be very compatible, but just dont want to disrupt behavior in v1. In zowe v2, we should switch this to enabled by default. The behavior can be enabled by setting the property `node.internalRouting=true` in the server config.

## Type of change
Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

## PR Checklist
Please delete options that are not relevant.
- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zlux/blob/master/CONTRIBUTING.md))
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [ ] video or image is included if visual changes are made
- [x] Relevant update to CHANGELOG.md
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works, or describe a test method below

## Testing
Case 1)
To test, you should be attempting login to desktop with and without apiml.
Without apiml, the code should contact zss directly. With apiml, it should contact apiml to contact zss.
If login succeeds in both cases, then this is working.

Case 2)
Test inter-plugin service calls using this PR https://github.com/zowe/sample-angular-app/pull/62
I sent a small message in postman and observed the following to prove it was working:
```
2021-08-02 13:00:58.826 <ZWED:2060> me DEBUG (_zsf.routing,webapp.js:1246) ZWED0198I - : Service called: org.zowe.zlux.sample.angular::callservice, POST /
2021-08-02 13:00:58.826 <ZWED:2060> me INFO (org.zowe.zlux.sample.angular:callservice,callService.js:19) Saw request, method=POST
2021-08-02 13:00:58.833 <ZWED:2060> me DEBUG (_zsf.routing,webapp.js:943) Call internally path=/ZLUX/plugins/org.zowe.zlux.sample.angular/services/hello/1.0.1
2021-08-02 13:00:58.834 <ZWED:2060> me DEBUG (_zsf.routing,webapp.js:1246) ZWED0198I - : Service called: org.zowe.zlux.sample.angular::hello, POST /
2021-08-02 13:00:58.834 <ZWED:2060> me INFO (org.zowe.zlux.sample.angular:hello,helloWorld.js:21) Saw request, method=POST
2021-08-02 13:00:58.835 <ZWED:2060> me INFO (org.zowe.zlux.sample.angular:callservice,callService.js:25) callService Returned: statusCode=200, statusMessage=OK, body length=288
```

![image](https://user-images.githubusercontent.com/30730276/127869992-8c993156-f64d-4908-b8e1-39b53ec0a89b.png)


## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, or if there are follow-up tasks and TODOs etc... -->
