### PR TITLE
API Catalog AT-TLS workaround (v2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the Zlux Server Framework package will be documented in t
 This repo is part of the app-server Zowe Component, and the change logs here may appear on Zowe.org in that section.
 
 ## 2.18.2
-- Bugfix: Workaround for API Catalog issuing double-TLS request when it is under AT-TLS by changing eureka registration content to match state of API Catalog (???)
+- Bugfix: Workaround for API Catalog issuing double-TLS request when it is under AT-TLS by changing eureka registration content to match state of API Catalog ([#609](https://github.com/zowe/zlux-server-framework/pull/609))
 
 ## 2.18.1
 - Bugfix: App-server could not register with discovery server when AT-TLS was enabled for app-server. (#581)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to the Zlux Server Framework package will be documented in this file..
 This repo is part of the app-server Zowe Component, and the change logs here may appear on Zowe.org in that section.
 
+## 2.18.2
+- Bugfix: Workaround for API Catalog issuing double-TLS request when it is under AT-TLS by changing eureka registration content to match state of API Catalog (???)
+
 ## 2.18.1
 - Bugfix: App-server could not register with discovery server when AT-TLS was enabled for app-server. (#581)
 - Bugfix: App-server /server/environment endpoint was missing the "agent" object, causing the Desktop to choose an indirect route to accessing ZSS. This fix improves latency and high availability behavior of ZSS APIs in the Desktop. (#589)

--- a/lib/apiml.js
+++ b/lib/apiml.js
@@ -84,17 +84,33 @@ function ApimlConnector({ hostName, port, discoveryUrls,
                         discoveryPort, tlsOptions, eurekaOverrides, isClientAttls, traceTls });
   //TODO config should never be checked through env var, but is temporarily needed to temporarily read gateway's ATTLS state to provide it with Eureka info it can work with.
   const clientGlobalAttls = process.env['ZWE_zowe_network_client_tls_attls'];
+  const serverGlobalAttls = process.env['ZWE_zowe_network_server_tls_attls'] == 'true';
+
   const clientGatewayAttls = process.env['ZWE_components_gateway_zowe_network_client_tls_attls'];
-  const clientAttls = (clientGlobalAttls == 'true') || (clientGatewayAttls == 'true');
+  const clientAGAttls = (clientGlobalAttls == 'true') || (clientGatewayAttls == 'true');
   this.isGatewayClientAttls = false;
   if ((clientGlobalAttls === undefined) && (clientGatewayAttls === undefined)) {
     // If client attls env vars are not set, have client follow server attls variable. it simplifies common case in which users want both.
-    const serverGlobalAttls = process.env['ZWE_zowe_network_server_tls_attls'] == 'true';
     const serverGatewayAttls = process.env['ZWE_components_gateway_zowe_network_server_tls_attls'] == 'true';
     this.isGatewayClientAttls = serverGlobalAttls || serverGatewayAttls;
   } else {
-    this.isGatewayClientAttls = clientAttls;
+    this.isGatewayClientAttls = clientAGAttls;
   }
+
+
+  //TODO config should never be checked through env var, but is temporarily needed to temporarily read apiCatalog's ATTLS state to provide it with Eureka info it can work with.
+  const clientApiCatalogAttls = process.env['ZWE_components_api_catalog_zowe_network_client_tls_attls'];
+  const clientACAttls = (clientGlobalAttls == 'true') || (clientApiCatalogAttls == 'true');
+  this.isApiCatalogClientAttls = false;
+  if ((clientGlobalAttls === undefined) && (clientApiCatalogAttls === undefined)) {
+    // If client attls env vars are not set, have client follow server attls variable. it simplifies common case in which users want both.
+    const serverApiCatalogAttls = process.env['ZWE_components_api_catalog_zowe_network_server_tls_attls'] == 'true';
+    this.isApiCatalogClientAttls = serverGlobalAttls || serverApiCatalogAttls;
+  } else {
+    this.isApiCatalogClientAttls = clientACAttls;
+  }
+
+  
   this.vipAddress = hostName;
 }
 
@@ -193,17 +209,19 @@ ApimlConnector.prototype = {
 
     log.debug("ZWED0141I", 'https', this.port); //"Protocol:", proto, "Port", port);
     log.debug("ZWED0142I", JSON.stringify(protocolObject)); //"Protocol Object:", JSON.stringify(protocolObject));
-    
-    const instance = Object.assign({}, MEDIATION_LAYER_INSTANCE_DEFAULTS('https', this.hostName, this.port));
+
+    //TODO this.isApiCatalogClientAttls is a workaround of an APIML bug in which it does not respect ATTLS when making client requests
+    const zluxProto = this.isApiCatalogClientAttls === true ? 'http' : 'https';
+    const instance = Object.assign({}, MEDIATION_LAYER_INSTANCE_DEFAULTS(zluxProto, this.hostName, this.port));
     Object.assign(instance, overrides);
     Object.assign(instance,  {
        instanceId: `${this.hostName}:zlux:${this.port}`,
        hostName:  this.hostName,
        ipAddr: this.ipAddr,
        vipAddress: "zlux",//this.vipAddress,
-       statusPageUrl: `https://${this.hostName}:${this.port}/server/eureka/info`,
-       healthCheckUrl: `https://${this.hostName}:${this.port}/server/eureka/health`,
-       homePageUrl: `https://${this.hostName}:${this.port}/`,
+       statusPageUrl: `${zluxProto}://${this.hostName}:${this.port}/server/eureka/info`,
+       healthCheckUrl: `${zluxProto}://${this.hostName}:${this.port}/server/eureka/health`,
+       homePageUrl: `${zluxProto}://${this.hostName}:${this.port}/`,
        port: {
          "$": protocolObject.httpPort, // This is a workaround for the mediation layer
          "@enabled": ''+protocolObject.httpEnabled


### PR DESCRIPTION
When fully using AT-TLS with Zowe, the following is seen when using app-server with api-catalog

```
 Error retrieving api doc by url for zlux at https://host:7556/api-docs/server
 javax.net.ssl.SSLException: Unsupported or unrecognized SSL message
```

This indicates api-catalog is ignoring the state of AT-TLS and sending an HTTPS request, doubling TLS which will fail.

Ideally this is fixed in the future via https://github.com/zowe/api-layer/issues/3940 and then a change can be coordinated to revert to hardcoded HTTPS 