### PR TITLE
Ability to enable TLS trace

### DIFF
--- a/lib/webserver.js
+++ b/lib/webserver.js
@@ -309,7 +309,10 @@ WebServer.prototype = {
         this.httpsOptions.ciphers = ciphers;
       }
       bootstrapLogger.debug('Using tls ciphers:',this.httpsOptions.ciphers);
-      
+      if (options.enableTrace) {
+        this.httpsOptions.enableTrace = true;
+      }
+      bootstrapLogger.debug('TLS trace:', this.httpsOptions.enableTrace ? 'enabled' : 'disabled');
       readTlsOptionsFromConfig(this.config, this.httpsOptions);
     }
   },


### PR DESCRIPTION
## Proposed changes

This PR adds ability to enable TLS trace. New environment variable that controls the TLS trace is
```bash
ZWED_node_https_enableTrace=true
```

## Type of change
Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

## PR Checklist
Please delete options that are not relevant.
- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zlux/blob/master/CONTRIBUTING.md))

