### PR TITLE
Do not retry login operations on failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to the Zlux Server Framework package will be documented in this file.
 This repo is part of the app-server Zowe Component, and the change logs here may appear on Zowe.org in that section.
 
+## 1.27.0
+
+- Bugfix: Avoid retrying APIML login if initial attempt fails for any reason
+
 ## 1.25.0
 
 - Enhancement: Improved callRootService when targeting agents such as ZSS to issue the request direct to the destination rather than using an additional loopback request to the app-server first. This should improve performance, reduce the need for the app-server being a client of itself, and allow for more request options when calling the agent.

--- a/plugins/sso-auth/lib/apimlHandler.js
+++ b/plugins/sso-auth/lib/apimlHandler.js
@@ -147,20 +147,14 @@ class ApimlHandler {
     if (request.body) {
       this.logger.debug(`Authenticate with body`);
       return new Promise((resolve, reject) => {
-        this.doLogin(request, sessionState).then(result=> {
-          if (result.success === true) {
-            resolve(result);
-          } else {
-            this.authenticateViaCookie(request, sessionState).then(result=> resolve(result))
-              .catch(e => reject(e));
-          }
+        this.doLogin(request, sessionState, false).then(result=> {
+          resolve(result);
         }).catch(e=> {
-          this.authenticateViaCookie(request, sessionState).then(result=> resolve(result))
-            .catch(e => reject(e));
+          Promise.resolve({success: false});
         });
       });
     } else if (request.cookies && request.cookies[TOKEN_NAME]) {
-      return this.authenticateViaCookie(request, sessionState);
+      return this.authenticateViaCookie(request, sessionState, true);
     } else {
       return Promise.resolve({success: false});
     }
@@ -180,7 +174,7 @@ class ApimlHandler {
           expiration = expirationDate.getTime() - now.getTime();
         }
         if (expiration < 1) {
-          this.doLogin(request, sessionState).then(result=> resolve(result))
+          this.doLogin(request, sessionState, true).then(result=> resolve(result))
             .catch(e => reject(e));
         } else {
           this.setState(request.cookies[TOKEN_NAME],
@@ -188,9 +182,8 @@ class ApimlHandler {
           resolve({success: true, username: sessionState.username, expms: expiration});
         }
       }).catch(e=> {
-        this.logger.debug('APIML query failed, trying login.');
-        this.doLogin(request, sessionState).then(result=> resolve(result))
-          .catch(e => reject(e));
+        this.logger.debug('APIML query failed.');
+        reject(e);
       });
     });
   }
@@ -270,12 +263,12 @@ class ApimlHandler {
     });
   }
 
-  doLogin(request, sessionState) {
+  doLogin(request, sessionState, useCookie) {
     return new Promise((resolve, reject) => {
       const gatewayUrl = this.gatewayUrl;
       const data = JSON.stringify({
-        username: request.body.username,
-        password: request.body.password
+        username: useCookie ? undefined: request.body.username,
+        password: useCookie ? undefined: request.body.password
       });
       const options = this.makeOptions('/gateway/api/v1/auth/login','POST', undefined, data.length);
 

--- a/plugins/sso-auth/lib/apimlHandler.js
+++ b/plugins/sso-auth/lib/apimlHandler.js
@@ -154,7 +154,7 @@ class ApimlHandler {
         });
       });
     } else if (request.cookies && request.cookies[TOKEN_NAME]) {
-      return this.authenticateViaCookie(request, sessionState, true);
+      return this.authenticateViaCookie(request, sessionState);
     } else {
       return Promise.resolve({success: false});
     }


### PR DESCRIPTION
There are a few cases in the apiml handler code where a different type of login is attempted if the first one fails, or a retry is attempted upon exception. Instead, a failure should give up in order to not cause lockout.