### PR TITLE
Two user-found bugfixes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to the Zlux Server Framework package will be documented in this file.
 This repo is part of the app-server Zowe Component, and the change logs here may appear on Zowe.org in that section.
 
+## 1.24.0
+
+- Bugfix: Fixed issue where server could not bind to a hostname value for node.https.ipAddresses
+- Bugfix: Fixed issue where if the server started slowly, a timeout at cluster storage setup could be encountered.
+
 ## 1.23.0
 
 - Bugfix: Removed warning ZWED0144W about failure to read keyrings by having terminal proxy read the tls options loaded by the server instead of loading twice

--- a/lib/clusterManager.js
+++ b/lib/clusterManager.js
@@ -680,8 +680,14 @@ if (cluster.isMaster) {
         return resultHandler[0];
       },
       function(e) {
-        clusterLogger.warn("ZWED0167W - Error adding to the storage: " + e);
-      }
+        if (e.startsWith('Timeout call')) {
+          clusterLogger.severe("ZWED0144E - Cluster storage object timeout." +
+                               "\nYou may change the value of '" + storageTimeout + "' ms by setting 'node.cluster.storageTimeout' within the config.");
+        } else {
+          clusterLogger.warn("ZWED0167W - Error adding to the storage: " + e);
+        }
+      }, storageTimeout /* We need to give ample timeout time since this method is used to verify
+      the completion of cluster storage initialization in webapp.js, Default: 30 seconds */
     );
   }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -70,10 +70,16 @@ function Server(appConfig, userConfig, startUpConfig, configLocation) {
     port = userConfig.node.http.port;
     typeString = 'http://'
   }
-  const address = ipaddr.process(addr);
-  if (address.range() == 'multicast') {
-    addr = '127.0.0.1';
+
+  try {
+    const address = ipaddr.process(addr);
+    if (address.range() == 'multicast') {
+      addr = '127.0.0.1';
+    }
+  } catch (e) {
+    bootstrapLogger.debug("IP address binding is not a valid IP. Is it a hostname?",addr);
   }
+  
   let serverUrl = typeString+addr+':'+port;
   let langManagers = [];
   this.langManagers = langManagers;


### PR DESCRIPTION
Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>

<!-- Thank you for submitting a PR to Zowe! To help us understand, test, and give feedback on your code, please fill in the details below. -->

## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

This fixes 2 problems found by users: 
1) timeout can occur at cluster storage init because something we thought would never take a long time did.
2) we have a regression where the server cannot bind to a hostname. this fixes it.

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

## PR Checklist
Please delete options that are not relevant.
- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zlux/blob/master/CONTRIBUTING.md))
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] Relevant update to CHANGELOG.md
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works, or describe a test method below

## Testing
<!-- Describe how this code should be tested. I've you've added an automated or unit test, then describe how to run it. Otherwise, describe how you have tested it and how others should test it. -->
Testing the cluster timeout is difficult because it was only reproduced on a slow system, but testing the hostname fix is easy: set node.http.ipAddresses to a hostname rather than IP, and watch as before the server would throw and exception. With this fix the server will load after it resolves the hostname to ip via dns.

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, or if there are follow-up tasks and TODOs etc... -->
