### PR TITLE
add NONSTRICT mode to app-server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to the Zlux Server Framework package will be documented in this file.
 This repo is part of the app-server Zowe Component, and the change logs here may appear on Zowe.org in that section.
 
+## 2.8.0
+
+- Enhancement: Support zowe.verifyCertificates=NONSTRICT (#468)
+
 ## 2.3.0
 
 - Bugfix: Proxies (zss, external services, and those made by router services) now default to the same HTTPS/TLS settings as the app-esrver.

--- a/lib/webserver.js
+++ b/lib/webserver.js
@@ -315,6 +315,9 @@ WebServer.prototype = {
       if (typeof this.config.allowInvalidTLSProxy == 'boolean') {
         this.httpsOptions.rejectUnauthorized = !this.config.allowInvalidTLSProxy;
       }
+      if (process.env.ZWE_zowe_verifyCertificates == 'NONSTRICT') {
+        this.httpsOptions.checkServerIdentity = function(hostname, cert) { return undefined; } 
+      }
       //secureOptions and secureProtocol documented here: 
       //https://nodejs.org/api/tls.html#tls_tls_createsecurecontext_options
       if (typeof options.secureOptions == 'number') {


### PR DESCRIPTION
We've been looking to add NONSTRICT mode for a while (#875) but weren't sure how 
This document describes how it can be done:
https://nodejs.org/docs/latest-v12.x/api/tls.html#tls_tls_checkserveridentity_hostname_cert
There is simply a function that can be added to a tls connection to control hostname validation.
So, when NONSTRICT is set, we just do a no-op.

This PR directly checks the verifyCertificates env var to accomplish the code.
This is undesirable, but can't be fixed until the server overhaul where we move from reading env vars over to reading zowe.yaml directly. So for now, this is as good as it gets I believe.