### PR TITLE
Upgraded node-forge and path-to-regexp

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "express-static-gzip": "~2.1.7",
         "graceful-fs": "~4.2.11",
         "ipaddr.js": "~2.1.0",
-        "node-forge": "1.3.3",
+        "node-forge": "1.4.0",
         "normalize-url": "~7.0.0",
         "require-from-string": "~2.0.2",
         "semver": "~7.6.0",
@@ -1978,9 +1978,10 @@
       }
     },
     "node_modules/node-forge": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.3.tgz",
-      "integrity": "sha512-rLvcdSyRCyouf6jcOIPe/BgwG/d7hKjzMKOas33/pHEr6gbq18IK9zV7DiPvzsz0oBJPme6qr6H6kGZuI9/DZg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
+      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
+      "license": "(BSD-3-Clause OR GPL-2.0)",
       "engines": {
         "node": ">= 6.13.0"
       }
@@ -2128,9 +2129,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
-      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
       "license": "MIT"
     },
     "node_modules/pathval": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "express-static-gzip": "~2.1.7",
     "graceful-fs": "~4.2.11",
     "ipaddr.js": "~2.1.0",
-    "node-forge": "1.3.3",
+    "node-forge": "1.4.0",
     "normalize-url": "~7.0.0",
     "require-from-string": "~2.0.2",
     "semver": "~7.6.0",
@@ -83,6 +83,9 @@
       "superagent": {
         "form-data": "4.0.4"
       }
+    },
+    "express": {
+        "path-to-regexp": "0.1.13"
     },
     "qs": "6.14.2"
   }


### PR DESCRIPTION
Shortly after my recent PR that upgraded undici and qs, BlackDuck reported two other "high" security issues related to node-forge and path-to-regex. Since the required upgrading distance is not big, I would like to create a second PR to upgrade them instead of asking for exemption.

Upgrades:
- node-forge (direct)
  - Version: 1.3.3 --> 1.4.0
  - Issue: CVE-2026-33891 (BDSA-2026-5637) and other 3 "high" security issues
- path-to-regex (transitive by express@4.21.2)
  - Version: 0.1.12 --> 0.1.13
  - Issue: CVE-2026-4867 (BDSA-2026-5650) and CVE-2026-33896 (BDSA-2026-5630)

Tests: manually tested the zlux desktop with [the pax created by this PR](https://zowe.jfrog.io/artifactory/libs-snapshot-local/org/zowe/zlux/zlux-core/3.5.0-zlux-server-framework-PR-668/zlux-core-3.5.0-20260330.083137.pax). It worked fine.