### PR TITLE
Add SSO info to api catalog tile

### DIFF
--- a/lib/apiml.js
+++ b/lib/apiml.js
@@ -78,7 +78,8 @@ const MEDIATION_LAYER_INSTANCE_DEFAULTS = (zluxProto, zluxHostname, zluxPort) =>
       +' Proxy Server',
     'mfaas.api-info.apiVersionProperties.v1.version': '1.0.0',
     'mfaas.api-info.apiVersionProperties.v1.version': '1.0.0',
-    'apiml.apiInfo.api-v1.swaggerUrl':`${zluxProto}://${zluxHostname}:${zluxPort}/api-docs/server`
+    'apiml.apiInfo.api-v1.swaggerUrl':`${zluxProto}://${zluxHostname}:${zluxPort}/api-docs/server`,
+    'apiml.authentication.scheme': 'zoweJwt'
   }
 }};
 


### PR DESCRIPTION
## Proposed changes
Utilizes change in https://github.com/zowe/zss/pull/428 within app-server to provide the same SSO item to the app-server tile in the api catalog.

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

## PR Checklist
Please delete options that are not relevant.
- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] video or image is included if visual changes are made
- [x] I have added tests that prove my fix is effective or that my feature works, or describe a test method below

## Testing
I tested the editor and jes explorer within the desktop to see that the change didn't impact auth behavior. I believe this is superficial metadata so, I don't expect any regressions.

## Screenshot
Here you can see the "SSO" label is added to the app-server tile with this change. Before, it was absent.
![image](https://user-images.githubusercontent.com/30730276/161584288-4ef3233f-9a5e-4db8-8d1b-fb938c388b9b.png)
