### PR TITLE
Apply tlsoptions to clients

### DIFF
--- a/lib/webapp.js
+++ b/lib/webapp.js
@@ -854,7 +854,7 @@ const staticHandlers = {
  *  This is passed to every other service of the plugin, so that 
  *  the service can be called by other services under the plugin
  */
-function WebServiceHandle(urlPrefix, environment, isAgentService, service) {
+function WebServiceHandle(urlPrefix, environment, isAgentService, service, tlsOptions) {
   this.urlPrefix = urlPrefix;
   if (!environment.loopbackConfig.port) {
     installLog.severe(`ZWED0003E`, loopbackConfig); //installLog.severe(`loopback configuration not valid,`,loopbackConfig, `loopback calls will fail!`);
@@ -862,6 +862,7 @@ function WebServiceHandle(urlPrefix, environment, isAgentService, service) {
   this.environment = environment;
   this.isAgentService = isAgentService;
   this.service = service;
+  this.tlsOptions = tlsOptions;
 }
 WebServiceHandle.prototype = {
   constructor: WebServiceHandle,
@@ -887,24 +888,21 @@ WebServiceHandle.prototype = {
       if (path) {
         url += path.startsWith('/') ? path : '/' + path;
       }
-      let rejectUnauthorized;
       let protocol;
       if (this.environment.loopbackConfig.isHttps) {
         protocol = 'https:';
-        rejectUnauthorized = false;
       } else {
         protocol = 'http:';
       }
-      const requestOptions = {
+      const requestOptions = Object.assign({
         hostname: this.environment.loopbackConfig.host,
         port: this.environment.loopbackConfig.port,
         method: options.method || "GET",
         protocol: protocol,
         path: url,
         auth: options.auth,
-        timeout: options.timeout,
-        rejectUnauthorized: rejectUnauthorized
-      };
+        timeout: options.timeout
+      }, this.tlsOptions);
       const headers = {};
       if (originalRequest) {
         var cookie = originalRequest.get('cookie');
@@ -1634,7 +1632,7 @@ WebApp.prototype = {
         this.expressApp.use(proxiedRootService.url, rootServicesMiddleware, this.auth.middleware, middlewareArray);
       }
       serviceHandleMap[name] = new WebServiceHandle(proxiedRootService.url, 
-                                                    this.wsEnvironment, true);
+                                                    this.wsEnvironment, true, undefined, this.options.tlsOptions);
     }
     this.expressApp.use(rootServicesMiddleware);
     
@@ -1650,24 +1648,24 @@ WebApp.prototype = {
         {needJson: true, needAuth: false, isPseudoSso: true});
     this._installRootService('/auth-logout', 'get', this.auth.doLogout, 
         {needJson: true, needAuth: false, isPseudoSso: true});
-    serviceHandleMap['auth'] = new WebServiceHandle('/auth', this.wsEnvironment);
+    serviceHandleMap['auth'] = new WebServiceHandle('/auth', this.wsEnvironment, false, undefined, this.options.tlsOptions);
     this._installRootService('/plugins', 'get', staticHandlers.plugins(this), 
         {needJson: false, needAuth: true, authType: "semi", isPseudoSso: false}); 
     this._installRootService('/plugins', 'use', staticHandlers.pluginLifecycle(this.options, pluginsArray),
       {needJson: true, needAuth: true, isPseudoSso: false});
-    serviceHandleMap['plugins'] = new WebServiceHandle('/plugins', this.wsEnvironment);
+    serviceHandleMap['plugins'] = new WebServiceHandle('/plugins', this.wsEnvironment, false, undefined, this.options.tlsOptions);
     this._installRootService('/server/proxies','get',staticHandlers.getServerProxies(this.options),
         {needJson: false, needAuth: false, isPseudoSso: false});
     this._installRootService('/server', 'use', staticHandlers.server(this.options), 
         {needJson: false, needAuth: true, isPseudoSso: false});
-    serviceHandleMap['server'] = new WebServiceHandle('/server', this.wsEnvironment);
+    serviceHandleMap['server'] = new WebServiceHandle('/server', this.wsEnvironment, false, undefined, this.options.tlsOptions);
     this._installRootService('/echo/*', 'get', staticHandlers.echo(),
         {needJson: false, needAuth: true, isPseudoSso: false});
-    serviceHandleMap['echo'] = new WebServiceHandle('/echo', this.wsEnvironment);
+    serviceHandleMap['echo'] = new WebServiceHandle('/echo', this.wsEnvironment, false, undefined, this.options.tlsOptions);
     this._installRootService('/apiManagement', 'use', staticHandlers.apiManagement(this),
         {needJson: false, needAuth: true, isPseudoSso: false});
     serviceHandleMap['apiManagement'] = new WebServiceHandle('/apiManagement', 
-        this.wsEnvironment);
+        this.wsEnvironment, false, undefined, this.options.tlsOptions);
     this.expressApp.use(staticHandlers.eureka());
     this.expressApp.use(staticHandlers.swagger(this.options.productCode));
   },
@@ -1862,7 +1860,7 @@ WebApp.prototype = {
       for (const version of Object.keys(group.versions)) {
         const service = group.versions[version];
         const subUrl = urlBase + zLuxUrl.makeServiceSubURL(service);
-        const handle = new WebServiceHandle(subUrl, this.wsEnvironment, false, service);
+        const handle = new WebServiceHandle(subUrl, this.wsEnvironment, false, service, this.options.tlsOptions);
         versionHandles[version] = handle;
         if (version === group.highestVersion) {
           const defaultSubUrl = urlBase + zLuxUrl.makeServiceSubURL(service, true);

--- a/plugins/sso-auth/lib/apimlHandler.js
+++ b/plugins/sso-auth/lib/apimlHandler.js
@@ -56,18 +56,7 @@ class ApimlHandler {
     this.logger = context.logger;    
     this.apimlConf = serverConf.node.mediationLayer.server;    
     this.gatewayUrl = `https://${this.apimlConf.hostname}:${this.apimlConf.gatewayPort}`;
-
-    if ((serverConf.node.https.certificateAuthorities === undefined) || (serverConf.node.allowInvalidTLSProxy===true)) {
-      this.logger.warn("This server is not configured with certificate authorities, so it will not validate certificates with APIML");
-      this.httpsAgent = new https.Agent({
-        rejectUnauthorized: false
-      });
-    } else {
-      this.httpsAgent = new https.Agent({
-        rejectUnauthorized: true,
-        ca: context.tlsOptions.ca
-      });
-    }
+    this.httpsAgent = new https.Agent(context.tlsOptions);
   }
 
   logout(request, sessionState) {


### PR DESCRIPTION
https://github.com/zowe/zlux-server-framework/pull/468 applied logic to allow the server to work in cert validation 'nonstrict' mode for SERVER activity.
For CLIENT activity, it was not done.
Client activity occurs in various places in the server, but over time we've created a "tlsOptions" object that can be reused by various clients, for passing around the CAs
Now, I want to pass in the whole object, because that will also pass in cipher customization, tls customization, and the nonstrict behavior.

this simplifies the logic a little because it makes various client behavior uniform. in some cases, this means making it less strict (in nonstrict mode) but in other cases, more strict (obeying cipher customization)