### PR TITLE
Update apimlHandler.js

### DIFF
--- a/plugins/sso-auth/lib/apimlHandler.js
+++ b/plugins/sso-auth/lib/apimlHandler.js
@@ -139,7 +139,7 @@ class ApimlHandler {
         this.doLogin(request, sessionState, false).then(result=> {
           resolve(result);
         }).catch(e=> {
-          Promise.resolve({success: false});
+          resolve({success: false}); // return the object directly
         });
       });
     } else if (request.cookies && request.cookies[TOKEN_NAME]) {


### PR DESCRIPTION
The catch block in the if (request.body) clause of the authenticate method returns a new Promise that resolves with an object {success: false}. However, this Promise is not returned from the authenticate method, and therefore, the result will not be used or processed by the calling code.