### PR TITLE
Update TLS configuration to disallow downgrades

### DIFF
--- a/lib/webserver.js
+++ b/lib/webserver.js
@@ -357,22 +357,10 @@ WebServer.prototype = {
           minTls = maxTls;
         }
 
-        this.httpsOptions.secureOptions = consts.SSL_OP_NO_SSLv2 | consts.SSL_OP_NO_SSLv3;
+        this.httpsOptions.secureOptions = consts.SSL_OP_NO_SSLv2 | consts.SSL_OP_NO_SSLv3 | consts.SSL_OP_NO_TLSv1 | consts.SSL_OP_NO_TLSv1_1;
 
         //TLS versions will be enabled unless explicitly disabled
-        // Though the default is to explicitly disable all below v1.2
-        if (minTls <= constants.TLS_VERSION["TLSv1.0"] && maxTls >= constants.TLS_VERSION["TLSv1.0"]) {
-          bootstrapLogger.debug("TLS 1.0 on");
-        } else {
-          bootstrapLogger.debug("TLS 1.0 off");
-          this.httpsOptions.secureOptions = this.httpsOptions.secureOptions | consts.SSL_OP_NO_TLSv1;
-        }
-        if (minTls <= constants.TLS_VERSION["TLSv1.1"] && maxTls >= constants.TLS_VERSION["TLSv1.1"]) {
-          bootstrapLogger.debug("TLS 1.1 on");
-        } else {
-          bootstrapLogger.debug("TLS 1.1 off");
-          this.httpsOptions.secureOptions = this.httpsOptions.secureOptions | consts.SSL_OP_NO_TLSv1_1;
-        }
+        // Though all below v1.2 are disabled regardless.
         if (minTls <= constants.TLS_VERSION["TLSv1.2"] && maxTls >= constants.TLS_VERSION["TLSv1.2"]) {
           bootstrapLogger.debug("TLS 1.2 on");
         } else {


### PR DESCRIPTION
After discussion, it was decided it would be best not to introduce the feature for allowing users to downgrade their TLS setup. We'll keep it at 1.2 minimum unless there is some high demand otherwise.