### PR TITLE
bugfix for property 'gatewayHostname'

### DIFF
--- a/lib/webapp.js
+++ b/lib/webapp.js
@@ -1562,16 +1562,16 @@ WebApp.prototype = {
     */
 
     const gatewayPort = this.options.componentConfig.node.mediationLayer.server.gatewayPort;
-    const gatewayHost = this.options.componentConfig.node.mediationLayer.server.gatewayHost;
+    const gatewayHostname = this.options.componentConfig.node.mediationLayer.server.gatewayHostname;
 
     // add brackets for ipv6 if not already there
-    let ipv6SafeGatewayHost = gatewayHost.includes(':') && !gatewayHost.includes('[') ? '['+gatewayHost+']' : gatewayHost;
+    let ipv6SafeGatewayHostname = gatewayHostname.includes(':') && !gatewayHostname.includes('[') ? '['+gatewayHostname+']' : gatewayHostname;
 
     
     if (this.options.gatewayRedirect) {
       this.expressApp.get('/', (req,res,next) => {
         if ((req.get('x-forwarded-port') != gatewayPort)
-          && (req.get('x-forwarded-host') != `${ipv6SafeGatewayHost}:${gatewayPort}`)
+          && (req.get('x-forwarded-host') != `${ipv6SafeGatewayHostname}:${gatewayPort}`)
           && ( req.query['zwed-no-redirect'] != 1 )) {
           res.redirect(this.options.gatewayRedirect+'/');
         } else if (this.options.componentConfig.node.rootRedirectURL) {
@@ -1590,7 +1590,7 @@ WebApp.prototype = {
       if (this.options.componentConfig.node.rootRedirectURL) {
         this.expressApp.get(this.options.componentConfig.node.rootRedirectURL, (req, res, next) => {
           if ((req.get('x-forwarded-port') != gatewayPort)
-              && (req.get('x-forwarded-host') != `${ipv6SafeGatewayHost}:${gatewayPort}`)
+              && (req.get('x-forwarded-host') != `${ipv6SafeGatewayHostname}:${gatewayPort}`)
               && ( req.query['zwed-no-redirect'] != 1 )) {
             res.redirect(this.options.gatewayRedirect+this.options.componentConfig.node.rootRedirectURL);
           } else {


### PR DESCRIPTION
The property `node.mediationLayer.server.gatewayHost` does not exist, `node.mediationLayer.server.gatewayHostname` does.
I introduced this typo in https://github.com/zowe/zlux-server-framework/pull/614 and as I continue to test ipv6 I found and fixed this.