### PR TITLE
Update semver to 5.7.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "normalize-url": "~7.0.0",
         "require-from-string": "~2.0.2",
         "rimraf": "~2.6.3",
-        "semver": "~5.5.1",
+        "semver": "~5.7.2",
         "swagger-parser": "~10.0.3",
         "ws": "^6.2.2",
         "yaml": "~1.10.2",
@@ -2311,9 +2311,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/semver": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
-      "integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "bin": {
         "semver": "bin/semver"
       }
@@ -4706,9 +4706,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "semver": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
-      "integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw=="
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g=="
     },
     "send": {
       "version": "0.18.0",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "normalize-url": "~7.0.0",
     "require-from-string": "~2.0.2",
     "rimraf": "~2.6.3",
-    "semver": "~5.5.1",
+    "semver": "~5.7.2",
     "swagger-parser": "~10.0.3",
     "ws": "^6.2.2",
     "yaml": "~1.10.2",


### PR DESCRIPTION
## Proposed changes
- Update `semver` to version `5.7.2` (because of blackduck reports)

## Type of change
Please delete options that are not relevant.
- [x] Chore, repository cleanup, updates the dependencies.
