### PR TITLE
Read File Sync with proper require

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -19,7 +19,6 @@ if (!global.COM_RS_COMMON_LOGGER) {
 
 const path = require('path');
 const fs = require('fs');
-const fsPromises = require('node:fs/promises');
 const Promise = require('bluebird');
 const ipaddr = require('ipaddr.js');
 const dns = require('dns');
@@ -97,7 +96,7 @@ let zoweVersion = "0.0.0";
 module.exports.setZoweVersionFromManifest = function setZoweVersionFromManifest(zoweConfig) {
   if (zoweConfig.zowe.runtimeDirectory) {
     try {
-      const contents = fsPromises.readFileSync(path.join(zoweConfig.zowe.runtimeDirectory, 'manifest.json'), {encoding: 'utf8'});
+      const contents = fs.readFileSync(path.join(zoweConfig.zowe.runtimeDirectory, 'manifest.json'), {encoding: 'utf8'});
       if (contents) {
         const asJson = JSON.parse(contents);
         if (asJson.version) {


### PR DESCRIPTION
<!-- Thank you for submitting a PR to Zowe! To help us understand, test, and give feedback on your code, please fill in the details below. -->

## Proposed changes
The message `ZWED0159E - Could not read zowe manifest, version unknown` is generated due to wrong `require` function:
```
      let contents = fsPromises.readFileSync(path.join(zoweConfig.zowe.runtimeDirectory, 'manifest.json'), {encoding: 'utf8'});  
                                ^                                                                   
TypeError: fsPromises.readFileSync is not a function                                                
```

Fixes: 
* https://github.com/zowe/zlux/issues/983
* Partially:
  * https://github.com/zowe/community/issues/2135
  * https://github.com/zowe/zowe-install-packaging/issues/3656

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

## PR Checklist
Please delete options that are not relevant.
- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zlux/blob/master/CONTRIBUTING.md))
- [x] Relevant update to CHANGELOG.md
- [x] My changes generate no new warnings

## Testing
No ZWED0159E with fix.

CHANGELOG: The message "ZWED0159E - Could not read zowe manifest, version unknown" is no longer printed always
VERSION 2.16.0
