### PR TITLE
Update references to nodejs cluster functions

### DIFF
--- a/lib/clusterManager.js
+++ b/lib/clusterManager.js
@@ -65,15 +65,16 @@ if (process.env.ZLUX_MAX_WORKERS && (maxWorkers != Number(process.env.ZLUX_MAX_W
 }
 
 var ClusterManager = function() {
-  this.isMaster = cluster.isMaster;
+  this.isMaster = cluster.isPrimary;
+  this.isPrimary = this.isMaster;
   this.messageIndex = 0;
   this.workersNum = minWorkers;
   this.workers = [];
   this.overrideFileConfig = true;
   events.EventEmitter.call(this);
-  if (this.isMaster) {
-    /* We create the storage object at the master cluster. Each cluster will loop through
-    and reference this master object, from any cluster */
+  if (this.isPrimary) {
+    /* We create the storage object at the primary cluster. Each cluster will loop through
+    and reference this primary object, from any cluster */
     this.storage = pluginStorage.LocalStorageFactory();
   }
 }
@@ -97,7 +98,7 @@ ClusterManager.prototype.getCpuUsagePercent = function() {
   return usagePercent;
 }
 
-if (cluster.isMaster) {
+if (cluster.isPrimary) {
   var stoppingProcess = false;
   process.once('SIGINT', function() {
     stoppingProcess = true;
@@ -205,7 +206,7 @@ if (cluster.isMaster) {
   }
 
   /* Having gotten here, we are already at the cluster, but it's safer to validate anyway
-    i. e. "if (this.storage) ..." since only the master cluster has storage */
+    i. e. "if (this.storage) ..." since only the primary cluster has storage */
   ClusterManager.prototype.getStorageByKey = function(pluginId, key, resultHandler) {
     return resultHandler(this.storage.get(key, pluginId));
   }
@@ -258,7 +259,7 @@ if (cluster.isMaster) {
 
   ClusterManager.prototype.startWorkers = function() {
     clusterLogger.info("ZWED0026I - Fork " + this.workersNum + " workers.");
-    cluster.setupMaster({ silent: true });//workers[wi].process.stdout is null without this line
+    cluster.setupPrimary({ silent: true });//workers[wi].process.stdout is null without this line
     for (let i = 0; i < this.workersNum; i++) {
       var wi = i%this.workersNum;
       this.startWorker(wi);
@@ -481,7 +482,7 @@ if (cluster.isMaster) {
     process.send({type : MessageTypes.reportInitialized, index : this.getIndexInCluster()});
   }
   
-  ClusterManager.prototype.handleMessageFromMaster = function(message) {
+  ClusterManager.prototype.handleMessageFromPrimary = function(message) {
     if (message.type) {
       if (message.type == MessageTypes.notify) {
         //console.log("Notification from " + message.index + ": " + message.notifyName);
@@ -503,7 +504,7 @@ if (cluster.isMaster) {
       }
     }, 10000).unref();
     process.on('message', function(message) {
-      thatClusterManager.handleMessageFromMaster(message);
+      thatClusterManager.handleMessageFromPrimary(message);
     });
   }
   
@@ -713,7 +714,7 @@ ClusterManager.prototype.start = function(configJSON, configLocation) {
   if (configJSON && configJSON.node && configJSON.node.cluster) {
     storageTimeout = configJSON.node.cluster.storageTimeout;
   }
-  if (cluster.isMaster) {
+  if (cluster.isPrimary) {
     clusterLogger.info(`ZWED0028I - Master ${process.pid} is running.`)
     this.initializing(function() {
       this.startWorkers();
@@ -725,7 +726,7 @@ ClusterManager.prototype.start = function(configJSON, configLocation) {
 }
 
 ClusterManager.prototype.callClusterMethod = function (moduleName, importedName, methodName, argsArray, callback, onerror = this.onError, timeout = 1000) {
-  if (cluster.isMaster) {
+  if (cluster.isPrimary) {
     return this.callClusterMethodLocal(-1, moduleName, importedName, methodName, argsArray, callback);
   } else {
     return this.callClusterMethodRemote(moduleName, importedName, methodName, argsArray, callback, onerror, timeout);
@@ -733,7 +734,7 @@ ClusterManager.prototype.callClusterMethod = function (moduleName, importedName,
 }
 
 ClusterManager.prototype.notifyOthers = function (notifyName, args, callback, onerror = this.onError) {
-  if (cluster.isMaster) {
+  if (cluster.isPrimary) {
     return this.notifyWorkers(notifyName, args, -1);
   } else {
     return this.notifyCluster(notifyName, args, this.getIndexInCluster(), callback, onerror);

--- a/lib/index.js
+++ b/lib/index.js
@@ -298,7 +298,7 @@ Server.prototype = {
 
       const percentComplete = `${Math.round((pluginCount/event.count)*100)}% (${pluginCount}/${event.count})`;
       let percentLoaded = `${Math.round((pluginsLoaded/event.count)*100)}% (${pluginsLoaded}/${event.count})`;
-      const masterProcess = !process.clusterManager || process.clusterManager.getIndexInCluster() == 0;
+      const primaryProcess = !process.clusterManager || process.clusterManager.getIndexInCluster() == 0;
       function handleIfComplete(index) {
         if (pluginCount === event.count) {
           if (!messageIssued) {
@@ -313,7 +313,7 @@ Server.prototype = {
 
 
       if (event.data.error) {
-        if (masterProcess) {
+        if (primaryProcess) {
           installLogger.warn(!messageIssued?`ZWED0027W`:`ZWED0170W`, event.data.identifier, event.data.pluginVersion, event.data.error.message, percentLoaded, percentComplete);
         }
         handleIfComplete(this);
@@ -321,12 +321,12 @@ Server.prototype = {
         return this.pluginLoaded(event.data).then(() => {
           pluginsLoaded++;
           percentLoaded = `${Math.round((pluginsLoaded/event.count)*100)}% (${pluginsLoaded}/${event.count})`;
-          if (masterProcess) {
+          if (primaryProcess) {
             installLogger.info(!messageIssued?`ZWED0290I`:`ZWED0292I`, event.data.identifier, event.data.pluginVersion, percentLoaded, percentComplete);
           }
           handleIfComplete(this);
         }, err => {
-          if (masterProcess) {
+          if (primaryProcess) {
             if (!messageIssued) {
               installLogger.warn(`ZWED0159W`, event.data.identifier, err.message, percentLoaded, percentComplete);
             } else {

--- a/lib/sessionStore.js
+++ b/lib/sessionStore.js
@@ -99,7 +99,7 @@ SessionStore.prototype.createSession = function(req, sess) {
 }
 
 SessionStore.prototype.isLocalStorage = function() {
-  return !process.clusterManager || process.clusterManager.isMaster;
+  return !process.clusterManager || process.clusterManager.isPrimary;
 }
 
 SessionStore.prototype.getTimestamp = function() {


### PR DESCRIPTION
https://nodejs.org/api/cluster.html#clusterismaster has been aliased to https://nodejs.org/api/cluster.html#clusterisprimary since node 16, and marked as deprecated by them.

In order to avoid surprises if the old name is removed in the future, I'm changing references in our code to point to the right objects today.
node 16 isn't even supported anymore, so all nodes in support have the new name.

I'm not 100% confident that extenders are not using `this.isMaster` in our code, so I'm leaving that there and creating an alias to `this.isPrimary` for the sake of organization, so mimic node's behavior.