### PR TITLE
Fix ivy app2app

### DIFF
--- a/utils/install-app.js
+++ b/utils/install-app.js
@@ -144,20 +144,22 @@ function copyRecognizers(appDir, appId, appVers) {
   let recognizers;
   let recognizersKeys;
   let configRecognizers;
-  let configLocation;
+  let configLocations = [];
+  let desktopPlugins = ['ng2desktop', 'ivydesktop'];
 
   if (process.env.ZWED_instanceDir) {
-    configLocation = path.join(process.env.ZWED_instanceDir, "ZLUX/pluginStorage/org.zowe.zlux.ng2desktop/");
+    configLocations = desktopPlugins.map(plugin => path.join(process.env.ZWED_instanceDir, `ZLUX/pluginStorage/org.zowe.zlux.${plugin}/`));
   } else {
     try {
       let instanceDir = JSON.parse(fs.readFileSync(userInput.zluxConfig)).instanceDir;
-      configLocation = path.join(instanceDir, "/ZLUX/pluginStorage/org.zowe.zlux.ng2desktop/");
+      configLocations = desktopPlugins.map(plugin => path.join(instanceDir, `/ZLUX/pluginStorage/org.zowe.zlux.${plugin}/`));
     } catch (e) {
       logger.severe('ZWED0152E'); //logger.error('Unable to locate server config instance location and INSTANCE_DIR environment variable does not exist.')
     }
   }
 
   try { // Get recognizers in a plugin's appDir/config/xxx location
+    configLocations.forEach((configLocation) => {
     fs.readdirSync(path.join(appDir, "config/recognizers")).forEach(filename => {
       const filepath = path.resolve(path.join(appDir, "config/recognizers"), filename);
       const filepathConfig = path.resolve(path.join(configLocation, "recognizers", filename));
@@ -197,6 +199,7 @@ function copyRecognizers(appDir, appId, appVers) {
         }
       }
     });
+    });
     logger.debug("Found recognizers inside '" + appId + "'");
   } catch (e) {
     logger.debug("Could not find recognizers in '" + (path.join(appDir, "config/recognizers")) + "'");
@@ -206,8 +209,9 @@ function copyRecognizers(appDir, appId, appVers) {
 function copyActions(appDir, appId, appVers) {
   let actions;
   let actionsKeys;
-  let configLocation;
-
+  let configLocations = [];
+  let desktopPlugins = ['ng2desktop', 'ivydesktop'];
+  
   try { // Get actions in a plugin's appDir/config/xxx location
     actions = JSON.parse(fs.readFileSync(path.join(appDir, "config/actions", appId))).actions;
     actionsKeys = Object.keys(actions)
@@ -221,11 +225,11 @@ function copyActions(appDir, appId, appVers) {
   }
 
   if (process.env.ZWED_instanceDir) {
-    configLocation = path.join(process.env.ZWED_instanceDir, "ZLUX/pluginStorage/org.zowe.zlux.ng2desktop/");
+    configLocations = desktopPlugins.map(plugin => path.join(process.env.ZWED_instanceDir, `ZLUX/pluginStorage/org.zowe.zlux.${plugin}/`));
   } else {
     try {
       let instanceDir = JSON.parse(fs.readFileSync(userInput.zluxConfig)).instanceDir;
-      configLocation = path.join(instanceDir, "/ZLUX/pluginStorage/org.zowe.zlux.ng2desktop/");
+      configLocations = desktopPlugins.map(plugin => path.join(instanceDir, `/ZLUX/pluginStorage/org.zowe.zlux.${plugin}/`));
     } catch (e) {
       logger.severe('ZWED0152E'); //logger.error("Unable to locate server config instance location and INSTANCE_DIR environment variable does not exist.")"
     }
@@ -233,8 +237,10 @@ function copyActions(appDir, appId, appVers) {
 
   if (actions) { // Attempt to copy actions over to config location for Desktop access later
     try { //TODO: Doing actions.actions is redundant. We may want to consider refactoring in the future
-      fs.writeFileSync(path.join(configLocation, "actions", appId), '{ "actions":' + JSON.stringify(actions) + '}');
-      logger.info('ZWED0295I', actions.length, appId); //logger.info("Successfully loaded " + actions.length + " actions for '" + appId + "' into config");
+      configLocations.forEach((configLocation) => {
+        fs.writeFileSync(path.join(configLocation, "actions", appId), '{ "actions":' + JSON.stringify(actions) + '}');
+        logger.info('ZWED0295I', actions.length, appId); //logger.info("Successfully loaded " + actions.length + " actions for '" + appId + "' into config");
+      });
     } catch (e) {
       logger.warn('ZWED0177W', 'actions', appId);
     }


### PR DESCRIPTION
Files such as pinnedPlugins.json and extension app2app recognizers/actions were only being copied to the ng2desktop workspace folder but not the ivydesktop one.
At this time, there really isnt a difference between assets of the two, so the simplest way to resolve this is to just copy such assets into both places.

This is one of 3 PRs that should go together. Needs:
https://github.com/zowe/zlux-app-server/pull/359
https://github.com/zowe/zlux-build/pull/159