### PR TITLE
Allow tls proxy specification in plugin, allow tlsOptions passthrough

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This repo is part of the app-server Zowe Component, and the change logs here may
 
 ## 1.28.0
 
+- Bugfix: Pass through tlsOptions object when making a proxy from an 'external'-type service, and allow the services to individually control tls verification strictness of their own proxy.
 - Bugfix: keyring_js did not worked properly for finding CAs due to using an older version in package.json than needed for the listKeyring function
 - Bugfix: Prevent loop upon EACCES error encountered when doing a TCP port bind
 - Bugfix: Avoid retrying APIML login if initial attempt fails for any reason

--- a/lib/webapp.js
+++ b/lib/webapp.js
@@ -1543,9 +1543,13 @@ WebApp.prototype = {
   makeExternalProxy(host, port, urlPrefix, isHttps, noAuth, pluginID, serviceName, allowInvalidTLSProxy) {
     const r = express.Router();
     installLog.info(`ZWED0053I`, `${isHttps? 'HTTPS' : 'HTTP'}`, `${pluginID}:${serviceName}`, `${host}:${port}/${urlPrefix}`); //installLog.info(`Setting up ${isHttps? 'HTTPS' : 'HTTP'} proxy ` +`(${pluginID}:${serviceName}) to destination=${host}:${port}/${urlPrefix}`);
-    if (allowInvalidTLSProxy === undefined) {
+    
+    // Global overrides if set so that debugging can proceed. 
+    if (this.options.allowInvalidTLSProxy) {
       allowInvalidTLSProxy =  this.options.allowInvalidTLSProxy;
     }
+    // This is done to be unambiguous about that we don't want any extra tls options, we just dont want tls validation
+    // TODO perhaps in the future tls options can come from services too.
     let tlsOptions = allowInvalidTLSProxy ? undefined : this.options.tlsOptions;
     let myProxy = proxy.makeSimpleProxy(host, port, {
       urlPrefix, 

--- a/lib/webapp.js
+++ b/lib/webapp.js
@@ -1540,15 +1540,20 @@ WebApp.prototype = {
     return r;
   },
   
-  makeExternalProxy(host, port, urlPrefix, isHttps, noAuth, pluginID, serviceName) {
+  makeExternalProxy(host, port, urlPrefix, isHttps, noAuth, pluginID, serviceName, allowInvalidTLSProxy) {
     const r = express.Router();
     installLog.info(`ZWED0053I`, `${isHttps? 'HTTPS' : 'HTTP'}`, `${pluginID}:${serviceName}`, `${host}:${port}/${urlPrefix}`); //installLog.info(`Setting up ${isHttps? 'HTTPS' : 'HTTP'} proxy ` +`(${pluginID}:${serviceName}) to destination=${host}:${port}/${urlPrefix}`);
+    if (allowInvalidTLSProxy === undefined) {
+      allowInvalidTLSProxy =  this.options.allowInvalidTLSProxy;
+    }
+    let tlsOptions = allowInvalidTLSProxy ? undefined : this.options.tlsOptions;
     let myProxy = proxy.makeSimpleProxy(host, port, {
       urlPrefix, 
       isHttps, 
       addProxyAuthorizations: (noAuth? null : this.auth.addProxyAuthorizations),
       processProxiedHeaders: (noAuth? null : this.auth.processProxiedHeaders),
-      allowInvalidTLSProxy: this.options.allowInvalidTLSProxy
+      allowInvalidTLSProxy: allowInvalidTLSProxy,
+      tlsOptions: tlsOptions
     }, pluginID, serviceName);
     proxyMap.set(pluginID + ":" + serviceName, myProxy);
     r.use(myProxy);
@@ -1807,7 +1812,7 @@ WebApp.prototype = {
 //      installLog.info(`${plugin.identifier}: installing external proxy at ${subUrl}`);
       router = this.makeExternalProxy(service.host, service.port,
           service.urlPrefix, service.isHttps,
-          undefined, plugin.identifier, service.name);
+          undefined, plugin.identifier, service.name, service.allowInvalidTLSProxy);
       break;
     default:
       //maybe a lang manager knows how to handle this...


### PR DESCRIPTION
Allow tls proxy specification in plugin, allow tlsOptions passthrough
It was noted that users of service type external could not get their proxy to work with certificate verification turned on sometimes, and it seems to be due to failure to pass through tlsoptions.
Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

## PR Checklist
Please delete options that are not relevant.
- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zlux/blob/master/CONTRIBUTING.md))
- [x] Relevant update to CHANGELOG.md
- [x] My changes generate no new warnings
