### PR TITLE
Test: RBAC profile lookup fix for cases such as %3A

### DIFF
--- a/plugins/sso-auth/lib/safprofile.js
+++ b/plugins/sso-auth/lib/safprofile.js
@@ -113,7 +113,7 @@ function makeProfileName(type, parms) {
 function makeProfileNameForRequest(url, method, instanceID) {
   let urlData;
   let type;
-  url = decodeURI(url);
+  url = url.split('/').map((part)=>{return decodeURIComponent(part);}).join('/');
   if (!url.match(/^\/[A-Za-z0-9]+\/plugins\//)) {
     url = url.toUpperCase();
     type = "core";


### PR DESCRIPTION
decodeURI does not handle A-Z a-z 0-9 ; , / ? : @ & = + $ - _ . ! ~ * ' ( ) #
decodeURIcomponent does not handle A-Z a-z 0-9 - _ . ! ~ * ' ( )
Switching to decodeURIcomponent will handle just a few more cases for percent decoding.
Perhaps we should just percent decode with our own logic, to handle ALL cases, or cases that better match what ESMs allow.