### PR TITLE
Bugfix for https and http addresses merge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to the Zlux Server Framework package will be documented in this file..
 This repo is part of the app-server Zowe Component, and the change logs here may appear on Zowe.org in that section.
 
+## 2.15.0
+- Bugfix: App-server could not run in HTTP mode for AT-TLS setup because it was not able to merge HTTPS and HTTP addresses. (#984)
+
 ## 2.14.0
 - Bugfix: App-server could not load when multiple discovery servers were present and the app-server was unable to reach the first one specified. Now, the app-server will iterate through the list of servers until an accessible one is reached. (#522)
 - Bugfix: App-server would not correctly detect when it was running in a high-availability configuration environment. (#521)

--- a/lib/util.js
+++ b/lib/util.js
@@ -514,10 +514,11 @@ module.exports.getBestHostname = function(zoweConfig) {
 }
 
 module.exports.getListeningAddresses = function(zoweConfig) {
-  let addrs = getHttpsListeningAddresses(zoweConfig);
+  let httpsAddrsCollection = getHttpsListeningAddresses(zoweConfig);
+  let addrs = [...httpsAddrsCollection];
   let otherAddrs = getHttpListeningAddresses(zoweConfig);
   otherAddrs.forEach((addr)=> {
-    if (addrs.indexOf(addr) == -1) { addrs.push(otherAddrs); }
+    if (addrs.indexOf(addr) == -1) { addrs.push(addr); }
   });
   return addrs;
 }


### PR DESCRIPTION
`getListeningAddresses` function has two issues in it 
- `getHttpsListeningAddresses` returns a not extensible collection so we cannot push new elements in.
- on `otherAddrs` iteration it tries to push complete collection into `addrs` instead of one address.

Covering https://github.com/zowe/zlux/issues/984