### PR TITLE
Fix for auth when using only zss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to the Zlux Server Framework package will be documented in this file.
 This repo is part of the app-server Zowe Component, and the change logs here may appear on Zowe.org in that section.
 
+## 2.3.0
+
+- Bugfix: sso-auth would reject zss cookie if it was using the zowe.cookieIdentifier suffix rather than its port. Now, both zss and app-server use zowe.cookieIdentifier always.
+
 ## 2.0.0
 
 - Breaking change: The list of properties sent back from the /server/environment has changed to reflect the different environment values present in Zowe v2

--- a/plugins/sso-auth/lib/zssHandler.js
+++ b/plugins/sso-auth/lib/zssHandler.js
@@ -25,8 +25,7 @@ class ZssHandler {
     this.instanceID = serverConf.instanceID;
     this.sessionExpirationMS = DEFAULT_EXPIRATION_MS; //ahead of time assumption of unconfigurable zss session length
     const zoweInstanceId = serverConf.cookieIdentifier;
-    const zssPort = serverConf.agent.https && serverConf.agent.https.port ? serverConf.agent.https.port : serverConf.agent.http.port;
-    this.zssCookieName = zluxUtil.isHaMode() ? COOKIE_NAME_BASE + zoweInstanceId : COOKIE_NAME_BASE + zssPort;
+    this.zssCookieName = COOKIE_NAME_BASE + zoweInstanceId;
     this.authorized = Promise.coroutine(function *authorized(request, sessionState, 
                                                              options) {
       const result = { authenticated: false, authorized: false };
@@ -197,7 +196,6 @@ class ZssHandler {
         if (typeof response.headers['set-cookie'] === 'object') {
           for (const cookie of response.headers['set-cookie']) {
             const content = cookie.split(';')[0];
-            console.log('cookie=',cookie);
             let index = content.indexOf(this.zssCookieName);
             if (index >= 0) {
               serverCookie = content;


### PR DESCRIPTION
app-server was expecting zss to have a cookie suffix of port conditional to ha setup, but zss unconditionally uses zowe.cookieIdentifier now, so app-server must expect the same.

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

## PR Checklist
Please delete options that are not relevant.
- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zlux/blob/master/CONTRIBUTING.md))
- [x] Relevant update to CHANGELOG.md
- [x] I have added tests that prove my fix is effective or that my feature works, or describe a test method below

## Testing
Turn off gateway, discovery, caching, and api-catalog server and try to login just using zss + app-server.