### PR TITLE
Use gateway client attls status in eureka object to determine http vs…

### DIFF
--- a/lib/apiml.js
+++ b/lib/apiml.js
@@ -83,12 +83,12 @@ function ApimlConnector({ hostName, port, discoveryUrls,
   Object.assign(this, { hostName, port, discoveryUrls,
                         discoveryPort, tlsOptions, eurekaOverrides, isClientAttls });
   //TODO config should never be checked through env var, but is temporarily needed to temporarily read gateway's ATTLS state to provide it with Eureka info it can work with.
-  const clientGlobalAttls = process.env['ZWE_zowe_network_client_tls_attls'] == 'true';
-  const clientGatewayAttls = process.env['ZWE_components_gateway_zowe_network_client_tls_attls'] == 'true';
-  const clientAttls = clientGlobalAttls || clientGatewayAttls;
+  const clientGlobalAttls = process.env['ZWE_zowe_network_client_tls_attls'];
+  const clientGatewayAttls = process.env['ZWE_components_gateway_zowe_network_client_tls_attls'];
+  const clientAttls = (clientGlobalAttls == 'true') || (clientGatewayAttls == 'true');
   this.isGatewayClientAttls = false;
-  if ((clientGlobalAttls !== false) && (clientLocalAttls !== false) && (!clientAttls)) {
-    // If client attls not explicitly false OR truthy, have client follow server attls variable. it simplifies common case in which users want both.
+  if ((clientGlobalAttls === undefined) && (clientGatewayAttls === undefined)) {
+    // If client attls env vars are not set, have client follow server attls variable. it simplifies common case in which users want both.
     const serverGlobalAttls = process.env['ZWE_zowe_network_server_tls_attls'] == 'true';
     const serverGatewayAttls = process.env['ZWE_components_gateway_zowe_network_server_tls_attls'] == 'true';
     this.isGatewayClientAttls = serverGlobalAttls || serverGatewayAttls;

--- a/lib/apiml.js
+++ b/lib/apiml.js
@@ -82,6 +82,19 @@ function ApimlConnector({ hostName, port, discoveryUrls,
                           discoveryPort, tlsOptions, eurekaOverrides, isClientAttls }) {
   Object.assign(this, { hostName, port, discoveryUrls,
                         discoveryPort, tlsOptions, eurekaOverrides, isClientAttls });
+  //TODO config should never be checked through env var, but is temporarily needed to temporarily read gateway's ATTLS state to provide it with Eureka info it can work with.
+  const clientGlobalAttls = process.env['ZWE_zowe_network_client_tls_attls'] == 'true';
+  const clientGatewayAttls = process.env['ZWE_components_gateway_zowe_network_client_tls_attls'] == 'true';
+  const clientAttls = clientGlobalAttls || clientGatewayAttls;
+  this.isGatewayClientAttls = false;
+  if ((clientGlobalAttls !== false) && (clientLocalAttls !== false) && (!clientAttls)) {
+    // If client attls not explicitly false OR truthy, have client follow server attls variable. it simplifies common case in which users want both.
+    const serverGlobalAttls = process.env['ZWE_zowe_network_server_tls_attls'] == 'true';
+    const serverGatewayAttls = process.env['ZWE_components_gateway_zowe_network_server_tls_attls'] == 'true';
+    this.isGatewayClientAttls = serverGlobalAttls || serverGatewayAttls;
+  } else {
+    this.isGatewayClientAttls = clientAttls;
+  }
   this.vipAddress = hostName;
 }
 
@@ -168,8 +181,14 @@ ApimlConnector.prototype = {
       // If the HTTP port is set to 0 then the API ML doesn't load zlux
       httpPort: Number(this.port),
       httpsPort: Number(this.port),
-      httpEnabled: false,
-      httpsEnabled: true
+      // TODO while the server should always be HTTPS for security,
+      // When AT-TLS is used, programs need to know when AT-TLS will add TLS to their traffic
+      // To align with the correct amount of TLS (Avoid no TLS and double TLS)
+      // It seems the gateway wants to be told app-server is 'http' when client TLS is set on it
+      // So this eureka object will be based upon that setting.
+      // This may change in the future, revisit.
+      httpEnabled: this.isGatewayClientAttls,
+      httpsEnabled: !this.isGatewayClientAttls
     };
 
     log.debug("ZWED0141I", 'https', this.port); //"Protocol:", proto, "Port", port);


### PR DESCRIPTION
This PR builds upon https://github.com/zowe/zlux-server-framework/pull/580 by altering the eureka object's status of https/http true/false dependent upon the status of the gateway's client attls setting.

This is because, client attls alters whether you must send a request as 'http' or 'https' in order to avoid double-tls, or no-tls situations.
In this PR, the app-server reports itself as 'http' if the gateway has client tls enabled, so that when the gateway contacts the app-server, it will HTTPS, as desired.

This logic does not consider the state of the app-server's server ATTLS setting, because whether server ATTLS is enabled or disabled, the app-server should always be HTTPS.