### PR TITLE
Fix env vars for external hosts and ports

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -415,13 +415,15 @@ module.exports.makeRemoteUrl = function(destination, req, serverConfig) {
     } else if (process.env.ZOWE_EXTERNAL_HOST) {
       zoweExternalHost = process.env.ZOWE_EXTERNAL_HOST;
     } else {
-      zoweExternalHost = process.env.ZOWE_EXPLORER_HOST;
+      zoweExternalHost = process.env.ZWE_zowe_externalDomains_0;
     }
   }
   if (destination.includes('ZWE_EXTERNAL_PORT')) {
-    if (process.env.ZWE_EXTERNAL_PORT) {
+    if (process.env.ZWE_zowe_externalPort) {
+      zoweExternalPort = process.env.ZWE_zowe_externalPort;
+    } if (process.env.ZWE_EXTERNAL_PORT) {
       zoweExternalPort = process.env.ZWE_EXTERNAL_PORT;
-    } else if (serverConfig.node.mediationLayer && serverConfig.node.mediaitonLayer.server && serverConfig.node.mediationLayer.server.gatewayPort) {
+    } else if (serverConfig.node.mediationLayer && serverConfig.node.mediationLayer.server && serverConfig.node.mediationLayer.server.gatewayPort) {
       zoweExternalPort = serverConfig.node.mediationLayer.server.gatewayPort;
     } else if (serverConfig.node.https.port) {
       zoweExternalPort = serverConfig.node.https.port;
@@ -434,8 +436,7 @@ module.exports.makeRemoteUrl = function(destination, req, serverConfig) {
           .replace('${ZOWE_EXTERNAL_HOST}', zoweExternalHost)
           .replace('${ZWE_EXTERNAL_HOST}', zoweExternalHost)
           .replace('${GATEWAY_PORT}', process.env.GATEWAY_PORT)
-          .replace('${ZWE_EXTERNAL_PORT}', zoweExternalPort)
-          .replace('${ZOWE_EXPLORER_HOST}', process.env.ZOWE_EXPLORER_HOST);
+          .replace('${ZWE_EXTERNAL_PORT}', zoweExternalPort);
 }
 
 module.exports.isPluginExternal = (plugin) => {

--- a/lib/webapp.js
+++ b/lib/webapp.js
@@ -271,15 +271,14 @@ function getUserEnv(rbac, serverConfig){
         //needed for any cross-server communication requirements
         "userEnvironment": {
           "EXTERNAL_COMPONENTS": process.env.EXTERNAL_COMPONENTS,
-          "LAUNCH_COMPONENT_GROUPS": process.env.LAUNCH_COMPONENT_GROUPS,
+          "ZWE_LAUNCH_COMPONENTS": process.env.ZWE_LAUNCH_COMPONENTS,
           "ZWED_node_mediationLayer_enabled": process.env.ZWED_node_mediationLayer_enabled,
 
-          //expected to be identical
-          "ZOWE_EXPLORER_HOST": process.env.ZOWE_EXPLORER_HOST,
           "ZWED_node_mediationLayer_server_hostname": process.env.ZWED_node_mediationLayer_server_hostname,
 
           //may diverge from above
-          "ZWE_EXTERNAL_HOSTS": process.env.ZWE_EXTERNAL_HOSTS,
+          "ZWE_EXTERNAL_HOSTS": process.env.ZWE_EXTERNAL_HOSTS ? process.env.ZWE_EXTERNAL_HOSTS : process.env.ZWE_zowe_externalDomains,
+          "ZWE_zowe_externalDomains": process.env.ZWE_zowe_externalDomains,
           
           //expected to be identical
           "ZWED_node_mediationLayer_server_gatewayPort": process.env.ZWED_node_mediationLayer_server_gatewayPort,
@@ -1397,8 +1396,8 @@ WebApp.prototype = {
       this.validDomains = process.env.ZWE_REFERER_HOSTS.toLowerCase().split(',');
     } else {
       let validDomains = [os.hostname().toLowerCase()];
-      if (process.env.ZOWE_EXPLORER_HOST && (validDomains[0] != process.env.ZOWE_EXPLORER_HOST)) {
-        validDomains.push(process.env.ZOWE_EXPLORER_HOST.toLowerCase());
+      if (process.env.ZWE_zowe_externalDomains_0 && (validDomains[0] != process.env.ZWE_zowe_externalDomains_0)) {
+        validDomains.push(process.env.ZWE_zowe_externalDomains_0.toLowerCase());
       }
       if (process.env.ZWE_EXTERNAL_HOSTS) {
         const externalHosts = process.env.ZWE_EXTERNAL_HOSTS.toLowerCase().split(',');


### PR DESCRIPTION
Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>

<!-- Thank you for submitting a PR to Zowe! To help us understand, test, and give feedback on your code, please fill in the details below. -->

## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

There are two primary issues attempted to be solved by this PR
1. the iframe remote url lookup has issues, such as a typo but also references to env vars that dont exist in v2
2. there are other references to env vars that dont exist in v2 for the env var lookup rest api

This attempts to substitute missing env vars with ones that are roughly equivalent. It is a breaking change in that some values are not equal, though they are similar to v1, the v1 env vars have been removed so the functions and attributes have likewise been removed/changed.


## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
## PR Checklist
Please delete options that are not relevant.
- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zlux/blob/master/CONTRIBUTING.md))
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
- [ ] video or image is included if visual changes are made
- [ ] Relevant update to CHANGELOG.md
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works, or describe a test method below

## Testing
<!-- Describe how this code should be tested. I've you've added an automated or unit test, then describe how to run it. Otherwise, describe how you have tested it and how others should test it. -->
I'm including this in test build https://github.com/zowe/zlux-build/pull/97
In the previous build, the api catalog would not load in the desktop due to this error:

```
TypeError: Cannot read property 'server' of undefined
    at Object.module.exports.makeRemoteUrl (/components/app-server/share/zlux-server-framework/lib/util.js:424:85)
```

So, we should not see this error and should instead see the api catalog load.

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, or if there are follow-up tasks and TODOs etc... -->
