### PR TITLE
Fix gatway gateway typo

### DIFF
--- a/plugins/sso-auth/lib/apimlHandler.js
+++ b/plugins/sso-auth/lib/apimlHandler.js
@@ -66,7 +66,7 @@ class ApimlHandler {
       }
       const gatewayUrl = this.gatewayUrl;
       const options = {
-        hostname: this.apimlConf.gatwayHostname,
+        hostname: this.apimlConf.gatewayHostname,
         port: this.apimlConf.gatewayPort,
 //TODO uncertainty about using apicatalog route instead of something part of the gateway itself
         path: '/apicatalog/api/v1/auth/logout',


### PR DESCRIPTION
Fixed typo that had the consequence that instead of reaching gateway by its hostname, localhost was tried.