### PR TITLE
bugfix to allow safkeyringjce in certificate checker

### DIFF
--- a/utils/certificateChecker.js
+++ b/utils/certificateChecker.js
@@ -59,17 +59,28 @@ if (userInput.type == 'JCERACFKS' && !userInput.alias) {
 let cert;
 if (userInput.type == 'JCERACFKS') {
   logger.debug('Checking keyring');
-  if (userInput.certificate.startsWith('safkeyring://')) {
-    let ring = userInput.certificate.substring(13);
-    if (ring.startsWith('//')) {
-      ring = ring.substring(2);
+  if (userInput.certificate.startsWith('safkeyring')) {
+    let markerIndex = userInput.certificate.indexOf('://');
+    if (markerIndex == -1) {
+      logger.severe('Invalid certificate name');
+      process.exit(-1);
+    } else {
+      let userAndRingname = userInput.certificate.substring(markerIndex+3);
+      if (userAndRingname.startsWith('//')) { //get rid of safkeyring:////
+        userAndRingname = userAndRingname.substring(2);
+      }
+      let splitIndex = userAndRingname.indexOf('/');
+      if (splitIndex == -1) {
+        logger.severe('Invalid certificate name');
+        process.exit(-1);
+      } else {
+        let username = userAndRingname.substring(0, splitIndex);
+        let ringname = userAndRingname.substring(splitIndex+1);
+        let keyringData = keyring_js.getPemEncodedData(username, ringname, userInput.alias).certificate;
+    
+        cert = forge.pki.certificateFromPem(keyringData);        
+      }  
     }
-    let parts = ring.split('/');
-    let username = parts[0];
-    let ringname = parts[1];
-    let keyringData = keyring_js.getPemEncodedData(username, ringname, userInput.alias).certificate;
-
-    cert = forge.pki.certificateFromPem(keyringData);
   } else {
     logger.severe('Invalid certificate name');
     process.exit(-1);

--- a/utils/certificateChecker.js
+++ b/utils/certificateChecker.js
@@ -62,7 +62,7 @@ if (userInput.type == 'JCERACFKS') {
   if (userInput.certificate.startsWith('safkeyring')) {
     let markerIndex = userInput.certificate.indexOf('://');
     if (markerIndex == -1) {
-      logger.severe('Invalid certificate name');
+      logger.severe('Invalid certificate name "'+userInput.certificate+'"');
       process.exit(-1);
     } else {
       let userAndRingname = userInput.certificate.substring(markerIndex+3);
@@ -70,8 +70,8 @@ if (userInput.type == 'JCERACFKS') {
         userAndRingname = userAndRingname.substring(2);
       }
       let splitIndex = userAndRingname.indexOf('/');
-      if (splitIndex == -1) {
-        logger.severe('Invalid certificate name');
+      if (splitIndex == -1 || splitIndex == 0) {
+        logger.severe('Invalid certificate name "'+userInput.certificate+'"');
         process.exit(-1);
       } else {
         let username = userAndRingname.substring(0, splitIndex);
@@ -82,7 +82,7 @@ if (userInput.type == 'JCERACFKS') {
       }  
     }
   } else {
-    logger.severe('Invalid certificate name');
+    logger.severe('Invalid certificate name "'+userInput.certificate+'"');
     process.exit(-1);
   }
 } else if (userInput.type.startsWith('JCE')) {


### PR DESCRIPTION
Fixes https://github.com/zowe/zlux/issues/1051
It was spotted that the certificate checker code assumed keystore type 'JCERACFKS' meant 'safkeyring://'
which it does for java 8 as far as I know. but it doesnt for newer java which this needs to handle.
So, this code was revised to more closely follow what webserver.js does within the app server, about not really caring what format is seen, because none of the 'safkeyring' string format is relevant to any language except java, so it all needs to be parsed out without error.