### PR TITLE
Added certificate checker utility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This repo is part of the app-server Zowe Component, and the change logs here may
 
 ## 3.2.0
 - Bugfix: App-server /server/environment endpoint was missing the "agent" object, causing the Desktop to choose an indirect route to accessing ZSS. This fix improves latency and high availability behavior of ZSS APIs in the Desktop. (#588)
-- Enhancement: Added utility certificateChecker.js which can use NodeJS to determine if a keystore of PKCS12, PEM, or SAF keyring is valid for use in Zowe (??)
+- Enhancement: Added utility certificateChecker.js which can use NodeJS to determine if a keystore of PKCS12, PEM, or SAF keyring is valid for use in Zowe (#597)
 - Bugfix: When eureka registration experienced a network failure, troubleshooting information was not available. The property `components.app-server.node.mediationLayer.traceTls` now exists for troubleshooting TLS issues. (#592)
 
 ## 3.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This repo is part of the app-server Zowe Component, and the change logs here may
 
 ## 3.2.0
 - Bugfix: App-server /server/environment endpoint was missing the "agent" object, causing the Desktop to choose an indirect route to accessing ZSS. This fix improves latency and high availability behavior of ZSS APIs in the Desktop. (#588)
+- Enhancement: Added utility certificateChecker.js which can use NodeJS to determine if a keystore of PKCS12, PEM, or SAF keyring is valid for use in Zowe (??)
 
 ## 3.1.0
 - Bugfix: App-server could not register with discovery server when AT-TLS was enabled for app-server. (#580)

--- a/utils/certificateChecker.js
+++ b/utils/certificateChecker.js
@@ -1,0 +1,130 @@
+const fs = require('fs');
+const os = require('os');
+let keyring_js;
+try {
+  if (os.platform() == 'os390') {
+    keyring_js = require('keyring_js');
+  }
+} catch (e) {
+  bootstrapLogger.warn('Could not load zcrypto library, SAF keyrings will be unavailable');
+}
+const forge = require('node-forge');
+const pki = forge.pki;
+
+const argParser = require('./argumentParser');
+
+if (!global.COM_RS_COMMON_LOGGER) {
+  const loggerFile = require('../../zlux-shared/src/logging/logger.js');
+  global.COM_RS_COMMON_LOGGER = new loggerFile.Logger();
+  global.COM_RS_COMMON_LOGGER.addDestination(global.COM_RS_COMMON_LOGGER.makeDefaultDestination(true,true,true,true,true));
+}
+const logger = global.COM_RS_COMMON_LOGGER.makeComponentLogger("_zsf.verify");
+
+
+
+const CERT_ARGS = [
+  new argParser.CLIArgument('certificate', 'c', argParser.constants.ARG_TYPE_VALUE),
+  new argParser.CLIArgument('type', 't', argParser.constants.ARG_TYPE_VALUE),
+  new argParser.CLIArgument('alias', 'a', argParser.constants.ARG_TYPE_VALUE),
+  new argParser.CLIArgument('eku', 'e', argParser.constants.ARG_TYPE_FLAG),
+];
+const commandArgs = process.argv.slice(2);
+const argumentParser = argParser.createParser(CERT_ARGS);
+const userInput = argumentParser.parse(commandArgs);
+
+if (!userInput.certificate) {
+  logger.error('ZWED5018E - Missing one or more parameters required to run.\nCertificate file was '+userInput.config);
+  process.exit(-1);
+}
+if (!userInput.certificate) {
+  logger.error('ZWED5018E - Missing one or more parameters required to run.\nCertificate type was '+userInput.type);
+  process.exit(-1);
+}
+if (userInput.type == 'JCERACFKS' && !userInput.alias) {
+  logger.error('ZWED5018E - Missing one or more parameters required to run.\nCertificate alias was '+userInput.alias);
+  process.exit(-1);
+}
+
+
+let cert;
+if (userInput.type == 'JCERACFKS') {
+  if (userInput.certificate.startsWith('safkeyring://')) {
+    let ring = userInput.certificate.substring(13);
+    if (ring.startsWith('//')) {
+      ring = ring.substring(2);
+    }
+    let parts = ring.split('/');
+    let username = parts[0];
+    let ringname = parts[1];
+    let keyringData = keyring_js.getPemEncodedData(username, ringname, userInput.alias).certificate;
+
+    cert = pki.certificateFromPem(keyringData);
+  } else {
+    logger.error('Invalid certificate name');
+    process.exit(-1);
+  }
+} else if (userInput.type.startsWith('JCE')) {
+  logger.error('Cannot validate certificate, type not supported for verification');
+  process.exit(0);
+} else if (userInput.type == 'PEM') {
+  logger.info('Checking PEM');
+  let pem = fs.readFileSync(userInput.certificate, 'utf8');
+  cert = pki.certificateFromPem(pem);
+} else if (userInput.type == 'PKCS12') {
+  logger.info('Checking PKCS12');
+  const p12Content = fs.readFileSync(userInput.certificate, 'binary');
+  const p12Asn1 = forge.asn1.fromDer(p12Content);
+  const p12 = forge.pkcs12.pkcs12FromAsn1(p12Asn1, false, process.env.ZWE_zowe_certificate_keystore_password);
+  p12.safeContents.forEach(safeContent => {
+    safeContent.safeBags.forEach(content => {
+      if (content.type === forge.pki.oids.certBag) { // this can be a certificate OR a CA
+        if (content.attributes.friendlyName == userInput.alias) {
+          const certificate = content.cert;
+          cert = forge.pki.certificateToPem(certificate);
+        }
+      }        
+    });
+  })
+} else {
+  logger.error('Cannot validate certificate, type not supported for verification');
+  process.exit(0);
+}
+
+
+if (userInput.eku) {
+  let EKU = cert.getExtension('extKeyUsage');
+  if (EKU) {
+    if (EKU.serverAuth != true) {
+      logger.error('Error: Certificate EKU missing Server Auth 1.3.6.1.5.5.7.3.1 attribute.');
+      logger.error('See https://docs.zowe.org/stable/user-guide/configure-certificates#extended-key-usage');
+      logger.error('Create a new certificate that meets the EKU requirements of Zowe before using Zowe.');
+      process.exit(-1);
+    } else if (EKU.clientAuth != true) {
+      logger.error('Error: Certificate EKU missing Client Auth 1.3.6.1.5.5.7.3.2 attribute.');
+      logger.error('See https://docs.zowe.org/stable/user-guide/configure-certificates#extended-key-usage');
+      logger.error('Create a new certificate that meets the EKU requirements of Zowe before using Zowe.');
+      process.exit(-1);
+    } else {
+      logger.info('Certificate EKU present with both server and client auth');
+    }
+  } else {
+    logger.info('Certificate auth compatible');
+  }
+}
+
+let currentTime = Date.now();
+if (cert.validity?.notBefore) {
+  if (cert.validity.notBefore.getTime() > currentTime) {
+    logger.error('Error: Certificate is not yet valid. Will not be valid until: '+cert.validity.notBefore.toString());
+    process.exit(-1);
+  }
+}
+if (cert.validity?.notAfter) {
+  if (cert.validity.notAfter.getTime() < currentTime) {
+    logger.error('Error: Certificate has expired at '+cert.validity.notAfter.toString());
+    process.exit(-1);
+  }
+  logger.info('Certificate is valid until '+cert.validity.notAfter.toString());
+}
+logger.info('Certificate checks complete');
+process.exit(0);

--- a/utils/certificateChecker.js
+++ b/utils/certificateChecker.js
@@ -9,7 +9,6 @@ try {
   bootstrapLogger.warn('Could not load zcrypto library, SAF keyrings will be unavailable');
 }
 const forge = require('node-forge');
-const pki = forge.pki;
 
 const argParser = require('./argumentParser');
 
@@ -48,6 +47,7 @@ if (userInput.type == 'JCERACFKS' && !userInput.alias) {
 
 let cert;
 if (userInput.type == 'JCERACFKS') {
+  logger.debug('Checking keyring');
   if (userInput.certificate.startsWith('safkeyring://')) {
     let ring = userInput.certificate.substring(13);
     if (ring.startsWith('//')) {
@@ -58,35 +58,39 @@ if (userInput.type == 'JCERACFKS') {
     let ringname = parts[1];
     let keyringData = keyring_js.getPemEncodedData(username, ringname, userInput.alias).certificate;
 
-    cert = pki.certificateFromPem(keyringData);
+    cert = forge.pki.certificateFromPem(keyringData);
   } else {
     logger.error('Invalid certificate name');
     process.exit(-1);
   }
 } else if (userInput.type.startsWith('JCE')) {
-  logger.error('Cannot validate certificate, type not supported for verification');
+  logger.info('Will not validate certificate of type='+userInput.type);
   process.exit(0);
 } else if (userInput.type == 'PEM') {
-  logger.info('Checking PEM');
+  logger.debug('Checking PEM');
   let pem = fs.readFileSync(userInput.certificate, 'utf8');
-  cert = pki.certificateFromPem(pem);
+  cert = forge.pki.certificateFromPem(pem);
 } else if (userInput.type == 'PKCS12') {
-  logger.info('Checking PKCS12');
+  logger.debug('Checking PKCS12 for alias '+userInput.alias);
   const p12Content = fs.readFileSync(userInput.certificate, 'binary');
   const p12Asn1 = forge.asn1.fromDer(p12Content);
   const p12 = forge.pkcs12.pkcs12FromAsn1(p12Asn1, false, process.env.ZWE_zowe_certificate_keystore_password);
-  p12.safeContents.forEach(safeContent => {
-    safeContent.safeBags.forEach(content => {
-      if (content.type === forge.pki.oids.certBag) { // this can be a certificate OR a CA
-        if (content.attributes.friendlyName == userInput.alias) {
-          const certificate = content.cert;
-          cert = forge.pki.certificateToPem(certificate);
+  for (let i = 0; i < p12.safeContents.length; i++) {
+    let safeContent = p12.safeContents[i];
+    for (let j = 0; j < safeContent.safeBags.length; j++) {
+      let bag = safeContent.safeBags[j];
+      if (bag.type === forge.pki.oids.certBag) { // this can be a certificate OR a CA
+        logger.debug('found a cert '+bag.attributes.friendlyName);
+        if (bag.attributes.friendlyName == userInput.alias) {
+          logger.debug('found an alias match');
+          cert = bag.cert;
+          break;
         }
       }        
-    });
-  })
+    }
+  }
 } else {
-  logger.error('Cannot validate certificate, type not supported for verification');
+  logger.info('Will not validate certificate of type='+userInput.type);
   process.exit(0);
 }
 

--- a/utils/certificateChecker.js
+++ b/utils/certificateChecker.js
@@ -1,3 +1,13 @@
+/*
+  This program and the accompanying materials are
+  made available under the terms of the Eclipse Public License v2.0 which accompanies
+  this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
+  
+  SPDX-License-Identifier: EPL-2.0
+  
+  Copyright Contributors to the Zowe Project.
+*/
+
 const fs = require('fs');
 const os = require('os');
 let keyring_js;


### PR DESCRIPTION
Depends upon https://github.com/zowe/zlux-app-server/pull/338

This PR has a tool, utils/certificateChecker.js
If you provide it with args of certificate files, file type, and alias, then it will try to load the cert and then check if it has expired and if it has the right EKU properties if appropriate.
It is intended to be used by the zowe startup process to prevent startup when known certificate incompatibilities are found.