### PR TITLE
Revert "correcting the URL parsing to get the zoweExternalHost"

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -402,15 +402,14 @@ module.exports.getRemoteIframeTemplate = function(remoteUrl) {
 
 module.exports.makeRemoteUrl = function(destination, req, serverConfig) {
   let referer = req.get('Referer');
-  let hostname = referer === '' ? '' : new URL(referer).hostname;
   loggers.utilLogger.debug(`referer: ${referer}`);
   
   let zoweExternalHost;
   let zoweExternalPort;
-
+  
   if(destination.includes('ZOWE_EXTERNAL_HOST') || destination.includes('ZWE_EXTERNAL_HOST')) {
-    if( hostname > '') {
-      zoweExternalHost = hostname; 
+    if( referer > '') {
+      zoweExternalHost = referer.split(':')[1].substring(2); 
     } else if (process.env.ZWE_EXTERNAL_HOST) {
       zoweExternalHost = process.env.ZWE_EXTERNAL_HOST;
     } else if (process.env.ZOWE_EXTERNAL_HOST) {


### PR DESCRIPTION
Reverts zowe/zlux-server-framework#396
Because it causes issue
```

TypeError [ERR_INVALID_URL]: Invalid URL: undefined
    at onParseError (internal/url.js:258:9)
    at new URL (internal/url.js:334:5)
    at Object.module.exports.makeRemoteUrl (/myuser/zowe-test/install/components/app-server/share/zlux-server-framework/lib/util.js:405:40)
    at /myuser/zowe-test/install/components/app-server/share/zlux-server-framework/lib/webapp.js:1996:36
    at Layer.handle [as handle_request] (/myuser/zowe-test/install/components/app-server/share/zlux-server-framework/node_modules/express/lib/router/layer.js:95:5)
    at trim_prefix (/myuser/zowe-test/install/components/app-server/share/zlux-server-framework/node_modules/express/lib/router/index.js:317:13)
    at /myuser/zowe-test/install/components/app-server/share/zlux-server-framework/node_modules/express/lib/router/index.js:284:7
    at Function.process_params (/myuser/zowe-test/install/components/app-server/share/zlux-server-framework/node_modules/express/lib/router/index.js:335:12)
    at next (/myuser/zowe-test/install/components/app-server/share/zlux-server-framework/node_modules/express/lib/router/index.js:275:10)
    at Function.handle (/myuser/zowe-test/install/components/app-server/share/zlux-server-framework/node_modules/express/lib/router/index.js:174:3)
    at router (/myuser/zowe-test/install/components/app-server/share/zlux-server-framework/node_modules/express/lib/router/index.js:47:12)
    at Layer.handle [as handle_request] (/myuser/zowe-test/install/components/app-server/share/zlux-server-framework/node_modules/express/lib/router/layer.js:95:5)
    at trim_prefix (/myuser/zowe-test/install/components/app-server/share/zlux-server-framework/node_modules/express/lib/router/index.js:317:13)
    at /myuser/zowe-test/install/components/app-server/share/zlux-server-framework/node_modules/express/lib/router/index.js:284:7
    at Function.process_params (/myuser/zowe-test/install/components/app-server/share/zlux-server-framework/node_modules/express/lib/router/index.js:335:12)
    at next (/myuser/zowe-test/install/components/app-server/share/zlux-server-framework/node_modules/express/lib/router/index.js:275:10)
2022-03-31 03:04:56.156 <ZWED:17236172> ZWESMVD INFO (org.zowe.zlux.bootstrap:adminnotificationdata,notificationProxy.js:42) ZWED0001IGET
TypeError [ERR_INVALID_URL]: Invalid URL: undefined
    at onParseError (internal/url.js:258:9)
    at new URL (internal/url.js:334:5)
    at Object.module.exports.makeRemoteUrl (/myuser/zowe-test/install/components/app-server/share/zlux-server-framework/lib/util.js:405:40)
    at /myuser/zowe-test/install/components/app-server/share/zlux-server-framework/lib/webapp.js:1996:36
    at Layer.handle [as handle_request] (/myuser/zowe-test/install/components/app-server/share/zlux-server-framework/node_modules/express/lib/router/layer.js:95:5)
    at trim_prefix (/myuser/zowe-test/install/components/app-server/share/zlux-server-framework/node_modules/express/lib/router/index.js:317:13)
    at /myuser/zowe-test/install/components/app-server/share/zlux-server-framework/node_modules/express/lib/router/index.js:284:7
    at Function.process_params (/myuser/zowe-test/install/components/app-server/share/zlux-server-framework/node_modules/express/lib/router/index.js:335:12)
    at next (/myuser/zowe-test/install/components/app-server/share/zlux-server-framework/node_modules/express/lib/router/index.js:275:10)
    at Function.handle (/myuser/zowe-test/install/components/app-server/share/zlux-server-framework/node_modules/express/lib/router/index.js:174:3)
    at router (/myuser/zowe-test/install/components/app-server/share/zlux-server-framework/node_modules/express/lib/router/index.js:47:12)
    at Layer.handle [as handle_request] (/myuser/zowe-test/install/components/app-server/share/zlux-server-framework/node_modules/express/lib/router/layer.js:95:5)
    at trim_prefix (/myuser/zowe-test/install/components/app-server/share/zlux-server-framework/node_modules/express/lib/router/index.js:317:13)
    at /myuser/zowe-test/install/components/app-server/share/zlux-server-framework/node_modules/express/lib/router/index.js:284:7
    at Function.process_params (/myuser/zowe-test/install/components/app-server/share/zlux-server-framework/node_modules/express/lib/router/index.js:335:12)
    at next (/myuser/zowe-test/install/components/app-server/share/zlux-server-framework/node_modules/express/lib/router/index.js:275:10)
```