### PR TITLE
Fix saf list concat

### DIFF
--- a/lib/webserver.js
+++ b/lib/webserver.js
@@ -137,7 +137,7 @@ function loadPem(locations, type, keyrings, pass) {
   const types = Object.keys(locationsByType);
   let saf = [];
   types.filter(type=> type.startsWith('safkeyring'))
-       .forEach((type)=> { saf.concat(locationsByType[type]) });
+       .forEach((type)=> { saf = saf.concat(locationsByType[type]) });
   if (saf && os.platform() != 'os390') {
     bootstrapLogger.severe('ZWED0145E');//Cannot load SAF keyring content outside of z/OS'
     process.exit(constants.EXIT_NO_SAFKEYRING);


### PR DESCRIPTION
This PR attempts to fix keyring regression seen.
I've noticed the list concat of different keyring types from #467 wasn't correctly updating the saf array.