### PR TITLE
Update undici from audit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "normalize-url": "~7.0.0",
         "require-from-string": "~2.0.2",
         "semver": "~7.6.0",
-        "undici": "6.21.2",
+        "undici": "6.23.0",
         "ws": "^6.2.3",
         "yaml": "~2.4.1",
         "yauzl": "~3.1.2"
@@ -2855,9 +2855,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.21.2",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.2.tgz",
-      "integrity": "sha512-uROZWze0R0itiAKVPsYhFov9LxrPMHLMEQFszeI2gCN6bnIIZ8twzBCJcN2LJrBBLfrP0t1FW0g+JmKVl8Vk1g==",
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.23.0.tgz",
+      "integrity": "sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==",
       "engines": {
         "node": ">=18.17"
       }

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "normalize-url": "~7.0.0",
     "require-from-string": "~2.0.2",
     "semver": "~7.6.0",
-    "undici": "6.21.2",
+    "undici": "6.23.0",
     "ws": "^6.2.3",
     "yaml": "~2.4.1",
     "yauzl": "~3.1.2"


### PR DESCRIPTION
This addresses non-exploitable https://nvd.nist.gov/vuln/detail/CVE-2026-22036