### PR TITLE
update changelog when its PR

### DIFF
--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -45,6 +45,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
   update-changelog:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     outputs:
       was_updated: ${{ steps.check-change.outputs.change_detected }}
@@ -120,6 +121,7 @@ jobs:
           fi
 
   check_changelog:
+    if: github.event_name == 'pull_request'
     needs: update-changelog
     runs-on: ubuntu-latest
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ This repo is part of the app-server Zowe Component, and the change logs here may
 - Enhancement: The title and description of the app server within the api catalog has been updated to be more complete, accurate, and useful.
 
 ## 2.10.0
- 
 
 - Enhancement: Avoid going directly to the Desktop when the gateway is active, by redirecting to the gateway equivalent homepage when the homepage is accessed. The redirect behavior can be prevented if desired by using the query parameter `?zwed-no-redirect=1` in your URL. (#449)
 - Bugfix: Proxy when encountering an error, now errors out with 500 Internal Server Error (#487)


### PR DESCRIPTION
Small update in changelog action, it will check and update changelog when its a PR, Currently some builds show that they are failing because of the changelog, the changelog logic shouldn't run unless if its a pull request.