### PR TITLE
Update node forge to v1.3.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "express-static-gzip": "~2.1.7",
         "graceful-fs": "~4.2.11",
         "ipaddr.js": "~2.1.0",
-        "node-forge": "~1.3.1",
+        "node-forge": "1.3.3",
         "normalize-url": "~7.0.0",
         "require-from-string": "~2.0.2",
         "semver": "~7.6.0",
@@ -1975,9 +1975,9 @@
       }
     },
     "node_modules/node-forge": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
-      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.3.tgz",
+      "integrity": "sha512-rLvcdSyRCyouf6jcOIPe/BgwG/d7hKjzMKOas33/pHEr6gbq18IK9zV7DiPvzsz0oBJPme6qr6H6kGZuI9/DZg==",
       "engines": {
         "node": ">= 6.13.0"
       }

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "express-static-gzip": "~2.1.7",
     "graceful-fs": "~4.2.11",
     "ipaddr.js": "~2.1.0",
-    "node-forge": "~1.3.1",
+    "node-forge": "1.3.3",
     "normalize-url": "~7.0.0",
     "require-from-string": "~2.0.2",
     "semver": "~7.6.0",


### PR DESCRIPTION
fixes an audit about a non-exploitable issue