### PR TITLE
Fix attls client config priority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This repo is part of the app-server Zowe Component, and the change logs here may
 
 ## 3.5.0
 - Bugfix: Fixed error ZWED0149E from occurring when using AT-TLS. This error did not mean something was wrong, so the message is no longer printed in that condition to avoid confusion. ([#633](https://github.com/zowe/zlux-server-framework/pull/633))
+- Bugfix: App-server was not respecting property "components.app-server.zowe.network.client.tls.attls". Instead, property "zowe.network.client.tls.attls" was taking priority, [(#653)](https://github.com/zowe/zlux-server-framework/pull/653)
 
 ## 3.4.0
 - Enhancement: Logging of URLs now accommodates when the app-server or gateway server are instructed to bind to an IPv6 address ([#614](https://github.com/zowe/zlux-server-framework/pull/614))

--- a/lib/util.js
+++ b/lib/util.js
@@ -536,12 +536,14 @@ module.exports.isServerHttps = function(zoweConfig) {
 }
 
 function isClientAttls(zoweConfig) {
-  let clientGlobalAttls = zoweConfig.zowe.network?.client?.tls?.attls;
-  let clientLocalAttls = zoweConfig.components['app-server'].zowe?.network?.client?.tls?.attls;
-  let clientAttls = clientGlobalAttls || clientLocalAttls;
+  const clientGlobalAttls = zoweConfig.zowe.network?.client?.tls?.attls;
+  const clientLocalAttls = zoweConfig.components['app-server'].zowe?.network?.client?.tls?.attls;
+  let clientAttls = clientLocalAttls !== undefined ? clientLocalAttls : !!clientGlobalAttls;
   if ((clientGlobalAttls !== false) && (clientLocalAttls !== false) && (!clientAttls)) {
     // If client attls not explicitly false OR truthy, have client follow server attls variable. it simplifies common case in which users want both.
-    return zoweConfig.zowe.network?.server?.tls?.attls || zoweConfig.components['app-server'].zowe?.network?.server?.tls?.attls;
+    const serverGlobalAttls = zoweConfig.zowe.network?.server?.tls?.attls;
+    const serverLocalAttls = zoweConfig.components['app-server'].zowe?.network?.server?.tls?.attls;
+    return serverLocalAttls !== undefined ? serverLocalAttls : !!serverGlobalAttls;
   } else {
     return clientAttls;
   }


### PR DESCRIPTION
components.app-server.zowe.network.client.tls.attls should take priority over zowe.network.client.tls.attls

Yet, if you set

components.app-server.zowe.network.client.tls.attls:false
and
zowe.network.client.tls.attls: true

You will see the eureka registration fail if due to incorrect http/https connection.


This PR fixes that.