### PR TITLE
Bugfix for proxy throwing on server error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This repo is part of the app-server Zowe Component, and the change logs here may
 - Enhancement: Allow timeout parameter to be specified in a callService or callRootService command, such as when needing a long timeout to request an agent response.
 - Enhancement: Removed need for app-server to be a client of itself when using the callService API, by adding the option for requests to this API to be executed internal to app-server. This option is very compatible with pre-existing use of callService but is disabled by default to avoid disruption. You can enable it by setting the server configuration property `node.internalRouting=true`
 - Bugfix: App-server would ignore when `VERIFY_CERTIFICATE=false` was set, and try to verify APIML servers. This would lead to login failures when APIML server was on a different system than App-server. Now, app-server will or will not verify APIML certificates according to `VERIFY_CERTIFICATE` value.
+- Bugfix: app-server could throw an uncaught exception when a proxied server had a socket error
 
 ## 1.24.0
 

--- a/lib/assets/i18n/log/messages_en.json
+++ b/lib/assets/i18n/log/messages_en.json
@@ -225,7 +225,7 @@
   "ZWED0037W":"Ending server process due to uncaught exception.",
   "ZWED0038W":"[Path=%s stderr]: %s",
   "ZWED0039W":"Exception at server cleanup function:\n%s",
-  "ZWED0040W":"Callservice: Service call failed. ",
+  "ZWED0040W":"Callservice: Service call to %s:%s%s failed. ",
   "ZWED0041W":"%s Exception caught. Message=%s",
   "ZWED0042W":"Stack trace follows\n%s",
   "ZWED0043W":"%s proxyWS error:%s",

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -87,6 +87,7 @@ function makeSimpleProxy(host, port, options, pluginID, serviceName) {
     } else {
       proxyLog.debug('ZWED0172I'); //proxyLog.debug('Callservice: no auth helper');
     }
+
     const req2 = httpApi.request(requestOptions, (res2) => {
       proxyLog.debug("ZWED0173I", res2.statusCode); //proxyLog.debug("status code" + res2.statusCode);
       res1.status(res2.statusCode);
@@ -125,9 +126,13 @@ function makeSimpleProxy(host, port, options, pluginID, serviceName) {
       res2.pipe(res1);
     });
     req2.on('error', (e) => {
-      proxyLog.warn('ZWED0040W', e); //proxyLog.warn('Callservice: Service call failed.');
-      res1.status(500).send(`ZWED0040W - Unable to complete network request to ${host}:${port}: `
-          + e.message, null, null);
+      proxyLog.warn('ZWED0040W', requestOptions.host, requestOptions.port, requestOptions.path, e); //proxyLog.warn('Callservice: Service call to ... failed.');
+      if (!req1.headersSent) {
+        res1.status(500).send(`ZWED0040W - Unable to complete network request to ${requestOptions.host}:${requestOptions.port}${requestOptions.path}: `
+                              + e.message, null, null);
+      } else {
+        res1.end();
+      }
     });
     if ((req1.method == 'POST') || (req1.method == 'PUT') || (req1.method == 'PATCH')) {
       proxyLog.debug('ZWED0175I'); //proxyLog.debug('Callservice: Forwarding request body to service');

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -127,12 +127,7 @@ function makeSimpleProxy(host, port, options, pluginID, serviceName) {
     });
     req2.on('error', (e) => {
       proxyLog.warn('ZWED0040W', requestOptions.host, requestOptions.port, requestOptions.path, e); //proxyLog.warn('Callservice: Service call to ... failed.');
-      if (!req1.headersSent) {
-        res1.status(500).send(`ZWED0040W - Unable to complete network request to ${requestOptions.host}:${requestOptions.port}${requestOptions.path}: `
-                              + e.message, null, null);
-      } else {
-        res1.end();
-      }
+      res1.end();
     });
     if ((req1.method == 'POST') || (req1.method == 'PUT') || (req1.method == 'PATCH')) {
       proxyLog.debug('ZWED0175I'); //proxyLog.debug('Callservice: Forwarding request body to service');


### PR DESCRIPTION
Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>

<!-- Thank you for submitting a PR to Zowe! To help us understand, test, and give feedback on your code, please fill in the details below. -->

## Proposed changes
Proxy.js responds to a proxy error by telling the requestor that an error happened. However, this was done in a way that would send headers, but due to proxying the headers might already be sent before. This will throw an exception.

So, this PR fixes the issue by checking if the headers were sent, and if not, sending the error message. However, if the headers were sent, it instead just ends the response without adding new info.

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

## PR Checklist
Please delete options that are not relevant.
- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zlux/blob/master/CONTRIBUTING.md))
- [x] New and existing unit tests pass locally with my changes
- [x] Relevant update to CHANGELOG.md
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works, or describe a test method below

## Testing
<!-- Describe how this code should be tested. I've you've added an automated or unit test, then describe how to run it. Otherwise, describe how you have tested it and how others should test it. -->
This could be tested by having a server that starts sending data to app-server but then crashes or has some sort of socket error on purpose. Before, a worker or server crash would happen. After, it would not.

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, or if there are follow-up tasks and TODOs etc... -->
