### PR TITLE
fix  catalog tile title

### DIFF
--- a/lib/apiml.js
+++ b/lib/apiml.js
@@ -68,7 +68,7 @@ const MEDIATION_LAYER_INSTANCE_DEFAULTS = (zluxProto, zluxHostname, zluxPort) =>
     "apiml.catalog.tile.version": zluxUtil.getZoweVersion(),
 
 
-    "apiml.service.title": "Core and Plugin Dataservice APIs",
+    "apiml.service.title": "App Server",
     "apiml.service.description": `This list includes core APIs for management of plugins, management of the server itself, and APIs brought by plugins and the app server agent, ZSS. Plugins that do not bring their own API documentation are shown here as stubs.`,
 
     "apiml.authentication.sso": "true",


### PR DESCRIPTION
The apiml catalog title appears to be swapped around from what one would expect.
The item at the top of the page is not the item that is shown on the tile. instead, it's the inner item.
this leads me with no choice i can see other than to label both the same, to prevent the UI from looking like this: 
![image](https://github.com/zowe/zlux-server-framework/assets/30730276/5337c778-b879-47bf-b93c-5c75bf3c4c34)
