### PR TITLE
Bugfix to prevent loop on EACCES

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This repo is part of the app-server Zowe Component, and the change logs here may
 ## 1.28.0
 
 - Bugfix: keyring_js did not worked properly for finding CAs due to using an older version in package.json than needed for the listKeyring function
+- Bugfix: Prevent loop upon EACCES error encountered when doing a TCP port bind
 
 ## 1.27.0
 

--- a/lib/assets/i18n/log/messages_en.json
+++ b/lib/assets/i18n/log/messages_en.json
@@ -377,5 +377,6 @@
   "ZWED0154E":"RESERVED: (%s) is not a supported architecture for %s. Skipping (%s)... Supported: %s",
   "ZWED0155E":"RESERVED: (%s) is not a supported endpoint for %s. Skipping (%s)... Supported: %s",
   "ZWED0156E":"RESERVED: Could not register default plugins into app-server",
-  "ZWED0157E":"RESERVED: Could not register default plugin %s into app-server"
+  "ZWED0157E":"RESERVED: Could not register default plugin %s into app-server",
+  "ZWED0158E":"Could not listen on address %s:%s. Insufficient permissions to perform port bind."
 }

--- a/lib/webserver.js
+++ b/lib/webserver.js
@@ -220,6 +220,10 @@ WebServer.prototype = {
     //making logging poor unless passed
     server.on('error',(e)=> {
       switch (e.code) {
+      case 'EACCES':
+        networkLogger.severe(`ZWED0158E`, ipAddress, port); //Could not listen on address %s:%s. Insufficient permissions to perform port bind.
+        process.exit(constants.EXIT_HTTPS_LOAD);
+        break;
       case 'EADDRINUSE':
         networkLogger.severe(`ZWED0004E`, ipAddress, port); //networkLogger.severe(`Could not listen on address ${ipAddress}:${port}. It is already in use by another process.`);
         process.exit(constants.EXIT_HTTPS_LOAD);


### PR DESCRIPTION
## Proposed changes
EACCES can be encountered when a system that has access restrictions on TCP ports disallows the server from from doing the listen operation that happens at startup. In this case, we had a bug where we'd catch the exception and attempt to retry. However, there's no change to succeed in this case so the fix is just to add this error code to our list of error codes we should stop rather than loop on.

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

## PR Checklist
Please delete options that are not relevant.
- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zlux/blob/master/CONTRIBUTING.md))
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] Relevant update to CHANGELOG.md
- [x] My changes generate no new warnings