### PR TITLE
(v2) add cors metadata to registration when client attls is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the Zlux Server Framework package will be documented in t
 This repo is part of the app-server Zowe Component, and the change logs here may appear on Zowe.org in that section.
 
 ## 2.14.4
-- Bugfix: Fix TN3270 and VT terminals not appearing in the Zowe Desktop when using AT-TLS by adding a workaround for an AT-TLS CORS error between the gateway and App Server where CORS metadata has been added to the eureka registration ([#???](https://github.com/zowe/zlux-server-framework/pull/???))
+- Bugfix: Fix TN3270 and VT terminals not appearing in the Zowe Desktop when using AT-TLS by adding a workaround for an AT-TLS CORS error between the gateway and App Server where CORS metadata has been added to the eureka registration ([#634](https://github.com/zowe/zlux-server-framework/pull/634))
 
 ## 2.18.3
 - Enhancement: Upgraded some old dependencies to new versions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to the Zlux Server Framework package will be documented in this file..
 This repo is part of the app-server Zowe Component, and the change logs here may appear on Zowe.org in that section.
 
-## 2.14.4
+## 2.18.4
 - Bugfix: Fix TN3270 and VT terminals not appearing in the Zowe Desktop when using AT-TLS by adding a workaround for an AT-TLS CORS error between the gateway and App Server where CORS metadata has been added to the eureka registration ([#634](https://github.com/zowe/zlux-server-framework/pull/634))
 
 ## 2.18.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to the Zlux Server Framework package will be documented in this file..
 This repo is part of the app-server Zowe Component, and the change logs here may appear on Zowe.org in that section.
 
+## 2.14.4
+- Bugfix: Fix TN3270 and VT terminals not appearing in the Zowe Desktop when using AT-TLS by adding a workaround for an AT-TLS CORS error between the gateway and App Server where CORS metadata has been added to the eureka registration ([#???](https://github.com/zowe/zlux-server-framework/pull/???))
+
 ## 2.18.3
 - Enhancement: Upgraded some old dependencies to new versions.
 

--- a/lib/apiml.js
+++ b/lib/apiml.js
@@ -79,9 +79,9 @@ const MEDIATION_LAYER_INSTANCE_DEFAULTS = (zluxProto, zluxHostname, zluxPort) =>
 }};
 
 function ApimlConnector({ hostName, port, discoveryUrls,
-                          discoveryPort, tlsOptions, eurekaOverrides, isClientAttls, traceTls }) {
+                          discoveryPort, catalogPort, gatewayPort, tlsOptions, eurekaOverrides, isClientAttls, traceTls }) {
   Object.assign(this, { hostName, port, discoveryUrls,
-                        discoveryPort, tlsOptions, eurekaOverrides, isClientAttls, traceTls });
+                        discoveryPort, catalogPort, gatewayPort, tlsOptions, eurekaOverrides, isClientAttls, traceTls });
   //TODO config should never be checked through env var, but is temporarily needed to temporarily read gateway's ATTLS state to provide it with Eureka info it can work with.
   const clientGlobalAttls = process.env['ZWE_zowe_network_client_tls_attls'];
   const serverGlobalAttls = process.env['ZWE_zowe_network_server_tls_attls'] == 'true';
@@ -232,6 +232,18 @@ ApimlConnector.prototype = {
        }
      });
 
+     // TODO: replace this with a single variable for detecting AT-TLS?
+     if (this.isGatewayClientAttls) {
+      let allowedOrigins = `https://${this.hostName}:${this.gatewayPort}`;
+      if (this.catalogPort != null && `${this.catalogPort}`.trim().length > 0) {
+        allowedOrigins = `${allowedOrigins},https://${this.hostName}:${this.catalogPort}`
+      }
+      Object.assign(instance.metadata, {
+        "apiml.corsEnabled": "true",
+        "apiml.corsAllowedOrigins": allowedOrigins
+      })
+     }
+    
      log.debug("ZWED0143I", JSON.stringify(instance)); //log.debug("API ML registration settings:", JSON.stringify(instance));
 
     return instance;

--- a/lib/index.js
+++ b/lib/index.js
@@ -212,6 +212,9 @@ Server.prototype = {
 
 
     const apimlConfig = this.componentConfig.node.mediationLayer;
+    Object.assign(apimlConfig.server, {
+      catalogPort: process.env['ZWE_components_api_catalog_port']
+    })
     if (apimlConfig.enabled) {
       if (firstWorker) {
         installLogger.debug('ZWED0033I', this.port, JSON.stringify(apimlConfig));
@@ -219,6 +222,8 @@ Server.prototype = {
           hostName: webAppOptions.hostname,
           port: this.port,
           discoveryUrls: apimlConfig.server.discoveryUrls || [`https://${apimlConfig.server.hostname}:${apimlConfig.server.port}/eureka/`],
+          gatewayPort: apimlConfig.server.gatewayPort,
+          catalogPort: apimlConfig.server.catalogPort,
           tlsOptions: this.tlsOptions,
           traceTls: apimlConfig.traceTls,
           eurekaOverrides: apimlConfig.eureka,


### PR DESCRIPTION
This PR is identical to https://github.com/zowe/zlux-server-framework/pull/617 but for v2.