### PR TITLE
Fix keyring existence check

### DIFF
--- a/lib/webserver.js
+++ b/lib/webserver.js
@@ -138,10 +138,10 @@ function loadPem(locations, type, keyrings, pass) {
   let saf = [];
   types.filter(type=> type.startsWith('safkeyring'))
        .forEach((type)=> { saf = saf.concat(locationsByType[type]) });
-  if (saf && os.platform() != 'os390') {
+  if (saf.length > 0 && os.platform() != 'os390') {
     bootstrapLogger.severe('ZWED0145E');//Cannot load SAF keyring content outside of z/OS'
     process.exit(constants.EXIT_NO_SAFKEYRING);
-  } else if (saf && keyring_js) {
+  } else if (saf.length > 0 && keyring_js) {
     saf.forEach((safEntry)=> {
       /*
         In the latest code it's possible the entry could start with
@@ -181,7 +181,7 @@ function loadPem(locations, type, keyrings, pass) {
                              userId, keyringName, label);
       }
     });
-  } else if (saf && !keyring_js) {
+  } else if (saf.length > 0 && !keyring_js) {
     //Cannot load SAF keyring due to missing keyring_js library');
     bootstrapLogger.warn('ZWED0150E');
   }


### PR DESCRIPTION
In prior code, the `saf` variable would be undefined when there are no keyrings. In the latest code, it is always defined as an array, but could be empty. Each `if (saf)` check therefore needs to check length instead of existence.