### PR TITLE
Change depgraph debug to trace

### DIFF
--- a/lib/depgraph.js
+++ b/lib/depgraph.js
@@ -44,7 +44,7 @@ DependencyGraph.prototype = {
   pluginsById: null,
   
   addPlugin(plugin) {
-    logger.debug("ZWED0146I", plugin.identifier); //logger.debug(`Adding plugin ${plugin.identifier}`);
+    logger.trace("ZWED0146I", plugin.identifier); //logger.trace(`Adding plugin ${plugin.identifier}`);
     if (this.pluginsById[plugin.identifier]) {
       logger.warn(`ZWED0017W`, plugin.identifier); //logger.warn(`Duplicate plugin identifier ` + plugin.identifier + ` found.`);
     }
@@ -63,7 +63,7 @@ DependencyGraph.prototype = {
     const g = {};
     let brokenDeps = [];
     for (const plugin of Object.values(this.pluginsById)) {
-      logger.debug("ZWED0147I", plugin); //logger.debug("processing plugin ", plugin, "\n")
+      logger.trace("ZWED0147I", plugin); //logger.trace("processing plugin ", plugin, "\n")
       const importerId = plugin.identifier;
       if (!g[importerId]) {
         g[importerId] = { 
@@ -94,12 +94,12 @@ DependencyGraph.prototype = {
             serviceRef: serviceImport
           };
           validateDep(depLink, this.pluginsById[providerId]);
-          logger.debug('ZWED0148I', providerId, depLink); //logger.debug('Found dependency: ', providerId, depLink)
+          logger.trace('ZWED0148I', providerId, depLink); //logger.trace('Found dependency: ', providerId, depLink)
           if (depLink.valid) {
             providerNode.deps.push(Object.freeze(depLink));
             if (!serviceImport.version) {
               serviceImport.version = depLink.actualVersion;
-              logger.debug(`ZWED0149I`, depLink); //logger.debug(`resolved actual version for import`,depLink);
+              logger.trace(`ZWED0149I`, depLink); //logger.trace(`resolved actual version for import`,depLink);
             }
           } else {
             brokenDeps.push(depLink)
@@ -115,13 +115,13 @@ DependencyGraph.prototype = {
         brokenDeps = [];
         for (const depLink of depsArray) {
           validateDep(depLink, this.pluginsById[depLink.provider]);
-          logger.debug('ZWED0150I', depLink.provider, depLink); //logger.debug('Found dependency: ', depLink.provider, depLink)
+          logger.trace('ZWED0150I', depLink.provider, depLink); //logger.trace('Found dependency: ', depLink.provider, depLink)
           if (depLink.valid) {
             depLink.validationError = undefined;
             let providerNode = g[depLink.provider];
             providerNode.deps.push(Object.freeze(depLink));
             depLink.serviceRef.version = depLink.actualVersion;
-            logger.debug(`ZWED0151I`, depLink); //logger.debug(`resolved actual version for import`,depLink);
+            logger.trace(`ZWED0151I`, depLink); //logger.trace(`resolved actual version for import`,depLink);
           } else {
             brokenDeps.push(depLink);
           }
@@ -148,14 +148,14 @@ DependencyGraph.prototype = {
    * properly instantiated.
    */
   _removeBrokenPlugins(graphWithBrokenDeps) {
-    logger.debug('ZWED0152I', graphWithBrokenDeps); //logger.debug('graph: ', graphWithBrokenDeps)
+    logger.trace('ZWED0152I', graphWithBrokenDeps); //logger.trace('graph: ', graphWithBrokenDeps)
     const rejects = {};
     const graph = graphWithBrokenDeps.graph;
     for (let brokenDep of graphWithBrokenDeps.brokenDeps) {
       visit(graph[brokenDep.importer], brokenDep.validationError);
     }
     function visit(pluginNode, validationError) {
-      logger.debug('ZWED0153I', pluginNode); //logger.debug('visiting broken node ', pluginNode)
+      logger.trace('ZWED0153I', pluginNode); //logger.trace('visiting broken node ', pluginNode)
       if (pluginNode.visited) {
         return;
       } 
@@ -171,7 +171,7 @@ DependencyGraph.prototype = {
       pluginNode.visiting = true;
       for (const dep of pluginNode.deps) {
         const importer = graph[dep.importer];
-        logger.debug("ZWED0154I", JSON.stringify(dep), JSON.stringify(importer)); //logger.debug("following link: ", dep, ": ", importer)
+        logger.trace("ZWED0154I", JSON.stringify(dep), JSON.stringify(importer)); //logger.trace("following link: ", dep, ": ", importer)
         let error;
         if (!dep.valid) {
           error = dep.validationError;
@@ -202,7 +202,7 @@ DependencyGraph.prototype = {
    * 
    */
   _toposort(graph) {
-    logger.debug('ZWED0155I', graph); //logger.debug('graph: ', graph)
+    logger.trace('ZWED0155I', graph); //logger.trace('graph: ', graph)
     const pluginsSorted = [];
     let time = 0;
     for (let importedPlugin of Object.values(graph)) {
@@ -211,7 +211,7 @@ DependencyGraph.prototype = {
     return pluginsSorted;
     
     function visit(pluginNode) {
-      logger.debug('ZWED0156I', pluginNode); //logger.debug('visiting node ', pluginNode)
+      logger.trace('ZWED0156I', pluginNode); //logger.trace('visiting node ', pluginNode)
       if (pluginNode.visited) {
         return;
       } 
@@ -230,7 +230,7 @@ DependencyGraph.prototype = {
       pluginNode.visiting = false;
       pluginNode.visited = true;
       pluginNode.finishingTime = ++time;
-      logger.debug("ZWED0157I", pluginNode.pluginId, pluginNode.discoveryTime, pluginNode.finishingTime); //logger.debug(`${pluginNode.pluginId}: `
+      logger.trace("ZWED0157I", pluginNode.pluginId, pluginNode.discoveryTime, pluginNode.finishingTime); //logger.trace(`${pluginNode.pluginId}: `
           //+ `${pluginNode.discoveryTime}/${pluginNode.finishingTime}`);
       //See the proof at the end of Cormen et al. (2001), 
       // "Section 22.4: Topological sort"
@@ -259,8 +259,8 @@ DependencyGraph.prototype = {
       }
       delete nonRejectedPlugins[node.pluginId];
     }
-    logger.debug("ZWED0158I", pluginsSortedAndFiltered); //logger.debug("*** pluginsSorted: ", pluginsSortedAndFiltered)
-    logger.debug("ZWED0159I", rejects); //logger.debug("*** rejects: ", rejects)
+    logger.trace("ZWED0158I", pluginsSortedAndFiltered); //logger.trace("*** pluginsSorted: ", pluginsSortedAndFiltered)
+    logger.trace("ZWED0159I", rejects); //logger.trace("*** rejects: ", rejects)
     return {
       plugins: pluginsSortedAndFiltered,
       rejects: Object.values(rejects)
@@ -324,7 +324,7 @@ function validateDep(dep, providerPlugin) {
   }
   dep.valid = valid;
   dep.validationError = validationError;
-  logger.debug('ZWED0160I', dep.valid); //logger.debug('dep.valid: ', dep.valid)
+  logger.trace('ZWED0160I', dep.valid); //logger.trace('dep.valid: ', dep.valid)
 }
 
 /*


### PR DESCRIPTION
depgraph debug automatically enables when components.app-server.debug: true
But, it's never been helpful, and spams A LOT.
Let's change this to trace instead of debug so that it shuts up.