### PR TITLE
Update ssh.js use of dh

### DIFF
--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -154,7 +154,7 @@ jobs:
           node-version: 18
 
       - name: '[Prep 3] Setup jFrog CLI'
-        uses: jfrog/setup-jfrog-cli@v2
+        uses: jfrog/setup-jfrog-cli@v5
         env:
           JF_ARTIFACTORY_1: ${{ secrets.JF_ARTIFACTORY_TOKEN }}
 

--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -154,7 +154,7 @@ jobs:
           node-version: 18
 
       - name: '[Prep 3] Setup jFrog CLI'
-        uses: jfrog/setup-jfrog-cli@v5
+        uses: jfrog/setup-jfrog-cli@v2
         env:
           JF_ARTIFACTORY_1: ${{ secrets.JF_ARTIFACTORY_TOKEN }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to the Zlux Server Framework package will be documented in t
 This repo is part of the app-server Zowe Component, and the change logs here may appear on Zowe.org in that section.
 
 ## 3.5.0
+- Enhancement: Improved SSH connection performance restoring use of Node.js built-in diffie-hellman logic. [()]() 
 - Bugfix: Fixed error ZWED0149E from occurring when using AT-TLS. This error did not mean something was wrong, so the message is no longer printed in that condition to avoid confusion. ([#633](https://github.com/zowe/zlux-server-framework/pull/633))
 - Bugfix: App-server was not respecting property "components.app-server.zowe.network.client.tls.attls". Instead, property "zowe.network.client.tls.attls" was taking priority, [(#653)](https://github.com/zowe/zlux-server-framework/pull/653)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the Zlux Server Framework package will be documented in t
 This repo is part of the app-server Zowe Component, and the change logs here may appear on Zowe.org in that section.
 
 ## 3.5.0
-- Enhancement: Improved SSH connection performance restoring use of Node.js built-in diffie-hellman logic. [()]() 
+- Enhancement: Improved SSH connection performance restoring use of Node.js built-in diffie-hellman logic. [(#669)](https://github.com/zowe/zlux-server-framework/pull/669) 
 - Bugfix: Fixed error ZWED0149E from occurring when using AT-TLS. This error did not mean something was wrong, so the message is no longer printed in that condition to avoid confusion. ([#633](https://github.com/zowe/zlux-server-framework/pull/633))
 - Bugfix: App-server was not respecting property "components.app-server.zowe.network.client.tls.attls". Instead, property "zowe.network.client.tls.attls" was taking priority, [(#653)](https://github.com/zowe/zlux-server-framework/pull/653)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "bluebird": "3.7.2",
         "body-parser": "~1.20.3",
         "cookie-parser": "~1.4.6",
-        "diffie-hellman": "^5.0.3",
         "express": "^4.21.2",
         "express-session": "~1.18.0",
         "express-static-gzip": "~2.1.7",
@@ -483,11 +482,6 @@
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
       "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
     },
-    "node_modules/bn.js": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
-    },
     "node_modules/body-parser": {
       "version": "1.20.3",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
@@ -521,11 +515,6 @@
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
-    },
-    "node_modules/brorand": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-      "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w=="
     },
     "node_modules/browser-stdout": {
       "version": "1.3.1",
@@ -957,16 +946,6 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
-      }
-    },
-    "node_modules/diffie-hellman": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
-      "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
-      "dependencies": {
-        "bn.js": "^4.1.0",
-        "miller-rabin": "^4.0.0",
-        "randombytes": "^2.0.0"
       }
     },
     "node_modules/dunder-proto": {
@@ -1821,18 +1800,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/miller-rabin": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
-      "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
-      "dependencies": {
-        "bn.js": "^4.0.0",
-        "brorand": "^1.0.1"
-      },
-      "bin": {
-        "miller-rabin": "bin/miller-rabin"
-      }
-    },
     "node_modules/mime": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
@@ -2212,6 +2179,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
       "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dev": true,
       "dependencies": {
         "safe-buffer": "^5.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "bluebird": "3.7.2",
     "body-parser": "~1.20.3",
     "cookie-parser": "~1.4.6",
-    "diffie-hellman": "^5.0.3",
     "express": "^4.21.2",
     "express-session": "~1.18.0",
     "express-static-gzip": "~2.1.7",

--- a/plugins/terminal-proxy/lib/ssh.js
+++ b/plugins/terminal-proxy/lib/ssh.js
@@ -11,11 +11,6 @@
 */
 
 const crypto = require("crypto");
-const nodeMajorIndex = process.versions.node.indexOf('.');
-const nodeVersion = Number(process.versions.node.substr(0,nodeMajorIndex));
-if (nodeVersion >= 12) {
-  var swcrypto = require("diffie-hellman/browser");
-}
 
 var clientVersion = 'SSH-2.0-UNP_1.1';
 var traceCrypto = false;
@@ -784,10 +779,8 @@ ssh.processEncryptedData = function (terminalWebsocketProxy,rawData){
           sessionData.prime =  sshv2PDU.readSizedData();
           sessionData.generator = sshv2PDU.readSizedData();     
           sshLogger.debug('sessionData.generator');
-          var dh = nodeVersion >= 12
-              ? swcrypto.createDiffieHellman(sessionData.prime,sessionData.generator)
-              : crypto.createDiffieHellman(sessionData.prime,sessionData.generator);
-               sshLogger.debug('made dh');
+          var dh = crypto.createDiffieHellman(sessionData.prime,sessionData.generator);
+          sshLogger.debug('made dh');
           sessionData.expectedReplyMsgCode = SSH_MESSAGE.SSH_MSG_KEX_DH_GEX_REPLY;
           var msgCodeBuffer = Buffer.alloc(1);
           msgCodeBuffer.writeUInt8(SSH_MESSAGE.SSH_MSG_KEX_DH_GEX_INIT);


### PR DESCRIPTION
Years ago we switched to a software implementation of diffie-hellman for the ssh login as opposed to the one built-in to nodejs. At this time, this improved performance for I think nodejs 14 or so. But newer node has improved performance again, and returning to its built-in crypto is superior for many reasons.

I have tested that this achieves the same goal of allowing you to login to the vt terminal app.