### PR TITLE
Derive keyring CA location from truststore address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to the Zlux Server Framework package will be documented in this file.
 This repo is part of the app-server Zowe Component, and the change logs here may appear on Zowe.org in that section.
 
+## 2.9.0
+
+- Enhancement: zowe.certificates.pem is no longer needed when using keyrings (#448)
+
 ## 2.8.0
 
 - Enhancement: Support zowe.verifyCertificates=NONSTRICT (#468)

--- a/lib/webserver.js
+++ b/lib/webserver.js
@@ -69,7 +69,10 @@ function parseSafKeyringAddress(safEntry) {
     const userId = safEntry.substring(0,endUserIndex);
     const endNameIndex = safEntry.indexOf('&',endUserIndex+1);
     if (endNameIndex == -1 || endNameIndex == safEntry.length-1) {
-      return null;
+      return {
+        userId,
+        keyringName: safEntry.substring(endUserIndex+1,endNameIndex)
+      }
     } else {
       return {
         userId,
@@ -275,31 +278,37 @@ WebServer.prototype = {
         }
       } 
       config.https.ipAddresses = uniqueIps;
-      if(keyring_js && process.env.KEYSTORE_TYPE == 'JCERACFKS') {
-        const keyringOwner = process.env.KEYRING_OWNER;
-        const keyringName = process.env.KEYRING_NAME;
-        let certificateList;
-        if (!config.https.certificateAuthorities) {
-          config.https.certificateAuthorities = [];
-        }
-        if(keyringOwner && keyringName) {
-          try {
-            certificateList = keyring_js.listKeyring(keyringOwner, keyringName);
-          } catch(e) {
-            bootstrapLogger.warn('ZWED0179W', keyringName, keyringOwner, e);
-          }
-        }
-        if(certificateList) {
-          for(let i = 0; i < certificateList.length; i++) {
-            if(certificateList[i].usage === 'CERTAUTH') {
-              let safKeyring = `safkeyring:////${keyringOwner}/${keyringName}&${certificateList[i].label}`;
-              if(config.https.certificateAuthorities.indexOf(safKeyring) === -1) {
-                config.https.certificateAuthorities.push(safKeyring);
+      let newEntries = [];
+      if(keyring_js && config.https.certificateAuthorities) { 
+        for (let j = 0; j < config.https.certificateAuthorities.length; j++) {
+          const entry = config.https.certificateAuthorities[j];
+          if (!entry.startsWith('safkeyring://')) {
+            //keep
+            newEntries.push(entry);
+          } else {
+            const {owner, ringName, label} = parseSafKeyringAddress(entry);
+            let certificateList;
+            if(owner && ringName) {
+              try {
+                certificateList = keyring_js.listKeyring(owner, ringName);
+              } catch(e) {
+                bootstrapLogger.warn('ZWED0179W', ringName, owner, e);
+              }
+            }
+            if(certificateList) {
+              for(let i = 0; i < certificateList.length; i++) {
+                if(certificateList[i].usage === 'CERTAUTH') {
+                  let safKeyring = `${entry}&${certificateList[i].label}`;
+                  if(config.https.certificateAuthorities.indexOf(safKeyring) === -1) {
+                    newEntries.push(safKeyring);
+                  }
+                }
               }
             }
           }
         }
       }
+      config.https.certificateAuthorities = newEntries;
     }
     return canRun;
   }),


### PR DESCRIPTION
This PR depends upon the following PRs: https://github.com/zowe/zlux-app-server/pull/247

This PR allows keyring locations to be specified in the CA section, even without labels. Previously a label was required, and it would react to the label by scanning the entire keyring.
Now, every time we see a keyring location specified, with our without a label, we scan the entire ring for CAs and we add all the labels we find. This allows users to specify a ring without listing a CA label, which simplifies zowe.yaml, but we maintain backward compatibility.

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

## PR Checklist
Please delete options that are not relevant.
- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zlux/blob/master/CONTRIBUTING.md))
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] video or image is included if visual changes are made
- [x] Relevant update to CHANGELOG.md
- [x] My changes generate no new warnings

## Testing
Just run zowe install packaging keyring test.