### PR TITLE
Fix for detecting whether or not in HA mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to the Zlux Server Framework package will be documented in this file..
 This repo is part of the app-server Zowe Component, and the change logs here may appear on Zowe.org in that section.
+
+## 2.14.0
+- Bugfix: App-server would not correctly detect when it was running in a high-availability configuration environment.
     
 ## 2.13.0
 - Added support for using zowe.network and components.app-server.zowe.network to set listener IP and TLS properties including max and min version, ciphers, and ECDH curves. (#511)

--- a/lib/util.js
+++ b/lib/util.js
@@ -490,9 +490,11 @@ module.exports.getCookieName = (cookieIdentifier) => {
   return 'connect.sid.' + cookieIdentifier;
 }
 
+
+const HA_INSTANCE_COUNT=Object.keys(process.env).filter(key=>!key.match(/ZWE_haInstances_.*_components_.*hostname.*/)).filter(key=>key.match(/ZWE_haInstances_.*hostname/)).length;
 const isHaMode = module.exports.isHaMode = function () {
-  const haInstanceCount = +process.env['ZWE_HA_INSTANCES_COUNT'];
-  return (!isNaN(haInstanceCount) && haInstanceCount > 1);
+  let isHaMode = (!isNaN(HA_INSTANCE_COUNT) && HA_INSTANCE_COUNT > 1);
+  return isHaMode;
 }
 
 //TODO, ATTLS


### PR DESCRIPTION
App-server was determining whether or not to do HA-related actions depending on whether it detected an environment variable that appears to never have been in v2, and maybe was from v1.

Now, I try to detect if we're in an HA mode depending environment variables that fit the pattern of `ZWE_haInstances_<something here>_hostname` but NOT `ZWE_haInstances_<something here>_components_<...>hostname`

This pattern attempts to count the quantity of items in the haInstances object, without counting references to hostname that could instead be present in some components.

Usually we would read the zowe yaml for this, but the existing, exported function doesnt take the config as an argument, so I do not want to break any API.