### PR TITLE
Add option to trace eureka registration in v3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This repo is part of the app-server Zowe Component, and the change logs here may
 
 ## 3.2.0
 - Bugfix: App-server /server/environment endpoint was missing the "agent" object, causing the Desktop to choose an indirect route to accessing ZSS. This fix improves latency and high availability behavior of ZSS APIs in the Desktop. (#588)
+- Bugfix: When eureka registration experienced a network failure, troubleshooting information was not available. The property `components.app-server.node.mediationLayer.traceTls` now exists for troubleshooting TLS issues. (#592)
 
 ## 3.1.0
 - Bugfix: App-server could not register with discovery server when AT-TLS was enabled for app-server. (#580)

--- a/lib/apiml.js
+++ b/lib/apiml.js
@@ -79,9 +79,9 @@ const MEDIATION_LAYER_INSTANCE_DEFAULTS = (zluxProto, zluxHostname, zluxPort) =>
 }};
 
 function ApimlConnector({ hostName, port, discoveryUrls,
-                          discoveryPort, tlsOptions, eurekaOverrides, isClientAttls }) {
+                          discoveryPort, tlsOptions, eurekaOverrides, isClientAttls, traceTls }) {
   Object.assign(this, { hostName, port, discoveryUrls,
-                        discoveryPort, tlsOptions, eurekaOverrides, isClientAttls });
+                        discoveryPort, tlsOptions, eurekaOverrides, isClientAttls, traceTls });
   //TODO config should never be checked through env var, but is temporarily needed to temporarily read gateway's ATTLS state to provide it with Eureka info it can work with.
   const clientGlobalAttls = process.env['ZWE_zowe_network_client_tls_attls'];
   const clientGatewayAttls = process.env['ZWE_components_gateway_zowe_network_client_tls_attls'];
@@ -246,7 +246,11 @@ ApimlConnector.prototype = {
   },*/
   
   registerMainServerInstance() {
-    const overrideOptions = this.isClientAttls ? {} : Object.assign({},this.tlsOptions)
+    const overrideOptions = this.isClientAttls
+          ? {}
+    //Use server's own TLS options except for TLS tracing.
+          : Object.assign(Object.assign({},this.tlsOptions), {enableTrace: this.traceTls ? true : false});
+    
     if (!this.tlsOptions.rejectUnauthorized) {
       //Keeping these certs causes an openssl error 46, unknown cert error in a dev environment
       delete overrideOptions.cert;

--- a/lib/index.js
+++ b/lib/index.js
@@ -220,6 +220,7 @@ Server.prototype = {
           port: this.port,
           discoveryUrls: apimlConfig.server.discoveryUrls || [`https://${apimlConfig.server.hostname}:${apimlConfig.server.port}/eureka/`],
           tlsOptions: this.tlsOptions,
+          traceTls: apimlConfig.traceTls,
           eurekaOverrides: apimlConfig.eureka,
           isClientAttls: util.isClientAttls(this.zoweConfig)
         });


### PR DESCRIPTION
Depends upon https://github.com/zowe/zlux-app-server/pull/336
v2 version of https://github.com/zowe/zlux-server-framework/pull/591

This PR adds the property components.app-server.node.mediationLayer.traceTls
It is used to set enableTrace from the NodeJS TLS level https://nodejs.org/api/tls.html#tlscreateserveroptions-secureconnectionlistener

This is needed because it seems to be the only way to get handshake tracing for NodeJS.
There's a previous property, components.app-server.node.https.enableTrace but it is only for inbound request from clients.
This new property allows you to trace the connection this server gives out to the discovery server, as an outbound request instead.
This can reveal the cause of low level networking issues if they arise.
How to test

Enabling components.app-server.node.mediationLayer.traceTls will show plenty of TLS handshake information during eureka registration. With it off (default), you should notice nothing different.