### PR TITLE
Enable app-server to reach apiml when in kubernetes if using self-signed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This repo is part of the app-server Zowe Component, and the change logs here may
 - Enhancement: Improved callRootService when targeting agents such as ZSS to issue the request direct to the destination rather than using an additional loopback request to the app-server first. This should improve performance, reduce the need for the app-server being a client of itself, and allow for more request options when calling the agent.
 - Enhancement: Allow timeout parameter to be specified in a callService or callRootService command, such as when needing a long timeout to request an agent response.
 - Enhancement: Removed need for app-server to be a client of itself when using the callService API, by adding the option for requests to this API to be executed internal to app-server. This option is very compatible with pre-existing use of callService but is disabled by default to avoid disruption. You can enable it by setting the server configuration property `node.internalRouting=true`
+- Bugfix: App-server would ignore when `VERIFY_CERTIFICATE=false` was set, and try to verify APIML servers. This would lead to login failures when APIML server was on a different system than App-server. Now, app-server will or will not verify APIML certificates according to `VERIFY_CERTIFICATE` value.
 
 ## 1.24.0
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -164,7 +164,6 @@ Server.prototype = {
     //this parameter has been duplicated all over the code, trying to consolidate.
     const allowInvalidTLSProxy = this.startUpConfig.allowInvalidTLSProxy || this.userConfig.node.allowInvalidTLSProxy;
     this.userConfig.node.allowInvalidTLSProxy = allowInvalidTLSProxy;
-    process.env.NODE_TLS_REJECT_UNAUTHORIZED= allowInvalidTLSProxy ? 0 : 1;
     
     const firstWorker = !(process.clusterManager && process.clusterManager.getIndexInCluster() != 0);
     if (!firstWorker) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -164,6 +164,7 @@ Server.prototype = {
     //this parameter has been duplicated all over the code, trying to consolidate.
     const allowInvalidTLSProxy = this.startUpConfig.allowInvalidTLSProxy || this.userConfig.node.allowInvalidTLSProxy;
     this.userConfig.node.allowInvalidTLSProxy = allowInvalidTLSProxy;
+    process.env.NODE_TLS_REJECT_UNAUTHORIZED= allowInvalidTLSProxy ? 0 : 1;
     
     const firstWorker = !(process.clusterManager && process.clusterManager.getIndexInCluster() != 0);
     if (!firstWorker) {

--- a/plugins/sso-auth/lib/apimlHandler.js
+++ b/plugins/sso-auth/lib/apimlHandler.js
@@ -57,7 +57,7 @@ class ApimlHandler {
     this.apimlConf = serverConf.node.mediationLayer.server;    
     this.gatewayUrl = `https://${this.apimlConf.hostname}:${this.apimlConf.gatewayPort}`;
 
-    if (serverConf.node.https.certificateAuthorities === undefined) {
+    if ((serverConf.node.https.certificateAuthorities === undefined) || (serverConf.node.allowInvalidTLSProxy===true)) {
       this.logger.warn("This server is not configured with certificate authorities, so it will not validate certificates with APIML");
       this.httpsAgent = new https.Agent({
         rejectUnauthorized: false


### PR DESCRIPTION
VERIFY_CERTIFICATES=true/false should apply globally but seems not to be the case in app-server. This is a fix for the case of contacting apiml for auth actions.
