### PR TITLE
ipv6 for app-server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to the Zlux Server Framework package will be documented in t
 This repo is part of the app-server Zowe Component, and the change logs here may appear on Zowe.org in that section.
 
 ## 3.4.0
-- Enhancement: Logging of URLs now accomodates when the app-server or gateway server are instructed to bind to an IPv6 address ([#?])()
+- Enhancement: Logging of URLs now accomodates when the app-server or gateway server are instructed to bind to an IPv6 address ([#614](https://github.com/zowe/zlux-server-framework/pull/614))
+- Enhancement: Eureka registration to discovery server now handles IPv6 in URLs ([#614](https://github.com/zowe/zlux-server-framework/pull/614))
 
 ## 3.3.0
 - Bugfix: Workaround for API Catalog issuing double-TLS request when it is under AT-TLS by changing eureka registration content to match state of API Catalog ([#610](https://github.com/zowe/zlux-server-framework/pull/610))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to the Zlux Server Framework package will be documented in this file.
 This repo is part of the app-server Zowe Component, and the change logs here may appear on Zowe.org in that section.
 
+## 3.4.0
+- Enhancement: Logging of URLs now accomodates when the app-server or gateway server are instructed to bind to an IPv6 address ([#?])()
+
 ## 3.3.0
 - Bugfix: Workaround for API Catalog issuing double-TLS request when it is under AT-TLS by changing eureka registration content to match state of API Catalog ([#610](https://github.com/zowe/zlux-server-framework/pull/610))
 - Enhancement: The app server no longer prints codes ZWED0036I, 54I, 55I, 62I-68I. These are now only shown in bootstrap or install debug logs, to clean up the job log. ([#608](https://github.com/zowe/zlux-server-framework/pull/608))

--- a/lib/apiml.js
+++ b/lib/apiml.js
@@ -35,7 +35,11 @@ const MEDIATION_LAYER_EUREKA_DEFAULTS = {
 };
 
 
-const MEDIATION_LAYER_INSTANCE_DEFAULTS = (zluxProto, zluxHostname, zluxPort) => { return {
+const MEDIATION_LAYER_INSTANCE_DEFAULTS = (zluxProto, zluxHostname, zluxPort) => {
+  const ipv6CompatHostname = this.hostName.contains(':') ? '[' + this.hostName + ']' : this.hostName;
+  
+  return {
+    
   instanceId: "localhost:zowe-zlux:8543",
   app: "zlux",
   hostName: "localhost",
@@ -60,7 +64,7 @@ const MEDIATION_LAYER_INSTANCE_DEFAULTS = (zluxProto, zluxHostname, zluxPort) =>
 
     "apiml.apiInfo.0.apiId": "org.zowe.zlux",
     "apiml.apiInfo.0.gatewayUrl": "api/v1",
-    "apiml.apiInfo.0.swaggerUrl": `${zluxProto}://${zluxHostname}:${zluxPort}/api-docs/server`,
+    "apiml.apiInfo.0.swaggerUrl": `${zluxProto}://${ipv6CompatHostname}:${zluxPort}/api-docs/server`,
     "apiml.apiInfo.0.version": "1.0.0",
 
     "apiml.catalog.tile.id": "zlux",
@@ -212,16 +216,17 @@ ApimlConnector.prototype = {
 
     //TODO this.isApiCatalogClientAttls is a workaround of an APIML bug in which it does not respect ATTLS when making client requests
     const zluxProto = this.isApiCatalogClientAttls === true ? 'http' : 'https';
+    const ipv6CompatHostname = this.hostName.contains(':') ? '[' + this.hostName + ']' : this.hostName;
     const instance = Object.assign({}, MEDIATION_LAYER_INSTANCE_DEFAULTS(zluxProto, this.hostName, this.port));
     Object.assign(instance, overrides);
     Object.assign(instance,  {
-       instanceId: `${this.hostName}:zlux:${this.port}`,
+       instanceId: `${ipv6CompatHostname}:zlux:${this.port}`,
        hostName:  this.hostName,
        ipAddr: this.ipAddr,
        vipAddress: "zlux",//this.vipAddress,
-       statusPageUrl: `${zluxProto}://${this.hostName}:${this.port}/server/eureka/info`,
-       healthCheckUrl: `${zluxProto}://${this.hostName}:${this.port}/server/eureka/health`,
-       homePageUrl: `${zluxProto}://${this.hostName}:${this.port}/`,
+       statusPageUrl: `${zluxProto}://${ipv6CompatHostname}:${this.port}/server/eureka/info`,
+       healthCheckUrl: `${zluxProto}://${ipv6CompatHostname}:${this.port}/server/eureka/health`,
+       homePageUrl: `${zluxProto}://${ipv6CompatHostname}:${this.port}/`,
        port: {
          "$": protocolObject.httpPort, // This is a workaround for the mediation layer
          "@enabled": ''+protocolObject.httpEnabled
@@ -239,7 +244,8 @@ ApimlConnector.prototype = {
 
   /*
    * TODO: commented out as this is a stretch goal
-  _makeServiceInstanceProperties(appId) {
+   _makeServiceInstanceProperties(appId) {
+   
     return  {
       instanceId: `${this.zluxHostName}:${appId}:${this.zluxPort}`,
       app: appId,

--- a/lib/apiml.js
+++ b/lib/apiml.js
@@ -36,7 +36,7 @@ const MEDIATION_LAYER_EUREKA_DEFAULTS = {
 
 
 const MEDIATION_LAYER_INSTANCE_DEFAULTS = (zluxProto, zluxHostname, zluxPort) => {
-  const ipv6CompatHostname = this.hostName.contains(':') ? '[' + this.hostName + ']' : this.hostName;
+  const ipv6CompatHostname = this.hostName.includes(':') ? '[' + this.hostName + ']' : this.hostName;
   
   return {
     
@@ -216,7 +216,7 @@ ApimlConnector.prototype = {
 
     //TODO this.isApiCatalogClientAttls is a workaround of an APIML bug in which it does not respect ATTLS when making client requests
     const zluxProto = this.isApiCatalogClientAttls === true ? 'http' : 'https';
-    const ipv6CompatHostname = this.hostName.contains(':') ? '[' + this.hostName + ']' : this.hostName;
+    const ipv6CompatHostname = this.hostName.includes(':') ? '[' + this.hostName + ']' : this.hostName;
     const instance = Object.assign({}, MEDIATION_LAYER_INSTANCE_DEFAULTS(zluxProto, this.hostName, this.port));
     Object.assign(instance, overrides);
     Object.assign(instance,  {

--- a/lib/apiml.js
+++ b/lib/apiml.js
@@ -338,10 +338,11 @@ ApimlConnector.prototype = {
   getRequestOptionsArray(method, path) {
     return this.discoveryUrls.map((url)=>{
       //in the form of https://host:port/eureka/, trim from https:// and following slash.
-      const hostAndPort = url.substring(8, url.indexOf('/', 8)).split(':');
+      // the url may have brackets for ipv6, which must be removed.
+      let hostAndPort = zluxUtil.getHostAndPortFromUrl(url);
       const options = Object.assign({
-        host: hostAndPort[0],
-        port: hostAndPort[1],
+        host: hostAndPort.host,
+        port: hostAndPort.port,
         method: method,
         path: path,
         headers: {'accept':'application/json'}

--- a/lib/apiml.js
+++ b/lib/apiml.js
@@ -36,7 +36,7 @@ const MEDIATION_LAYER_EUREKA_DEFAULTS = {
 
 
 const MEDIATION_LAYER_INSTANCE_DEFAULTS = (zluxProto, zluxHostname, zluxPort) => {
-  const ipv6CompatHostname = this.hostName.includes(':') ? '[' + this.hostName + ']' : this.hostName;
+  const ipv6CompatHostname = zluxHostname.includes(':') ? '[' + zluxHostname + ']' : zluxHostname;
   
   return {
     

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -30,8 +30,12 @@ const DEFAULT_HANDSHAKE_TIMEOUT = 30000;
 function convertOptions(request, realHost, realPort, urlPrefix, requestProcessingOptions) {
   var options = {};
   proxyLog.debug("ZWED0166I", request.headers.host); //proxyLog.debug("request host " + request.headers.host);
+
+  // add brackets for ipv6 if not already there
+  let ipv6RealHost = realHost.includes(':') && !realHost.includes('[') ? '['+realHost+']' : realHost;
+  
   var headers = request.headers;
-  var newHeaders = {};
+  var newHeaders = {};  
   const headersToRemove = requestProcessingOptions && Array.isArray(requestProcessingOptions.headersToRemove) ? requestProcessingOptions.headersToRemove : undefined;
   for (var propName in headers) {
     if (headers.hasOwnProperty(propName)) {
@@ -40,9 +44,9 @@ function convertOptions(request, realHost, realPort, urlPrefix, requestProcessin
         continue;
       }
       if (propName == "host"){
-        newHeaders[propName] = realHost+":"+realPort;
+        newHeaders[propName] = ipv6RealHost+":"+realPort;
       } else if (propName == "origin") {
-        newHeaders[propName] = realHost+":"+realPort;
+        newHeaders[propName] = ipv6RealHost+":"+realPort;
       } else if(propName.startsWith("sec-websocket")) {
         // Drop websocket headers
       } else {
@@ -52,7 +56,7 @@ function convertOptions(request, realHost, realPort, urlPrefix, requestProcessin
   }
   options.host = realHost;
   options.port = realPort;
-  options.family = 4;       /* "rs22" can resolve to IPV6 if otherwise */
+  options.family = ipv6RealHost.contains('[') ? 6 : 4;
   options.headers = newHeaders;
   options.path = urlPrefix + request.url;
   options.method = request.method;

--- a/lib/util.js
+++ b/lib/util.js
@@ -125,7 +125,7 @@ function getPrefixForService(serviceName, type, version) {
   
 function getGatewayUrlForService(zoweConfig, includeProtocol, serviceName, type, version) {
   const apimlConfig = zoweConfig.components['app-server'].node.mediationLayer.server;
-  return `${includeProtocol?'https://':''}${apimlConfig.gatewayHostname.contains(':') ? '['+apimlConfig.gatewayHostname+']' : apimlConfig.gatewayHostname}:${apimlConfig.gatewayPort}${getPrefixForService(serviceName, type, version)}`;
+  return `${includeProtocol?'https://':''}${apimlConfig.gatewayHostname.includes(':') ? '['+apimlConfig.gatewayHostname+']' : apimlConfig.gatewayHostname}:${apimlConfig.gatewayPort}${getPrefixForService(serviceName, type, version)}`;
 };
 
 module.exports.getGatewayUrlForService = getGatewayUrlForService;

--- a/lib/util.js
+++ b/lib/util.js
@@ -116,6 +116,34 @@ module.exports.getZoweVersion = function getZoweVersion() {
   return zoweVersion;
 }
 
+
+const urlRegexp = new RegExp(":\/\/");
+module.exports.getHostAndPortFromUrl = function getHostAndPortFromUrl(url) {
+  const urlStartIndex = url.search(urlRegexp);
+  if (urlStartIndex == -1) {
+    return undefined;
+  }
+  let pathIndex = url.indexOf('/', urlStartIndex+3);
+  if (pathIndex == -1) {
+    pathIndex = undefined;
+  }
+  let hostAndPort = url.substring(urlStartIndex+3, pathIndex);
+  let lastColonIndex = hostAndPort.lastIndexOf(':');
+  if (lastColonIndex == -1) {
+    // No port, so we return default ports.
+    return {
+      host: hostAndPort,
+      port: url.startsWith('https') ? 443 : 80
+    }
+  } else {
+    return {
+      //strip [] around ipv6 if exists
+      host: hostAndPort.substring(0, lastColonIndex).replace('[', '').replace(']', ''),
+      port: hostAndPort.substring(lastColonIndex+1)
+    }
+  }
+}
+
 //maybe better in apiml.js but there would be a circular dependency around the logger init.
 function getPrefixForService(serviceName, type, version) {
   let typePath = type || 'api';

--- a/lib/util.js
+++ b/lib/util.js
@@ -125,7 +125,7 @@ function getPrefixForService(serviceName, type, version) {
   
 function getGatewayUrlForService(zoweConfig, includeProtocol, serviceName, type, version) {
   const apimlConfig = zoweConfig.components['app-server'].node.mediationLayer.server;
-  return `${includeProtocol?'https://':''}${apimlConfig.gatewayHostname}:${apimlConfig.gatewayPort}${getPrefixForService(serviceName, type, version)}`;
+  return `${includeProtocol?'https://':''}${apimlConfig.gatewayHostname.contains(':') ? '['+apimlConfig.gatewayHostname+']' : apimlConfig.gatewayHostname}:${apimlConfig.gatewayPort}${getPrefixForService(serviceName, type, version)}`;
 };
 
 module.exports.getGatewayUrlForService = getGatewayUrlForService;

--- a/lib/webapp.js
+++ b/lib/webapp.js
@@ -1525,7 +1525,7 @@ WebApp.prototype = {
     delete tlsOptions.key;
     delete tlsOptions.cert;
     isHttps = !zluxUtil.isClientAttls(this.options.zoweConfig) && isHttps;
-    installLog.info(`ZWED0053I`, `${isHttps? 'HTTPS' : 'HTTP'}`, `${pluginID}:${serviceName}`, `${host}:${port}/${urlPrefix}`); //installLog.info(`Setting up ${isHttps? 'HTTPS' : 'HTTP'} proxy ` +`(${pluginID}:${serviceName}) to destination=${host}:${port}/${urlPrefix}`);
+    installLog.info(`ZWED0053I`, `${isHttps? 'HTTPS' : 'HTTP'}`, `${pluginID}:${serviceName}`, `${host.includes(':') ? '['+host+']' : host}:${port}/${urlPrefix}`); //installLog.info(`Setting up ${isHttps? 'HTTPS' : 'HTTP'} proxy ` +`(${pluginID}:${serviceName}) to destination=${host}:${port}/${urlPrefix}`);
     let myProxy = proxy.makeSimpleProxy(host, port, {
       urlPrefix, 
       isHttps, 
@@ -1559,11 +1559,15 @@ WebApp.prototype = {
 
     const gatewayPort = this.options.componentConfig.node.mediationLayer.server.gatewayPort;
     const gatewayHost = this.options.componentConfig.node.mediationLayer.server.gatewayHost;
+
+    // add brackets for ipv6 if not already there
+    let ipv6SafeGatewayHost = gatewayHost.includes(':') && !gatewayHost.includes('[') ? '['+gatewayHost+']' : gatewayHost;
+
     
     if (this.options.gatewayRedirect) {
       this.expressApp.get('/', (req,res,next) => {
         if ((req.get('x-forwarded-port') != gatewayPort)
-          && (req.get('x-forwarded-host') != `${gatewayHost}:${gatewayPort}`)
+          && (req.get('x-forwarded-host') != `${ipv6SafeGatewayHost}:${gatewayPort}`)
           && ( req.query['zwed-no-redirect'] != 1 )) {
           res.redirect(this.options.gatewayRedirect+'/');
         } else if (this.options.componentConfig.node.rootRedirectURL) {
@@ -1582,7 +1586,7 @@ WebApp.prototype = {
       if (this.options.componentConfig.node.rootRedirectURL) {
         this.expressApp.get(this.options.componentConfig.node.rootRedirectURL, (req, res, next) => {
           if ((req.get('x-forwarded-port') != gatewayPort)
-              && (req.get('x-forwarded-host') != `${gatewayHost}:${gatewayPort}`)
+              && (req.get('x-forwarded-host') != `${ipv6SafeGatewayHost}:${gatewayPort}`)
               && ( req.query['zwed-no-redirect'] != 1 )) {
             res.redirect(this.options.gatewayRedirect+this.options.componentConfig.node.rootRedirectURL);
           } else {

--- a/lib/webserver.js
+++ b/lib/webserver.js
@@ -447,7 +447,8 @@ WebServer.prototype = {
   }),
 
   callListen(methodServer, methodName, methodNameForLogging, ipAddress, port) {
-    const addressForLogging = `${ipAddress}:${port}`;
+    //We wrap : in [ ] due to IPv6 formatting
+    const addressForLogging = `${ipAddress.contains(':') ? '['+ipAddress+']' : ipAddress}:${port}`;
     const logFunction = function () {
       networkLogger.info("ZWED0129I", methodNameForLogging, addressForLogging); //networkLogger.log(bootstrapLogger.INFO,`(${methodNameForLogging})  `
           //+ `Listening on ${addressForLogging}`)
@@ -458,11 +459,11 @@ WebServer.prototype = {
   },
 
   close() {
-    this.httpServers.forEach((server)=> {
+    this.httpServers.forEach((server)=> {  
       let info = server.address();
       if (info) {
         //could be undefined if there was an error binding, yet close() still works
-        networkLogger.info(`ZWED0076I`, `${info.address}:${info.port}`); //networkLogger.info(`(HTTP) Closing server ${info.address}:${info.port}`);
+        networkLogger.info(`ZWED0076I`, `${info.address.contains(':') ? '['+info.address+']' : info.address}:${info.port}`); //networkLogger.info(`(HTTP) Closing server ${info.address}:${info.port}`);
       }
       server.close();      
     });
@@ -470,7 +471,7 @@ WebServer.prototype = {
       let info = server.address();
       if (info) {
         //could be undefined if there was an error binding, yet close() still works
-        networkLogger.info(`ZWED0077I`, `${info.address}:${info.port}`); //networkLogger.info(`(HTTPS) Closing server ${info.address}:${info.port}`);
+        networkLogger.info(`ZWED0077I`, `info.address.contains(':') ? '['+info.address+']' : info.address}:${info.port}`); //networkLogger.info(`(HTTPS) Closing server ${info.address}:${info.port}`);
       }
       server.close();      
     });

--- a/lib/webserver.js
+++ b/lib/webserver.js
@@ -459,7 +459,7 @@ WebServer.prototype = {
   },
 
   close() {
-    this.httpServers.forEach((server)=> {  
+    this.httpServers.forEach((server)=> {
       let info = server.address();
       if (info) {
         //could be undefined if there was an error binding, yet close() still works
@@ -471,7 +471,7 @@ WebServer.prototype = {
       let info = server.address();
       if (info) {
         //could be undefined if there was an error binding, yet close() still works
-        networkLogger.info(`ZWED0077I`, `info.address.contains(':') ? '['+info.address+']' : info.address}:${info.port}`); //networkLogger.info(`(HTTPS) Closing server ${info.address}:${info.port}`);
+        networkLogger.info(`ZWED0077I`, `${info.address.contains(':') ? '['+info.address+']' : info.address}:${info.port}`); //networkLogger.info(`(HTTPS) Closing server ${info.address}:${info.port}`);
       }
       server.close();      
     });

--- a/lib/webserver.js
+++ b/lib/webserver.js
@@ -448,7 +448,7 @@ WebServer.prototype = {
 
   callListen(methodServer, methodName, methodNameForLogging, ipAddress, port) {
     //We wrap : in [ ] due to IPv6 formatting
-    const addressForLogging = `${ipAddress.contains(':') ? '['+ipAddress+']' : ipAddress}:${port}`;
+    const addressForLogging = `${ipAddress.includes(':') ? '['+ipAddress+']' : ipAddress}:${port}`;
     const logFunction = function () {
       networkLogger.info("ZWED0129I", methodNameForLogging, addressForLogging); //networkLogger.log(bootstrapLogger.INFO,`(${methodNameForLogging})  `
           //+ `Listening on ${addressForLogging}`)
@@ -463,7 +463,7 @@ WebServer.prototype = {
       let info = server.address();
       if (info) {
         //could be undefined if there was an error binding, yet close() still works
-        networkLogger.info(`ZWED0076I`, `${info.address.contains(':') ? '['+info.address+']' : info.address}:${info.port}`); //networkLogger.info(`(HTTP) Closing server ${info.address}:${info.port}`);
+        networkLogger.info(`ZWED0076I`, `${info.address.includes(':') ? '['+info.address+']' : info.address}:${info.port}`); //networkLogger.info(`(HTTP) Closing server ${info.address}:${info.port}`);
       }
       server.close();      
     });
@@ -471,7 +471,7 @@ WebServer.prototype = {
       let info = server.address();
       if (info) {
         //could be undefined if there was an error binding, yet close() still works
-        networkLogger.info(`ZWED0077I`, `${info.address.contains(':') ? '['+info.address+']' : info.address}:${info.port}`); //networkLogger.info(`(HTTPS) Closing server ${info.address}:${info.port}`);
+        networkLogger.info(`ZWED0077I`, `${info.address.includes(':') ? '['+info.address+']' : info.address}:${info.port}`); //networkLogger.info(`(HTTPS) Closing server ${info.address}:${info.port}`);
       }
       server.close();      
     });


### PR DESCRIPTION
This PR acts upon strings printed to the users, eureka registration, proxying, and headers.

These strings take zowe configuration values for host/ip and create a URL from them in the form of `https://ip:port/`
This is incorrect when ipv6 ips are used, as they must be wrapped in `[`.
I detect this by detecting `:` in the ip.
Then I wrap it like `https://[ipv6]:port/`.

This same decision making is applied to such URLs in eureka registration (apiml.js)

Sometimes, the reverse is needed - zowe may pass in env vars with full URLs and when we just need the host, we must remove the '[]'.