### PR TITLE
Fix missing 'proto' regerence

### DIFF
--- a/lib/apiml.js
+++ b/lib/apiml.js
@@ -175,7 +175,7 @@ ApimlConnector.prototype = {
     log.debug("ZWED0141I", 'https', this.port); //"Protocol:", proto, "Port", port);
     log.debug("ZWED0142I", JSON.stringify(protocolObject)); //"Protocol Object:", JSON.stringify(protocolObject));
     
-    const instance = Object.assign({}, MEDIATION_LAYER_INSTANCE_DEFAULTS(proto, this.hostName, this.port));
+    const instance = Object.assign({}, MEDIATION_LAYER_INSTANCE_DEFAULTS('https', this.hostName, this.port));
     Object.assign(instance, overrides);
     Object.assign(instance,  {
        instanceId: `${this.hostName}:zlux:${this.port}`,


### PR DESCRIPTION
PR https://github.com/zowe/zlux-server-framework/pull/580 removed https://github.com/zowe/zlux-server-framework/blob/b071c9a2077d1214dd7d4b950ea3bd1247598f7c/lib/apiml.js#L174 which was still referenced by mistake - replaced it with the fixed value 'https' as intended.