### PR TITLE
Fix /server/environment endpoint for best ZSS route (v3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to the Zlux Server Framework package will be documented in this file.
 This repo is part of the app-server Zowe Component, and the change logs here may appear on Zowe.org in that section.
 
+## 3.2.0
+- Bugfix: App-server /server/environment endpoint was missing the "agent" object, causing the Desktop to choose an indirect route to accessing ZSS. This fix improves latency and high availability behavior of ZSS APIs in the Desktop. (#588)
+
 ## 3.1.0
 - Bugfix: App-server could not register with discovery server when AT-TLS was enabled for app-server. (#580)
 

--- a/lib/webapp.js
+++ b/lib/webapp.js
@@ -234,7 +234,8 @@ const hostname = os.hostname();
 function getUserEnv(rbac, zoweConfig){
   var date = new Date();
   return new Promise(function(resolve, reject){
-    const nodeConfig = zoweConfig.components['app-server'].node;
+    const serverConfig = zoweConfig.components['app-server'];
+    const nodeConfig = serverConfig.node;
     if (rbac) {
       resolve({
         "timestamp": date.toUTCString(),
@@ -248,7 +249,7 @@ function getUserEnv(rbac, zoweConfig){
         "hostname": hostname,
         "userEnvironment": process.env,
         "agent": {
-          "mediationLayer": nodeConfig.agent?.mediationLayer
+          "mediationLayer": serverConfig.agent?.mediationLayer
         },
         "PID": process.pid,
         "PPID": process.ppid,
@@ -279,7 +280,7 @@ function getUserEnv(rbac, zoweConfig){
           "GATEWAY_PORT": nodeConfig.mediationLayer.server.gatewayPort,
         },
         "agent": {
-          "mediationLayer": nodeConfig.agent?.mediationLayer
+          "mediationLayer": serverConfig.agent?.mediationLayer
         }
       })
     }


### PR DESCRIPTION
A regression from v2.10 caused app-server to send an empty object for the "agent" attribute on the /server/environment URL.
This attribute was used by the Desktop to determine the best route to ZSS. When missing, it causes the Desktop to reach ZSS through the app-server, as in the following network chain:

browser -> gateway -> app-server -> gateway -> zss
or when gateway is missing

browser -> app-server -> zss

The correct routing when the gateway is present should be

browser -> gateway -> zss

This PR restores that behavior by fixing the /server/environment URL so that the Desktop has the info necessary to find that more direct route.