### PR TITLE
Fix Eureka Registration when ATTLS (v2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to the Zlux Server Framework package will be documented in this file..
 This repo is part of the app-server Zowe Component, and the change logs here may appear on Zowe.org in that section.
 
+## 2.18.1
+- Bugfix: App-server could not register with discovery server when AT-TLS was enabled for app-server. (#581)
+
 ## 2.17.0
 - Enhancement: Added function `isClientAttls(zoweConfig)` within `libs/util.js`. Whenever a plugin makes a network request, it should always use this to determine if a normally HTTPS request should instead be made as HTTP due to AT-TLS handling the TLS when enabled. (#544)
 - Bugfix: Fixed function `isServerAttls(zoweConfig)` within `libs/util.js`, which was preventing using AT-TLS with app-server. (#544)

--- a/lib/apiml.js
+++ b/lib/apiml.js
@@ -171,7 +171,7 @@ ApimlConnector.prototype = {
       httpEnabled: false,
       httpsEnabled: true
     };
-    const proto = 'https';
+    const proto = this.isClientAttls ? 'http' : 'https';
 
     log.debug("ZWED0141I", proto, this.port); //"Protocol:", proto, "Port", port);
     log.debug("ZWED0142I", JSON.stringify(protocolObject)); //"Protocol Object:", JSON.stringify(protocolObject));
@@ -228,7 +228,7 @@ ApimlConnector.prototype = {
   },*/
   
   registerMainServerInstance() {
-    const overrideOptions = Object.assign({},this.tlsOptions);
+    const overrideOptions = this.isClientAttls ? {} : Object.assign({},this.tlsOptions)
     if (!this.tlsOptions.rejectUnauthorized) {
       //Keeping these certs causes an openssl error 46, unknown cert error in a dev environment
       delete overrideOptions.cert;
@@ -240,7 +240,8 @@ ApimlConnector.prototype = {
       eureka: Object.assign({}, MEDIATION_LAYER_EUREKA_DEFAULTS, this.eurekaOverrides),
       requestMiddleware: function (requestOpts, done) {
         done(Object.assign(requestOpts, overrideOptions));
-      }
+      },
+      ssl: !this.isClientAttls
     }
     log.debug("ZWED0144I", JSON.stringify(zluxProxyServerInstanceConfig, null, 2)); //log.debug("zluxProxyServerInstanceConfig: " 
         //+ JSON.stringify(zluxProxyServerInstanceConfig, null, 2))
@@ -280,7 +281,12 @@ ApimlConnector.prototype = {
   },
 
   getServiceUrls() {
-    return this.discoveryUrls.map(url => url + (url.endsWith('/') ? '' : '/') + 'apps');
+    let urls = this.discoveryUrls.map(url => url + (url.endsWith('/') ? '' : '/') + 'apps');
+    if (this.isClientAttls) {
+      return urls.map(url => url.replaceAll('https', 'http'));
+    } else {
+      return urls;
+    }
   },
 
   getRequestOptionsArray(method, path) {

--- a/lib/apiml.js
+++ b/lib/apiml.js
@@ -171,9 +171,8 @@ ApimlConnector.prototype = {
       httpEnabled: false,
       httpsEnabled: true
     };
-    const proto = this.isClientAttls ? 'http' : 'https';
 
-    log.debug("ZWED0141I", proto, this.port); //"Protocol:", proto, "Port", port);
+    log.debug("ZWED0141I", 'https', this.port); //"Protocol:", proto, "Port", port);
     log.debug("ZWED0142I", JSON.stringify(protocolObject)); //"Protocol Object:", JSON.stringify(protocolObject));
     
     const instance = Object.assign({}, MEDIATION_LAYER_INSTANCE_DEFAULTS(proto, this.hostName, this.port));
@@ -183,9 +182,9 @@ ApimlConnector.prototype = {
        hostName:  this.hostName,
        ipAddr: this.ipAddr,
        vipAddress: "zlux",//this.vipAddress,
-       statusPageUrl: `${proto}://${this.hostName}:${this.port}/server/eureka/info`,
-       healthCheckUrl: `${proto}://${this.hostName}:${this.port}/server/eureka/health`,
-       homePageUrl: `${proto}://${this.hostName}:${this.port}/`,
+       statusPageUrl: `https://${this.hostName}:${this.port}/server/eureka/info`,
+       healthCheckUrl: `https://${this.hostName}:${this.port}/server/eureka/health`,
+       homePageUrl: `https://${this.hostName}:${this.port}/`,
        port: {
          "$": protocolObject.httpPort, // This is a workaround for the mediation layer
          "@enabled": ''+protocolObject.httpEnabled

--- a/lib/apiml.js
+++ b/lib/apiml.js
@@ -82,6 +82,19 @@ function ApimlConnector({ hostName, port, discoveryUrls,
                           discoveryPort, tlsOptions, eurekaOverrides, isClientAttls }) {
   Object.assign(this, { hostName, port, discoveryUrls,
                         discoveryPort, tlsOptions, eurekaOverrides, isClientAttls });
+  //TODO config should never be checked through env var, but is temporarily needed to temporarily read gateway's ATTLS state to provide it with Eureka info it can work with.
+  const clientGlobalAttls = process.env['ZWE_zowe_network_client_tls_attls'];
+  const clientGatewayAttls = process.env['ZWE_components_gateway_zowe_network_client_tls_attls'];
+  const clientAttls = (clientGlobalAttls == 'true') || (clientGatewayAttls == 'true');
+  this.isGatewayClientAttls = false;
+  if ((clientGlobalAttls === undefined) && (clientGatewayAttls === undefined)) {
+    // If client attls env vars are not set, have client follow server attls variable. it simplifies common case in which users want both.
+    const serverGlobalAttls = process.env['ZWE_zowe_network_server_tls_attls'] == 'true';
+    const serverGatewayAttls = process.env['ZWE_components_gateway_zowe_network_server_tls_attls'] == 'true';
+    this.isGatewayClientAttls = serverGlobalAttls || serverGatewayAttls;
+  } else {
+    this.isGatewayClientAttls = clientAttls;
+  }
   this.vipAddress = hostName;
 }
 
@@ -168,8 +181,14 @@ ApimlConnector.prototype = {
       // If the HTTP port is set to 0 then the API ML doesn't load zlux
       httpPort: Number(this.port),
       httpsPort: Number(this.port),
-      httpEnabled: false,
-      httpsEnabled: true
+      // TODO while the server should always be HTTPS for security,
+      // When AT-TLS is used, programs need to know when AT-TLS will add TLS to their traffic
+      // To align with the correct amount of TLS (Avoid no TLS and double TLS)
+      // It seems the gateway wants to be told app-server is 'http' when client TLS is set on it
+      // So this eureka object will be based upon that setting.
+      // This may change in the future, revisit.
+      httpEnabled: this.isGatewayClientAttls,
+      httpsEnabled: !this.isGatewayClientAttls
     };
 
     log.debug("ZWED0141I", 'https', this.port); //"Protocol:", proto, "Port", port);

--- a/lib/apiml.js
+++ b/lib/apiml.js
@@ -175,7 +175,7 @@ ApimlConnector.prototype = {
     log.debug("ZWED0141I", 'https', this.port); //"Protocol:", proto, "Port", port);
     log.debug("ZWED0142I", JSON.stringify(protocolObject)); //"Protocol Object:", JSON.stringify(protocolObject));
     
-    const instance = Object.assign({}, MEDIATION_LAYER_INSTANCE_DEFAULTS(proto, this.hostName, this.port));
+    const instance = Object.assign({}, MEDIATION_LAYER_INSTANCE_DEFAULTS('https', this.hostName, this.port));
     Object.assign(instance, overrides);
     Object.assign(instance,  {
        instanceId: `${this.hostName}:zlux:${this.port}`,


### PR DESCRIPTION
app-server should use "utils.isClientAttls()" to determine if outbound network requests should be https (if not attls) or http (if attls, because then attls adds the tls, becoming https in the end).

It appears that apiml.js does not do these checks when doing eureka registration, so when attls is used, it does double-tls, resulting in the repeated error:

Eureka request failed to endpoint ..., next server retry...

This error can be seen under normal circumstances due to a timing issue, but eventually resolves to a message

" registered with eureka:..."

In the case of attls, due to the double-tls failure, success never occurs and the "eureka request failed to endpoint" continues forever.


In this PR, I use "isClientAttls" in a few places.
In my testing, it is only truly needed in "getServiceUrls()"
However, through reading documentation of https://www.npmjs.com/package/@rocketsoftware/eureka-js-client and checking other areas in this code, I identified 4 places where it would be best to be explicitly either http or https, rather than allowing the eureka-js-client library to do some implicit behavior that may change in the future.


## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)


## PR Checklist
Please delete options that are not relevant.
- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zlux/blob/master/CONTRIBUTING.md))
- [x] Relevant update to CHANGELOG.md
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works, or describe a test method below

## Testing
* Toggle "zowe.network.server.tls.attls" and "zowe.network.client.tls.attls" so that they are either both true or both false.
* When both false, there should be no regression. Its the default and currently works.
* When both true, " registered with eureka:..." should be seen in log. It is seen whenever you have a valid network configuration (AT-TLS or not) between app-server and discovery.
* seeing "Eureka request failed to endpoint ..., next server retry..." in the log at first is normal, but if it continues without " registered with eureka:..." then it is a problem.
* env var "NODE_DEBUG: tls,request" can be used to observe what network activity app-server does before these "eureka" messages appear. You should see "http://" urls and no "TLS" messages when AT-TLS is enabled. You should see "https://" and "TLS" messages when AT-TLS is disabled.