### PR TITLE
Upgraded undici and qs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This repo is part of the app-server Zowe Component, and the change logs here may
 ## 3.5.0
 - Bugfix: Fixed error ZWED0149E from occurring when using AT-TLS. This error did not mean something was wrong, so the message is no longer printed in that condition to avoid confusion. ([#633](https://github.com/zowe/zlux-server-framework/pull/633))
 - Bugfix: App-server was not respecting property "components.app-server.zowe.network.client.tls.attls". Instead, property "zowe.network.client.tls.attls" was taking priority, [(#653)](https://github.com/zowe/zlux-server-framework/pull/653)
+- Enhancement: Upgraded old dependencies to new versions: qs and undici. [(#666)](https://github.com/zowe/zlux-server-framework/pull/666)
 
 ## 3.4.0
 - Enhancement: Logging of URLs now accommodates when the app-server or gateway server are instructed to bind to an IPv6 address ([#614](https://github.com/zowe/zlux-server-framework/pull/614))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ This repo is part of the app-server Zowe Component, and the change logs here may
 ## 3.5.0
 - Bugfix: Fixed error ZWED0149E from occurring when using AT-TLS. This error did not mean something was wrong, so the message is no longer printed in that condition to avoid confusion. ([#633](https://github.com/zowe/zlux-server-framework/pull/633))
 - Bugfix: App-server was not respecting property "components.app-server.zowe.network.client.tls.attls". Instead, property "zowe.network.client.tls.attls" was taking priority, [(#653)](https://github.com/zowe/zlux-server-framework/pull/653)
-- Enhancement: Upgraded old dependencies to new versions: qs and undici. [(#666)](https://github.com/zowe/zlux-server-framework/pull/666)
 
 ## 3.4.0
 - Enhancement: Logging of URLs now accommodates when the app-server or gateway server are instructed to bind to an IPv6 address ([#614](https://github.com/zowe/zlux-server-framework/pull/614))

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "normalize-url": "~7.0.0",
         "require-from-string": "~2.0.2",
         "semver": "~7.6.0",
-        "undici": "6.23.0",
+        "undici": "6.24.1",
         "ws": "^6.2.3",
         "yaml": "~2.4.1",
         "yauzl": "~3.1.2"
@@ -510,21 +510,6 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
-      }
-    },
-    "node_modules/body-parser/node_modules/qs": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
-      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "side-channel": "^1.0.6"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/brace-expansion": {
@@ -1213,21 +1198,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/express/node_modules/qs": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
-      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "side-channel": "^1.0.6"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/extend": {
@@ -2216,9 +2186,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -2855,9 +2825,10 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.23.0.tgz",
-      "integrity": "sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==",
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.1.tgz",
+      "integrity": "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==",
+      "license": "MIT",
       "engines": {
         "node": ">=18.17"
       }

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "normalize-url": "~7.0.0",
     "require-from-string": "~2.0.2",
     "semver": "~7.6.0",
-    "undici": "6.23.0",
+    "undici": "6.24.1",
     "ws": "^6.2.3",
     "yaml": "~2.4.1",
     "yauzl": "~3.1.2"
@@ -83,6 +83,7 @@
       "superagent": {
         "form-data": "4.0.4"
       }
-    }
+    },
+    "qs": "6.14.2"
   }
 }


### PR DESCRIPTION
Upgraded the following dependencies: (handling high security risks reported by BluckDuck)

- undici: 6.23.0 -> 6.24.1
- _(override)_ qs: 6.* -> 6.14.2

Testing: manual tests.

I installed an instance of 3.5.0 from [libs-release-local/org/zowe/nightly/v3/zowe-3.5.0-staging-9869-20260327055956.pax](https://zowe.jfrog.io/artifactory/libs-release-local/org/zowe/nightly/v3/zowe-3.5.0-staging-9869-20260327055956.pax) and replaced the `runtime/component/app-server` with the pax created by this PR. The virtual desktop and the default apps worked fine.