### PR TITLE
Fix to work with apiml customized token name in v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to the Zlux Server Framework package will be documented in this file..
 This repo is part of the app-server Zowe Component, and the change logs here may appear on Zowe.org in that section.
 
+## 2.18.1
+- Fix: Server would not work when API Gateway token name was customized (#574)
+
 ## 2.17.0
 - Enhancement: Added function `isClientAttls(zoweConfig)` within `libs/util.js`. Whenever a plugin makes a network request, it should always use this to determine if a normally HTTPS request should instead be made as HTTP due to AT-TLS handling the TLS when enabled. (#544)
 - Bugfix: Fixed function `isServerAttls(zoweConfig)` within `libs/util.js`, which was preventing using AT-TLS with app-server. (#544)

--- a/plugins/sso-auth/lib/apimlHandler.js
+++ b/plugins/sso-auth/lib/apimlHandler.js
@@ -20,7 +20,6 @@ const zluxUtil = require('../../../lib/util');
  * However, it is not clear if that is configurable or if APIML may use a different value under other circumstances
  */
 const DEFAULT_EXPIRATION_MS = 29700000;
-const TOKEN_NAME = 'apimlAuthenticationToken';
 
 function readUtf8FilesToArray(fileArray) {
   var contentArray = [];
@@ -56,7 +55,7 @@ function readUtf8FilesToArray(fileArray) {
 class ApimlHandler {
   constructor(pluginDef, pluginConf, componentConf, context, zoweConf) {
     this.logger = context.logger;
-    this.apimlConf = componentConf.node.mediationLayer.server;    
+    this.apimlConf = componentConf.node.mediationLayer.server;
     this.tokenName = this.apimlConf.cookieName;
     this.gatewayUrl = `https://${this.apimlConf.gatewayHostname}:${this.apimlConf.gatewayPort}`;
     this.isHttps = !zluxUtil.isClientAttls(zoweConf);

--- a/plugins/sso-auth/lib/apimlHandler.js
+++ b/plugins/sso-auth/lib/apimlHandler.js
@@ -56,12 +56,8 @@ function readUtf8FilesToArray(fileArray) {
 class ApimlHandler {
   constructor(pluginDef, pluginConf, componentConf, context, zoweConf) {
     this.logger = context.logger;
-    if (zoweConf.zowe.cookieIdentifier && (zoweConf.components.gateway?.apiml?.security?.auth?.uniqueCookie === true)) {
-      this.tokenName = `${TOKEN_NAME}.${zoweConf.zowe.cookieIdentifier}`;
-    } else {
-      this.tokenName = TOKEN_NAME;
-    }
     this.apimlConf = componentConf.node.mediationLayer.server;    
+    this.tokenName = this.apimlConf.cookieName;
     this.gatewayUrl = `https://${this.apimlConf.gatewayHostname}:${this.apimlConf.gatewayPort}`;
     this.isHttps = !zluxUtil.isClientAttls(zoweConf);
     if (this.isHttps) {


### PR DESCRIPTION
Depends upon https://github.com/zowe/zlux-app-server/pull/328

## Proposed changes
This PR changes sso-auth to identify the correct name of the APIML cookie when it is customized. Prior, sso-auth could only handle the default cookie name.

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

## PR Checklist
Please delete options that are not relevant.
- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zlux/blob/master/CONTRIBUTING.md))
- [x] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
- [x] Relevant update to CHANGELOG.md
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works, or describe a test method below

## Testing
Setup APIML customized cookie as described within https://672897b8df9db03907cd59a6--zowe-docs-master.netlify.app/stable/user-guide/api-mediation/configuration-unique-cookie-name-for-multiple-zowe-instances

Then, check to see if you can login to the desktop.
Do not check if the editor works. This requires a change in ZSS which will be in a separate PR. It is expected not to work until then.