### PR TITLE
Sanity check on agent configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to the Zlux Server Framework package will be documented in this file.
 This repo is part of the app-server Zowe Component, and the change logs here may appear on Zowe.org in that section.
 
+## 1.26.0
+
+- Bugfix: Added small check on agent network configuration to avoid throwing an exception if the agent configuration included JWT information, but not network information
+
 ## 1.25.0
 
 - Enhancement: Improved callRootService when targeting agents such as ZSS to issue the request direct to the destination rather than using an additional loopback request to the app-server first. This should improve performance, reduce the need for the app-server being a client of itself, and allow for more request options when calling the agent.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to the Zlux Server Framework package will be documented in this file.
 This repo is part of the app-server Zowe Component, and the change logs here may appear on Zowe.org in that section.
 
-## 1.26.0
+## 1.27.0
 
 - Bugfix: Added small check on agent network configuration to avoid throwing an exception if the agent configuration included JWT information, but not network information
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -99,7 +99,7 @@ function getPrefixForService(serviceName, type, version) {
 };
 
 module.exports.getAgentRequestOptions = function(serverConfig, tlsOptions, includeCert, path) {
-  if (serverConfig && serverConfig.node && serverConfig.agent) {
+  if (serverConfig && serverConfig.node && serverConfig.agent && (serverConfig.agent.https || serverConfig.agent.http)) {
     const agentConfig = serverConfig.agent;
     const useApiml = !!(agentConfig.mediationLayer &&
                         agentConfig.mediationLayer.enabled &&


### PR DESCRIPTION
<!-- Thank you for submitting a PR to Zowe! To help us understand, test, and give feedback on your code, please fill in the details below. -->

## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

This PR addresses the fact the dev readme ends up giving you an unusable environment due to internal logic expecting agent config to be entirely present or entirely missing, and we had some present but useless object by default in which all the values were 0, and this confused the server. The server should do sanity checks upon the agent body before proceeding to access attributes that dont exist.

This PR addresses Issue: https://github.com/zowe/zlux/issues/758

This PR depends upon the following PRs: https://github.com/zowe/zlux-app-server/pull/188

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

## PR Checklist
Please delete options that are not relevant.
- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zlux/blob/master/CONTRIBUTING.md))
- [x] New and existing unit tests pass locally with my changes
- [x] Relevant update to CHANGELOG.md
- [x] My changes generate no new warnings
