### PR TITLE
Removing use of deprecated url.parse api in node 24

### DIFF
--- a/lib/webapp.js
+++ b/lib/webapp.js
@@ -416,9 +416,8 @@ const staticHandlers = {
     //To not abuse FS, cache for a second
     
     return function(req, res) {
-      let parsedRequest = url.parse(req.url, true);
-      const type = parsedRequest.query["type"] ? parsedRequest.query["type"] : 'all';
-      const refresh = parsedRequest.query['refresh'];
+      const type = req.query.type ? req.query.type : 'all';
+      const refresh = req.query.refresh;
       const now = Date.now();
       if (refresh == 'true' && (lastCall+CALL_INTERVAL < now)) {
         lastCall = now;

--- a/plugins/sso-auth/lib/zssHandler.js
+++ b/plugins/sso-auth/lib/zssHandler.js
@@ -277,7 +277,7 @@ class ZssHandler {
   
   _makeProfileName(reqUrl, method) {
     //console.log("request.originalUrl", request.originalUrl)
-    const path = url.parse(reqUrl).pathname;
+    const path = new URL(reqUrl).pathname;
     //console.log("originalPath", originalPath)
     const resourceName = makeProfileNameForRequest(path, method, this.instanceID);
     //console.log("resourceName", resourceName)


### PR DESCRIPTION
node is deprecating `url.parse()`. i dont think they're removing it any time soon, but they say to use `new URL()` instead.
so, i found that in 2 places:

1) the GET /plugins call, (as seen when login to desktop), was using it to check for headers. `req.headers` already exists in expressjs so i dont know why we did that. i made that change.

2) RBAC used url parsing to get part of the path. `new URL()` can do the same. So, you'll need to run an RBAC test to be sure of that change.