### PR TITLE
Bump @rocketsoftware/eureka-js-client to remove sensitive logging

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0-zlux.version.replacement",
       "license": "EPL-2.0",
       "dependencies": {
-        "@rocketsoftware/eureka-js-client": "^4.5.8",
+        "@rocketsoftware/eureka-js-client": "^4.5.9",
         "@rocketsoftware/express-ws": "^5.0.1",
         "accept-language-parser": "~1.5.0",
         "axios": "^1.7.9",
@@ -138,9 +138,9 @@
       "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="
     },
     "node_modules/@rocketsoftware/eureka-js-client": {
-      "version": "4.5.8",
-      "resolved": "https://registry.npmjs.org/@rocketsoftware/eureka-js-client/-/eureka-js-client-4.5.8.tgz",
-      "integrity": "sha512-584jWl4/GdiuswYQuB/qesps4Y8JGjopIqJD7qVtLufaCErdTGBWgv+sKZen21VRlLS4I4U2I2Nbaf3RiX5qXA==",
+      "version": "4.5.9",
+      "resolved": "https://registry.npmjs.org/@rocketsoftware/eureka-js-client/-/eureka-js-client-4.5.9.tgz",
+      "integrity": "sha512-M88s5Fr8DKDe+RDdbC+BGksTVlNWXIL8q6CePqp6/KbvzLBOvJdR+uZcqhCvNWxmP4PxR0zsVSwjsBiPKU5r4Q==",
       "license": "MIT",
       "dependencies": {
         "@cypress/request": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "test:storage": "mocha --timeout 10000 ./test/storage/*.js"
   },
   "dependencies": {
-    "@rocketsoftware/eureka-js-client": "^4.5.8",
+    "@rocketsoftware/eureka-js-client": "^4.5.9",
     "@rocketsoftware/express-ws": "^5.0.1",
     "accept-language-parser": "~1.5.0",
     "axios": "^1.7.9",


### PR DESCRIPTION
This PR bumps @rocketsoftware/eureka-js-client in order to remove the sensitive logging:

https://github.com/RocketSoftware/eureka-js-client/pull/6


This PR depends upon the following PRs:

## Type of change
Please delete options that are not relevant.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Change in a documentation
- [ ] Refactor the code 
- [X] Chore, repository cleanup, updates the dependencies.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
