### PR TITLE
Remove axios in favor of undici, a library made by nodejs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This repo is part of the app-server Zowe Component, and the change logs here may
 
 ## 3.2.0
 - Bugfix: App-server /server/environment endpoint was missing the "agent" object, causing the Desktop to choose an indirect route to accessing ZSS. This fix improves latency and high availability behavior of ZSS APIs in the Desktop. (#588)
+- Bugfix: Reduce minimum memory consumption. A bug in the library "axios" caused abnormally high memory utilization every startup, and has been removed. The app-servers functionality has not been altered from this change. (??)
 
 ## 3.1.0
 - Bugfix: App-server could not register with discovery server when AT-TLS was enabled for app-server. (#580)

--- a/lib/apimlStorage.ts
+++ b/lib/apimlStorage.ts
@@ -10,22 +10,19 @@
 
 import * as https from 'https';
 import * as http from 'http';
-import axios from 'axios';
-import { AxiosInstance } from 'axios';
+import { Client, Dispatcher } from 'undici';
 
-let apimlClient: AxiosInstance;
+let apimlClient: Client;
 
 export function configure(settings: ApimlStorageSettings) {
   if (settings.isHttps) {
-    apimlClient = axios.create({
-      baseURL: `https://${settings.host}:${settings.port}`,
-      httpsAgent: new https.Agent(settings.tlsOptions)
-    });
+
+    //per documentation, client first arg "shoould only include protocol, hostname, and port"
+    apimlClient = new Client(`https://${settings.host}:${settings.port}`, {
+                              connect: settings.tlsOptions
+                             });
   } else {
-    apimlClient = axios.create({
-      baseURL: `https://${settings.host}:${settings.port}`,
-      httpAgent: new http.Agent()
-    });
+    apimlClient = new Client(`https://${settings.host}:${settings.port}`);
   }
 }
 
@@ -163,34 +160,45 @@ async function apimlDoRequest(req: ApimlRequest): Promise<ApimlResponse> {
     throw new ApimlStorageError('APIML_STORAGE_NOT_CONFIGURED');
   }
   try {
-    const response = await apimlClient.request({
+    const response: Dispatcher.ResponseData = await apimlClient.request({
+      path: req.path,
       method: req.method,
-      url: req.path,
-      data: req.body,
+      body: req.body,
       headers: req.headers,
+      throwOnError: true
     });
+    const json = await response.body.json();
+
     const apimlResponse: ApimlResponse = {
       headers: response.headers as http.IncomingHttpHeaders,
-      statusCode: response.status,
-      json: response.data
+      statusCode: response.statusCode,
+      json: json
     };
     return apimlResponse;
   } catch (e) {
-    if (e.response) {
-      const response = e.response;
+    let headers = e.headers;
+    let statusCode = e.statusCode;
+    let json = e.body;
+    if (typeof e.body == 'string') {
+      try {
+        json = JSON.parse(e.body)
+      } catch (e) {
+
+      }
+    }
+    if (json && headers && statusCode) {
       const apimlResponse: ApimlResponse = {
-        headers: response.headers,
-        statusCode: response.status,
-        json: response.data
+        headers, statusCode, json
       };
       const err = checkHttpResponse(apimlResponse);
       if (err) {
         throw err;
       }
       return apimlResponse;
-    } else if (e.request) {
-      throw new ApimlStorageError('APIML_STORAGE_CONNECTION_ERROR', e);
     } else {
+      if (!e.message) {
+        e.message = e.code;
+      }
       throw new ApimlStorageError('APIML_STORAGE_UNKNOWN_ERROR', e);
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@rocketsoftware/eureka-js-client": "^4.5.8",
         "@rocketsoftware/express-ws": "^5.0.1",
         "accept-language-parser": "~1.5.0",
-        "axios": "^1.7.9",
         "bluebird": "3.7.2",
         "body-parser": "~1.20.3",
         "cookie-parser": "~1.4.6",
@@ -27,6 +26,7 @@
         "require-from-string": "~2.0.2",
         "semver": "~7.6.0",
         "swagger-parser": "~10.0.3",
+        "undici": "^6.21.2",
         "ws": "^6.2.3",
         "yaml": "~2.4.1",
         "yauzl": "~3.1.2"
@@ -420,30 +420,6 @@
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.0.tgz",
       "integrity": "sha512-3AungXC4I8kKsS9PuS4JH2nc+0bVY/mjgrephHTIi8fpEeGsTHBUJeosp0Wc1myYMElmD0B3Oc4XL/HVJ4PV2g=="
-    },
-    "node_modules/axios": {
-      "version": "1.7.9",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
-      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
-    "node_modules/axios/node_modules/form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -1197,25 +1173,6 @@
       "dev": true,
       "bin": {
         "flat": "cli.js"
-      }
-    },
-    "node_modules/follow-redirects": {
-      "version": "1.15.6",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
-      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
       }
     },
     "node_modules/forever-agent": {
@@ -2129,11 +2086,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
-    },
     "node_modules/psl": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
@@ -2641,6 +2593,14 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/undici": {
+      "version": "6.21.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.2.tgz",
+      "integrity": "sha512-uROZWze0R0itiAKVPsYhFov9LxrPMHLMEQFszeI2gCN6bnIIZ8twzBCJcN2LJrBBLfrP0t1FW0g+JmKVl8Vk1g==",
+      "engines": {
+        "node": ">=18.17"
       }
     },
     "node_modules/universalify": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "@rocketsoftware/eureka-js-client": "^4.5.8",
     "@rocketsoftware/express-ws": "^5.0.1",
     "accept-language-parser": "~1.5.0",
-    "axios": "^1.7.9",
     "bluebird": "3.7.2",
     "body-parser": "~1.20.3",
     "cookie-parser": "~1.4.6",
@@ -55,6 +54,7 @@
     "require-from-string": "~2.0.2",
     "semver": "~7.6.0",
     "swagger-parser": "~10.0.3",
+    "undici": "6.21.2",
     "ws": "^6.2.3",
     "yaml": "~2.4.1",
     "yauzl": "~3.1.2"


### PR DESCRIPTION
This PR switches out the `axios` use in apimlStorage.ts for `undici` instead. No functionality is changed, but this should fix a high memory utilization issue.


How to test:

Install sample-angular-app (zwe components install -o /zowe/components/app-server/share/sample-angular-app)
Enable it and the caching service
Ensure you dont have ZLUX_NO_CLUSTER=1  set. This storage doesnt work in no-cluster mode.
Open it up (need to use ?use-v2-desktop=true in URL)
On the storage panel, set the dropdown to "HA"
Set, get, and play around with the values to confirm its setting & getting data properly.
