### PR TITLE
add cors metadata to registration when client attls is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to the Zlux Server Framework package will be documented in this file.
 This repo is part of the app-server Zowe Component, and the change logs here may appear on Zowe.org in that section.
 
+## 3.4.0
+- Bugfix: Workaround for AT-TLS CORS error between the gateway and App Server by adding cors metadata to the eureka registration([#617](https://github.com/zowe/zlux-server-framework/pull/617))
+
 ## 3.3.0
 - Bugfix: Workaround for API Catalog issuing double-TLS request when it is under AT-TLS by changing eureka registration content to match state of API Catalog ([#610](https://github.com/zowe/zlux-server-framework/pull/610))
 - Enhancement: The app server no longer prints codes ZWED0036I, 54I, 55I, 62I-68I. These are now only shown in bootstrap or install debug logs, to clean up the job log. ([#608](https://github.com/zowe/zlux-server-framework/pull/608))

--- a/lib/apiml.js
+++ b/lib/apiml.js
@@ -79,9 +79,9 @@ const MEDIATION_LAYER_INSTANCE_DEFAULTS = (zluxProto, zluxHostname, zluxPort) =>
 }};
 
 function ApimlConnector({ hostName, port, discoveryUrls,
-                          discoveryPort, tlsOptions, eurekaOverrides, isClientAttls, traceTls }) {
+                          discoveryPort, catalogPort, gatewayPort, tlsOptions, eurekaOverrides, isClientAttls, traceTls }) {
   Object.assign(this, { hostName, port, discoveryUrls,
-                        discoveryPort, tlsOptions, eurekaOverrides, isClientAttls, traceTls });
+                        discoveryPort, catalogPort, gatewayPort, tlsOptions, eurekaOverrides, isClientAttls, traceTls });
   //TODO config should never be checked through env var, but is temporarily needed to temporarily read gateway's ATTLS state to provide it with Eureka info it can work with.
   const clientGlobalAttls = process.env['ZWE_zowe_network_client_tls_attls'];
   const serverGlobalAttls = process.env['ZWE_zowe_network_server_tls_attls'] == 'true';
@@ -231,6 +231,13 @@ ApimlConnector.prototype = {
          "@enabled": ''+protocolObject.httpsEnabled
        }
      });
+     // TODO: replace this with a single variable for detecting AT-TLS?
+     if (this.isGatewayClientAttls) {
+      Object.assign(instance.metadata, {
+        "apiml.corsEnabled": "true",
+        "apiml.corsAllowedOrigins": `https://${this.hostName}:${this.catalogPort},https://${this.hostName}:${this.gatewayPort}`
+      })
+     }
 
      log.debug("ZWED0143I", JSON.stringify(instance)); //log.debug("API ML registration settings:", JSON.stringify(instance));
 

--- a/lib/apiml.js
+++ b/lib/apiml.js
@@ -233,9 +233,13 @@ ApimlConnector.prototype = {
      });
      // TODO: replace this with a single variable for detecting AT-TLS?
      if (this.isGatewayClientAttls) {
+      let allowedOrigins = `https://${this.hostName}:${this.gatewayPort}`;
+      if (this.catalogPort != null && `${this.catalogPort}`.trim().length > 0) {
+        allowedOrigins = `${allowedOrigins},https://${this.hostName}:${this.catalogPort}`
+      }
       Object.assign(instance.metadata, {
         "apiml.corsEnabled": "true",
-        "apiml.corsAllowedOrigins": `https://${this.hostName}:${this.catalogPort},https://${this.hostName}:${this.gatewayPort}`
+        "apiml.corsAllowedOrigins": allowedOrigins
       })
      }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -212,6 +212,9 @@ Server.prototype = {
 
 
     const apimlConfig = this.componentConfig.node.mediationLayer;
+    Object.assign(apimlConfig.server, {
+      catalogPort: process.env['ZWE_components_api_catalog_port']
+    })
     if (apimlConfig.enabled) {
       if (firstWorker) {
         installLogger.debug('ZWED0033I', this.port, JSON.stringify(apimlConfig));
@@ -219,6 +222,8 @@ Server.prototype = {
           hostName: webAppOptions.hostname,
           port: this.port,
           discoveryUrls: apimlConfig.server.discoveryUrls || [`https://${apimlConfig.server.hostname}:${apimlConfig.server.port}/eureka/`],
+          gatewayPort: apimlConfig.server.gatewayPort,
+          catalogPort: apimlConfig.server.catalogPort,
           tlsOptions: this.tlsOptions,
           traceTls: apimlConfig.traceTls,
           eurekaOverrides: apimlConfig.eureka,


### PR DESCRIPTION
Looking for feedback on the `catalogPort` parameter. The environment variable works, but I'd rather add the information to the `mediationLayer` object being passed through the code. I couldn't find where this object is initialized.

## Proposed changes
This PR addresses Issue: https://github.com/zowe/zowe-install-packaging/issues/432

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Change in a documentation
- [ ] Refactor the code 
- [ ] Chore, repository cleanup, updates the dependencies.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## PR Checklist
Please delete options that are not relevant.
- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zlux/blob/master/CONTRIBUTING.md))
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
- [ ] video or image is included if visual changes are made
- [x] Relevant update to CHANGELOG.md
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works, or describe a test method below

## Testing
Manually tested on the Marist systems. Will be included in automated system tests [with this PR](https://github.com/zowe/zowe-install-packaging/pull/4248).

