### PR TITLE
upgrade axios

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@rocketsoftware/eureka-js-client": "^4.5.9",
         "@rocketsoftware/express-ws": "^5.0.1",
         "accept-language-parser": "~1.5.0",
-        "axios": "^1.8.4",
+        "axios": "1.13.2",
         "bluebird": "3.7.2",
         "body-parser": "~1.20.3",
         "cookie-parser": "~1.4.6",
@@ -425,10 +425,9 @@
       "integrity": "sha512-3AungXC4I8kKsS9PuS4JH2nc+0bVY/mjgrephHTIi8fpEeGsTHBUJeosp0Wc1myYMElmD0B3Oc4XL/HVJ4PV2g=="
     },
     "node_modules/axios": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
-      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
-      "license": "MIT",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.2.tgz",
+      "integrity": "sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.4",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@rocketsoftware/eureka-js-client": "^4.5.9",
     "@rocketsoftware/express-ws": "^5.0.1",
     "accept-language-parser": "~1.5.0",
-    "axios": "^1.8.4",
+    "axios": "1.13.2",
     "bluebird": "3.7.2",
     "body-parser": "~1.20.3",
     "cookie-parser": "~1.4.6",


### PR DESCRIPTION
I was thinking of moving to undici as we did in v3, but it only supports node 18.17+, and  while that meets our criteria too, I don't want to disrupt users of older node 18 for v2.