### PR TITLE
Updated eureka data to current recommendations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to the Zlux Server Framework package will be documented in this file..
 This repo is part of the app-server Zowe Component, and the change logs here may appear on Zowe.org in that section.
 
+## 2.11.0
+
+- Enhancement: The title and description of the app server within the api catalog has been updated to be more complete, accurate, and useful.
+
 ## 2.10.0
 
 - Enhancement: Avoid going directly to the Desktop when the gateway is active, by redirecting to the gateway equivalent homepage when the homepage is accessed. The redirect behavior can be prevented if desired by using the query parameter `?zwed-no-redirect=1` in your URL. (#449)

--- a/lib/apiml.js
+++ b/lib/apiml.js
@@ -50,35 +50,29 @@ const MEDIATION_LAYER_INSTANCE_DEFAULTS = (zluxProto, zluxHostname, zluxPort) =>
     renewalIntervalInSecs: 30 // heartbeatInterval
   },
   metadata: {
-    "routed-services.1.gateway-url": "/api/v1",
-    "routed-services.1.service-url": "/",
-    "routed-services.2.gateway-url": "/ui/v1",
-    "routed-services.2.service-url": "/",
-    "routed-services.3.gateway-url": "/ws/v1",
-    "routed-services.3.service-url": "/",
-    "routed-services.4.gateway-url": "/v1/api-doc",
-    "routed-services.4.service-url": "/",
+    "apiml.routes.api__v1.gatewayUrl": "/api/v1",
+    "apiml.routes.api__v1.serviceUrl": "/",
+    "apiml.routes.ui__v1.gatewayUrl": "/ui/v1",
+    "apiml.routes.ui__v1.serviceUrl": "/",
+    "apiml.routes.ws__v1.gatewayUrl": "/ws/v1",
+    "apiml.routes.ws__v1.serviceUrl": "/",
 
-    'mfaas.discovery.catalogUiTile.id': 'zlux',
-    'mfaas.discovery.catalogUiTile.title': 'Zowe Application Server',
-    'mfaas.discovery.catalogUiTile.description': 'The Proxy Server is an '
-       + 'HTTP, HTTPS, and Websocket server built upon NodeJS and ExpressJS. '
-       + 'This serves static content via "Plugins", and is extensible by '
-       + 'REST and Websocket "Dataservices" optionally present within Plugins.',
-    'mfaas.discovery.catalogUiTile.version': '1.0.0',
+    "apiml.apiInfo.0.apiId": "org.zowe.zlux",
+    "apiml.apiInfo.0.gatewayUrl": "api/v1",
+    "apiml.apiInfo.0.swaggerUrl": `${zluxProto}://${zluxHostname}:${zluxPort}/api-docs/server`,
+    "apiml.apiInfo.0.version": "1.0.0",
 
-    'mfaas.discovery.service.title': 'Zowe Application Server',
-    'mfaas.discovery.service.description': 'The Proxy Server is an HTTP, '
-      + 'HTTPS, and Websocket server built upon NodeJS and ExpressJS. This '
-      + 'serves static content via "Plugins", and is extensible by REST and '
-      + 'Websocket "Dataservices" optionally present within Plugins.',
+    "apiml.catalog.tile.id": "zlux",
+    "apiml.catalog.tile.title": "App Server",
+    "apiml.catalog.tile.description": `Zowe's App Server is the component of Zowe which serves the Zowe Desktop. It is an extensible webserver for HTTPS and Websocket APIs written using ExpressJS. Extensions are delivered as 'App Framework Plugins', and several are included by default.`,
+    "apiml.catalog.tile.version": zluxUtil.getZoweVersion(),
 
-    'mfaas.api-info.apiVersionProperties.v1.title': 'Zowe Application Server API',
-    'mfaas.api-info.apiVersionProperties.v1.description': 'An API for the ZLux '
-      +' Proxy Server',
-    'mfaas.api-info.apiVersionProperties.v1.version': '1.0.0',
-    'mfaas.api-info.apiVersionProperties.v1.version': '1.0.0',
-    'apiml.apiInfo.api-v1.swaggerUrl':`${zluxProto}://${zluxHostname}:${zluxPort}/api-docs/server`,
+
+    "apiml.service.title": "Core and Plugin Dataservice APIs",
+    "apiml.service.description": `This list includes core APIs for management of plugins, management of the server itself, and APIs brought by plugins and the app server agent, ZSS. Plugins that do not bring their own API documentation are shown here as stubs.`,
+
+    "apiml.authentication.sso": "true",
+
     'apiml.authentication.scheme': 'zoweJwt'
   }
 }};

--- a/lib/assets/i18n/log/messages_en.json
+++ b/lib/assets/i18n/log/messages_en.json
@@ -378,5 +378,6 @@
   "ZWED0155E":"RESERVED: (%s) is not a supported endpoint for %s. Skipping (%s)... Supported: %s",
   "ZWED0156E":"RESERVED: Could not register default plugins into app-server",
   "ZWED0157E":"RESERVED: Could not register default plugin %s into app-server",
-  "ZWED0158E":"Could not listen on address %s:%s. Insufficient permissions to perform port bind."
+  "ZWED0158E":"Could not listen on address %s:%s. Insufficient permissions to perform port bind.",
+  "ZWED0159E":"Could not read zowe manifest, version unknown"
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -72,6 +72,8 @@ function Server(zoweConfig, configLocation) {
   this.setLogLevels();
   const productCode = util.getProductCode(zoweConfig); 
   unp.setProductCode(productCode);
+
+  util.setZoweVersionFromManifest(zoweConfig); 
   
   this.componentConfig.node.hostname = this.componentConfig.node.hostname ? this.componentConfig.node.hostname : os.hostname();
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -19,6 +19,7 @@ if (!global.COM_RS_COMMON_LOGGER) {
 
 const path = require('path');
 const fs = require('fs');
+const fsPromises = require('node:fs/promises');
 const Promise = require('bluebird');
 const ipaddr = require('ipaddr.js');
 const dns = require('dns');
@@ -90,6 +91,30 @@ module.exports.initLoggerMessages = function initLoggerMessages(logLanguage) {
     loggers.storeLogger._messages = messages;
   }
 };
+
+let zoweVersion = "0.0.0";
+//This will read manifest.json within zowe's runtime directory, location known by zowe config.
+module.exports.setZoweVersionFromManifest = setZoweVersionFromManifest(zoweConfig) {
+  if (zoweConfig.zowe.runtimeDirectory) {
+    try {
+      const contents = fsPromises.readFileSync(path.join(zoweConfig.zowe.runtimeDirectory, 'manifest.json'), {encoding: 'utf8'});
+      if (contents) {
+        const asJson = JSON.parse(contents);
+        if (asJson.version) {
+          zoweVersion = asJson.version;
+        } else {
+          loggers.utilLogger.severe('ZWED0159E');
+        }
+      }
+    } catch (e) {
+      loggers.utilLogger.severe('ZWED0159E');
+    }
+  }
+}
+
+module.exports.getZoweVersion = getZoweVersion() {
+  return zoweVersion;
+}
 
 //maybe better in apiml.js but there would be a circular dependency around the logger init.
 function getPrefixForService(serviceName, type, version) {

--- a/lib/util.js
+++ b/lib/util.js
@@ -94,7 +94,7 @@ module.exports.initLoggerMessages = function initLoggerMessages(logLanguage) {
 
 let zoweVersion = "0.0.0";
 //This will read manifest.json within zowe's runtime directory, location known by zowe config.
-module.exports.setZoweVersionFromManifest = setZoweVersionFromManifest(zoweConfig) {
+module.exports.setZoweVersionFromManifest = function setZoweVersionFromManifest(zoweConfig) {
   if (zoweConfig.zowe.runtimeDirectory) {
     try {
       const contents = fsPromises.readFileSync(path.join(zoweConfig.zowe.runtimeDirectory, 'manifest.json'), {encoding: 'utf8'});

--- a/lib/util.js
+++ b/lib/util.js
@@ -112,7 +112,7 @@ module.exports.setZoweVersionFromManifest = function setZoweVersionFromManifest(
   }
 }
 
-module.exports.getZoweVersion = getZoweVersion() {
+module.exports.getZoweVersion = function getZoweVersion() {
   return zoweVersion;
 }
 


### PR DESCRIPTION
The data sent in the eureka conversation to the apiml is about 5 years old and has properties that are no longer used anywhere else. I'm surprised this didn't cause more issues, but we were at least seeing that the title and description of the app-server as seen in the api catalog was highly outdated, and not very useful.

We were seeing a behavior with client certificates recently where if a client certificate is used in a browser but its one that isnt valid for zowe, then zowe will reject it in 1 of 2 ways:
- if accessing the api catalog, a login page will be shown since the client certificate wasnt enough
- if accessing the desktop, the gateway will intercept the desktop, and send back a 401 instead. this is terrible UX that we want to avoid, it prevents people from getting any further with login.

To fix the issue above, my thought is that there's something different in the way api catalog is registered to apiml versus app server. So, I updated the eureka info of the app server to have property names and values based upon api catalog, to more closely match what's good values these days. My hope is that it fixes the 401 issue, but regardless it does make the catalog tile more useful.