### PR TITLE
Bugfix reported on callservice as well as attempt to prevent crash on container, or at least trace the issue

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -192,6 +192,7 @@ Server.prototype = {
       //networking
       hostname: this.componentConfig.node.hostname,
       port: this.port,
+      isHttps: util.isServerHttps(this.zoweConfig),
       proxiedHost: this.componentConfig.agent?.host,
       proxiedPort: this.componentConfig.agent?.https?.port || this.componentConfig.agent?.http?.port,
       isProxiedHttps: proxiedOptions?.protocol == 'https:',

--- a/utils/yamlConfig.ts
+++ b/utils/yamlConfig.ts
@@ -185,12 +185,16 @@ function resolveTemplates(property: any, topObj: any): {property: any, templates
       result = property;
       for (let i = 0; i < property.length; i++) {
         let item = resolveTemplates(property[i], topObj);
-        if (debugLog===true){ console.log(`resolved ${property[i]} as ${item.property}`); }
+        if (debugLog===true && (item.property != property[i])) {
+          console.log(`resolved ${JSON.stringify(property[i])} as ${JSON.stringify(item.property,null,2)}`);
+        }
         property[i] = item.property;
         templateFound = templateFound || item.templates;
       }
-    } else {
-      // console.log('decend');
+    } else if (property) {
+      if (debugLog === true) {
+        console.log('decend on '+JSON.stringify(property).substring(0,40));
+      }
       result = property;
       const keys: string[] = Object.keys(property);    
       keys.forEach((key:string)=> {


### PR DESCRIPTION
some logic was depending upon isHttps which was missing, so added it back.
Other fix I'm trying to do here is that containers are crashing with:
```
resolved [object Object] as [object Object]
resolved [object Object] as [object Object]
/component/share/zlux-server-framework/utils/yamlConfig.js:197
            var keys = Object.keys(property);
                              ^

TypeError: Cannot convert undefined or null to object
    at Function.keys (<anonymous>)
    at resolveTemplates (/component/share/zlux-server-framework/utils/yamlConfig.js:197:31)
    at /component/share/zlux-server-framework/utils/yamlConfig.js:201:30
```

So, noticed the resolution spam needs to be trimmed and stringified, and also that how is an undefined getting treated as an object? i'm not sure, maybe its a function or something, so I added tracing to print it.