### PR TITLE
Add more no-caching headers

### DIFF
--- a/lib/webapp.js
+++ b/lib/webapp.js
@@ -1228,8 +1228,9 @@ const commonMiddleware = {
     return function httpCachingHeaders(req, res, next) {
       //service.httpCaching = false means
       //"Cache-control: no-store" and "Pragma: no-cache"
-      res.set('Cache-control', 'no-store');
+      res.set('Cache-control', 'no-cache, no-store');
       res.set('Pragma', 'no-cache');
+      res.set('Expires', '0');
       next();
     }
   },


### PR DESCRIPTION
The server currently has a way you can decide if you want your network calls to be cached by the browser or not. Usually, you'd want to cache static content but not dynamic content like an api.
The headers we set for no-caching weren't sufficient for all browsers, so security scanners recommend this extra set of headers in this PR.