### PR TITLE
Log in local timezone if configured to

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,11 @@
 All notable changes to the Zlux Server Framework package will be documented in this file.
 This repo is part of the app-server Zowe Component, and the change logs here may appear on Zowe.org in that section.
 
+## 3.1.0
+- Enhancement: Server can be set to log using the local timezone via property `zowe.logger.timezone: environment` which will use the value of the TZ environment variable. (#572)
+
 ## 3.0.0
-- Enhancement: Add ability for server to dynamically load plugin web content based on `entryPoint` specification in the
-`pluginDefinition.json`
+- Enhancement: Add ability for server to dynamically load plugin web content based on `entryPoint` specification in the `pluginDefinition.json`
 
 ## 2.17.0
 - Enhancement: Added function `isClientAttls(zoweConfig)` within `libs/util.js`. Whenever a plugin makes a network request, it should always use this to determine if a normally HTTPS request should instead be made as HTTP due to AT-TLS handling the TLS when enabled. (#544)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the Zlux Server Framework package will be documented in t
 This repo is part of the app-server Zowe Component, and the change logs here may appear on Zowe.org in that section.
 
 ## 3.4.0
-- Enhancement: Server can be set to log using the local timezone via property `zowe.logging.timezone: environment` which will use the value of the TZ environment variable. (#572)
+- Enhancement: Server can be set to log using the local timezone via property `zowe.logging.timezone: local` which will use the value of the TZ environment variable. (#572)
 
 ## 3.0.0
 - Enhancement: Add ability for server to dynamically load plugin web content based on `entryPoint` specification in the `pluginDefinition.json`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 All notable changes to the Zlux Server Framework package will be documented in this file.
 This repo is part of the app-server Zowe Component, and the change logs here may appear on Zowe.org in that section.
 
-## 3.1.0
-- Enhancement: Server can be set to log using the local timezone via property `zowe.logger.timezone: environment` which will use the value of the TZ environment variable. (#572)
+## 3.4.0
+- Enhancement: Server can be set to log using the local timezone via property `zowe.logging.timezone: environment` which will use the value of the TZ environment variable. (#572)
 
 ## 3.0.0
 - Enhancement: Add ability for server to dynamically load plugin web content based on `entryPoint` specification in the `pluginDefinition.json`

--- a/lib/util.js
+++ b/lib/util.js
@@ -13,7 +13,12 @@
 
 if (!global.COM_RS_COMMON_LOGGER) {
   const loggerFile = require('../../zlux-shared/src/logging/logger.js');
-  global.COM_RS_COMMON_LOGGER = new loggerFile.Logger();
+  let msOffset = undefined;
+  if (process.env.ZWE_zowe_logging_timezone == 'environment') {
+    let d = new Date();
+    msOffset = d.getTimezoneOffset() * 1000 * 60;
+  }
+  global.COM_RS_COMMON_LOGGER = new loggerFile.Logger(msOffset);
   global.COM_RS_COMMON_LOGGER.addDestination(global.COM_RS_COMMON_LOGGER.makeDefaultDestination(true,true,true,true,true));
 }
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -14,9 +14,12 @@
 if (!global.COM_RS_COMMON_LOGGER) {
   const loggerFile = require('../../zlux-shared/src/logging/logger.js');
   let msOffset = undefined;
-  if (process.env.ZWE_zowe_logging_timezone == 'environment') {
-    let d = new Date();
-    msOffset = d.getTimezoneOffset() * 1000 * 60;
+  let timezonePreference = process.env.ZWE_zowe_logging_timezone;
+  if (timezonePreference) {
+    if (timezonePreference.toLowerCase() == 'local') {
+      let d = new Date();
+      msOffset = d.getTimezoneOffset() * 1000 * 60;
+    }
   }
   global.COM_RS_COMMON_LOGGER = new loggerFile.Logger(msOffset);
   global.COM_RS_COMMON_LOGGER.addDestination(global.COM_RS_COMMON_LOGGER.makeDefaultDestination(true,true,true,true,true));

--- a/utils/packaging-utils.js
+++ b/utils/packaging-utils.js
@@ -11,11 +11,13 @@
 const path = require('path');
 const Promise = require('bluebird');
 const fs = require('graceful-fs');
-//assuming that this is file isnt being called from another that is already using the logger... else expect strange logs
-const logging = require('../../zlux-shared/src/logging/logger.js');
-const coreLogger = new logging.Logger();
-//simple program, no need for logger names to be displayed
-coreLogger.addDestination(coreLogger.makeDefaultDestination(true,false,false));
+let coreLogger = global.COM_RS_COMMON_LOGGER;
+if (!global.COM_RS_COMMON_LOGGER) { //app-server creates logger prior to this running, so don't create twice.
+  const logging = require('../../zlux-shared/src/logging/logger.js');
+  coreLogger = new logging.Logger();
+  //simple program, no need for logger names to be displayed
+  coreLogger.addDestination(coreLogger.makeDefaultDestination(true,false,false));
+}
 
 let logger;
 


### PR DESCRIPTION
This PR checks the zowe property `zowe.logging.timezone: local` via environment variable `ZWE_zowe_logging_timezone` (due to early load of logging, the yaml isnt available)
when this is set to "environment", the server will get the timezone from nodejs (nodejs knows system timezone, seems to respect the TZ environment variable)

It will apply this timezone as an offset so that the server can log in local time instead of UTC time.
The default is still UTC time via `zowe.logging.timezone: utc`