### PR TITLE
Allow CAs to be passed into callService, or default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This repo is part of the app-server Zowe Component, and the change logs here may
 ## 2.8.0
 
 - Enhancement: Support zowe.verifyCertificates=NONSTRICT (#468)
+- Enhancement: Allow dataservices to pass CAs into the call() function (#462)
 
 ## 2.3.0
 

--- a/lib/webapp.js
+++ b/lib/webapp.js
@@ -905,6 +905,9 @@ WebServiceHandle.prototype = {
         timeout: options.timeout,
         rejectUnauthorized: rejectUnauthorized
       };
+      if (requestOptions.rejectUnauthorized === true) {
+        requestOptions.ca = options.ca ? options.ca : this.environment.agentRequestOptions.ca; 
+      }
       const headers = {};
       if (originalRequest) {
         var cookie = originalRequest.get('cookie');


### PR DESCRIPTION
This PR allows a dataservice that issues a call() to provide CAs to associate with that call, overriding the default.

The default CAs will be sufficient for calls that occur within servers known to zowe's core via keystore configuration. This is generally the servers under the apiml gateway sphere. If your service needs to contact a server elsewhere, and needs its CA for verification, then you can override the CA list on the call() when you provide the call() options object.
The CAs will only be used if certificate verification is enabled, which is determined at the server config level.