### PR TITLE
Fix CA loading

### DIFF
--- a/lib/webserver.js
+++ b/lib/webserver.js
@@ -278,37 +278,43 @@ WebServer.prototype = {
         }
       } 
       config.https.ipAddresses = uniqueIps;
-      let newEntries = [];
-      if(keyring_js && config.https.certificateAuthorities) { 
-        for (let j = 0; j < config.https.certificateAuthorities.length; j++) {
-          const entry = config.https.certificateAuthorities[j];
-          if (!entry.startsWith('safkeyring://')) {
-            //keep
-            newEntries.push(entry);
-          } else {
-            const {owner, ringName, label} = parseSafKeyringAddress(entry);
+      if(keyring_js && config.https.certificateAuthorities) {
+        let newEntries = [];
+        const locationsByType = splitCryptoLocationsByType(config.https.certificateAuthorities);
+        if (locationsByType.safkeyring) {
+          locationsByType.safkeyring.forEach((keyringLocation)=> {
+
+            const {userId, keyringName, label} = parseSafKeyringAddress(keyringLocation.startsWith('//') ? keyringLocation.substring(2) : keyringLocation);
             let certificateList;
-            if(owner && ringName) {
+            if(userId && keyringName) {
               try {
-                certificateList = keyring_js.listKeyring(owner, ringName);
+                certificateList = keyring_js.listKeyring(userId, keyringName);
               } catch(e) {
-                bootstrapLogger.warn('ZWED0179W', ringName, owner, e);
+                bootstrapLogger.warn('ZWED0179W', keyringName, userId, e);
               }
             }
             if(certificateList) {
               for(let i = 0; i < certificateList.length; i++) {
                 if(certificateList[i].usage === 'CERTAUTH') {
-                  let safKeyring = `${entry}&${certificateList[i].label}`;
+                  let safKeyring = `safkeyring:////${userId}/${keyringName}&${certificateList[i].label}`;
                   if(config.https.certificateAuthorities.indexOf(safKeyring) === -1) {
                     newEntries.push(safKeyring);
                   }
                 }
               }
             }
-          }
+
+
+
+          });
         }
+        if (locationsByType.file) {
+          locationsByType.file.forEach((fileLocation)=> {
+            newEntries.push(fileLocation);
+          });
+        }
+        config.https.certificateAuthorities = newEntries;
       }
-      config.https.certificateAuthorities = newEntries;
     }
     return canRun;
   }),

--- a/lib/webserver.js
+++ b/lib/webserver.js
@@ -71,7 +71,7 @@ function parseSafKeyringAddress(safEntry) {
     if (endNameIndex == -1 || endNameIndex == safEntry.length-1) {
       return {
         userId,
-        keyringName: safEntry.substring(endUserIndex+1,endNameIndex)
+        keyringName: safEntry.substring(endUserIndex+1)
       }
     } else {
       return {


### PR DESCRIPTION
CA loading broke with https://github.com/zowe/zlux-server-framework/pull/448 for both keyring & pem situations. This PR fixes it by rewriting the section which did the decision making about CAs. But, to get the full benefit of being able to run Zowe without needing to specify the PEM section when using keyrings, then this is needed too: https://github.com/zowe/zlux-app-server/pull/247