### PR TITLE
Do not issue ZWED0149E when attls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to the Zlux Server Framework package will be documented in this file.
 This repo is part of the app-server Zowe Component, and the change logs here may appear on Zowe.org in that section.
 
+## 3.5.0
+- Bugfix: Fixed error ZWED149E from occurring when using AT-TLS. This error did not mean something was wrong, so the message is no longer printed in that condition to avoid confusion. ([#???]())
+
 ## 3.4.0
 - Enhancement: Logging of URLs now accomodates when the app-server or gateway server are instructed to bind to an IPv6 address ([#614](https://github.com/zowe/zlux-server-framework/pull/614))
 - Enhancement: Eureka registration to discovery server now handles IPv6 in URLs ([#614](https://github.com/zowe/zlux-server-framework/pull/614))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the Zlux Server Framework package will be documented in t
 This repo is part of the app-server Zowe Component, and the change logs here may appear on Zowe.org in that section.
 
 ## 3.5.0
-- Bugfix: Fixed error ZWED149E from occurring when using AT-TLS. This error did not mean something was wrong, so the message is no longer printed in that condition to avoid confusion. ([#???]())
+- Bugfix: Fixed error ZWED149E from occurring when using AT-TLS. This error did not mean something was wrong, so the message is no longer printed in that condition to avoid confusion. ([#633](https://github.com/zowe/zlux-server-framework/pull/633))
 
 ## 3.4.0
 - Enhancement: Logging of URLs now accomodates when the app-server or gateway server are instructed to bind to an IPv6 address ([#614](https://github.com/zowe/zlux-server-framework/pull/614))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,10 @@ All notable changes to the Zlux Server Framework package will be documented in t
 This repo is part of the app-server Zowe Component, and the change logs here may appear on Zowe.org in that section.
 
 ## 3.5.0
-- Bugfix: Fixed error ZWED149E from occurring when using AT-TLS. This error did not mean something was wrong, so the message is no longer printed in that condition to avoid confusion. ([#633](https://github.com/zowe/zlux-server-framework/pull/633))
+- Bugfix: Fixed error ZWED0149E from occurring when using AT-TLS. This error did not mean something was wrong, so the message is no longer printed in that condition to avoid confusion. ([#633](https://github.com/zowe/zlux-server-framework/pull/633))
 
 ## 3.4.0
-- Enhancement: Logging of URLs now accomodates when the app-server or gateway server are instructed to bind to an IPv6 address ([#614](https://github.com/zowe/zlux-server-framework/pull/614))
+- Enhancement: Logging of URLs now accommodates when the app-server or gateway server are instructed to bind to an IPv6 address ([#614](https://github.com/zowe/zlux-server-framework/pull/614))
 - Enhancement: Eureka registration to discovery server now handles IPv6 in URLs ([#614](https://github.com/zowe/zlux-server-framework/pull/614))
 - Bugfix: Fix TN3270 and VT terminals not appearing in the Zowe Desktop when using AT-TLS by adding a workaround for an AT-TLS CORS error between the gateway and App Server where CORS metadata has been added to the eureka registration ([#617](https://github.com/zowe/zlux-server-framework/pull/617))
 
@@ -77,7 +77,7 @@ This repo is part of the app-server Zowe Component, and the change logs here may
 
 ## 2.3.0
 
-- Bugfix: Proxies (zss, external services, and those made by router services) now default to the same HTTPS/TLS settings as the app-esrver.
+- Bugfix: Proxies (zss, external services, and those made by router services) now default to the same HTTPS/TLS settings as the app-server.
 
 ## 2.0.0
 

--- a/lib/webserver.js
+++ b/lib/webserver.js
@@ -397,7 +397,11 @@ WebServer.prototype = {
         this.httpsOptions.enableTrace = true;
       }
       bootstrapLogger.debug('TLS trace:', this.httpsOptions.enableTrace ? 'enabled' : 'disabled');
-      readTlsOptionsFromConfig(nodeConfig, this.httpsOptions, zoweConfig.zowe?.certificate?.keystore?.password);
+          
+
+      if (util.isServerHttps(zoweConfig) || !(util.isClientAttls(zoweConfig))) {
+        readTlsOptionsFromConfig(nodeConfig, this.httpsOptions, zoweConfig.zowe?.certificate?.keystore?.password);
+      }
     }
   },  
 


### PR DESCRIPTION
ZWED149E can occur when ATTLS is used where it tries to load a keyring even when it has no reason to.

I'm changing up the code slightly: if there's no expected TLS interactions, then there's no need for the certificates.
This PR checks if either the server is TLS, or expects to do TLS client calls, and if neither is true, no keyring content is loaded. This stops ZWED0149E because the associated block of code never runs.

To test, try an ATTLS setup. Without this fix, you'll see ZWED0149E. With this fix, you wont.
There should be no other change in behavior, and, in neither case is zowe broken, as this error message was misleading.