### PR TITLE
Add dual cert support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to the Zlux Server Framework package will be documented in t
 This repo is part of the app-server Zowe Component, and the change logs here may appear on Zowe.org in that section.
 
 ## 3.5.0
-- Enhancement: Improved SSH connection performance restoring use of Node.js built-in diffie-hellman logic. [(#669)](https://github.com/zowe/zlux-server-framework/pull/669) 
+- Enhancement: The app-server can now use separate certificates for inbound server TLS and outbound client TLS connections. When `zowe.certificate.keystore.clientCertificateAlias` (keyring) or both `zowe.certificate.pem.clientCertificate` and `zowe.certificate.pem.clientKey` (PEM) are defined, those are used for all outbound client connections while the main certificate is used only for serving HTTPS. When not defined, behavior is unchanged. [(#674)](https://github.com/zowe/zlux-server-framework/pull/674)
+- Enhancement: Improved TLS options: `getTlsOptions()` now returns client TLS options by default, while `getServerTlsOptions()` explicitly returns server TLS options. [(#674)](https://github.com/zowe/zlux-server-framework/pull/674) [(#669)](https://github.com/zowe/zlux-server-framework/pull/669) 
 - Bugfix: Fixed error ZWED0149E from occurring when using AT-TLS. This error did not mean something was wrong, so the message is no longer printed in that condition to avoid confusion. ([#633](https://github.com/zowe/zlux-server-framework/pull/633))
 - Bugfix: App-server was not respecting property "components.app-server.zowe.network.client.tls.attls". Instead, property "zowe.network.client.tls.attls" was taking priority, [(#653)](https://github.com/zowe/zlux-server-framework/pull/653)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to the Zlux Server Framework package will be documented in t
 This repo is part of the app-server Zowe Component, and the change logs here may appear on Zowe.org in that section.
 
 ## 3.5.0
+- Enhancement: Improved SSH connection performance restoring use of Node.js built-in diffie-hellman logic. [(#669)](https://github.com/zowe/zlux-server-framework/pull/669) 
 - Enhancement: The app-server can now use separate certificates for inbound server TLS and outbound client TLS connections. When `zowe.certificate.keystore.clientCertificateAlias` (keyring) or both `zowe.certificate.pem.clientCertificate` and `zowe.certificate.pem.clientKey` (PEM) are defined, those are used for all outbound client connections while the main certificate is used only for serving HTTPS. When not defined, behavior is unchanged. [(#674)](https://github.com/zowe/zlux-server-framework/pull/674)
 - Enhancement: Improved TLS options: `getTlsOptions()` now returns client TLS options by default, while `getServerTlsOptions()` explicitly returns server TLS options. [(#674)](https://github.com/zowe/zlux-server-framework/pull/674) [(#669)](https://github.com/zowe/zlux-server-framework/pull/669) 
 - Bugfix: Fixed error ZWED0149E from occurring when using AT-TLS. This error did not mean something was wrong, so the message is no longer printed in that condition to avoid confusion. ([#633](https://github.com/zowe/zlux-server-framework/pull/633))

--- a/lib/assets/i18n/log/messages_en.json
+++ b/lib/assets/i18n/log/messages_en.json
@@ -188,6 +188,8 @@
   "ZWED0301I": "Found %s in config for '%s'",
   "ZWED0302I": "HA mode is %s",
   "ZWED0303I": "Plugin %s will not be loaded because no dataservices requested it",
+  "ZWED0304I": "Using client certificate: %s",
+  "ZWED0305I": "Using separate certificates for server TLS and client TLS connections",
 
   "ZWED0003W":"User=%s (%s): Session %s failed. Plugin response: %s",
   "ZWED0004W":"Tomcat for ID=%s not starting, no services succeeded loading",

--- a/lib/webapp.js
+++ b/lib/webapp.js
@@ -84,7 +84,7 @@ function DataserviceContext(serviceDefinition, serviceConfiguration,
   this.plugin = pluginContext;
   this.storage = pluginStorage.PluginStorageFactory(this.plugin.pluginDef.identifier, utilLog);
   this.logger = createDataserviceLogger(pluginContext, serviceDefinition);
-  this.tlsOptions = Object.assign({},webapp.options.tlsOptions);
+  this.tlsOptions = Object.assign({},webapp.options.clientTlsOptions || webapp.options.tlsOptions);
   this.wsRouterPatcher = webapp.expressWs.applyTo;
 }
 
@@ -563,7 +563,7 @@ const staticHandlers = {
         addProxyAuthorizations: options.auth.addProxyAuthorizations,
         allowInvalidTLSProxy: options.componentConfig.node.allowInvalidTLSProxy
       };
-      proxyOptions = Object.assign(proxyOptions, getAgentProxyOptions(options.zoweConfig, options.tlsOptions, true));
+      proxyOptions = Object.assign(proxyOptions, getAgentProxyOptions(options.zoweConfig, options.clientTlsOptions || options.tlsOptions, true));
       proxyOptions.urlPrefix = proxyOptions.urlPrefix ?  proxyOptions.urlPrefix + '/server' : '/server';
 
       router.get('/agent*', proxy.makeSimpleProxy(options.proxiedHost, options.proxiedPort,
@@ -1405,7 +1405,7 @@ function WebApp(options){
   this.setValidReferrers();
   this.wsEnvironment = {
     loopbackConfig: this.loopbackConfig,
-    agentRequestOptions: zluxUtil.getAgentRequestOptions(options.zoweConfig, options.tlsOptions, false),
+    agentRequestOptions: zluxUtil.getAgentRequestOptions(options.zoweConfig, options.clientTlsOptions || options.tlsOptions, false),
     isClientAttls: zluxUtil.isClientAttls(options.zoweConfig)
   }
   this.auth = options.auth;
@@ -1492,7 +1492,8 @@ WebApp.prototype = {
   
   makeProxy(urlPrefix, noAuth, overrideOptions, host, port) {
     const r = express.Router();
-    let tlsOptions = Object.assign({}, this.options.tlsOptions);
+    const effectiveTlsOptions = this.options.clientTlsOptions || this.options.tlsOptions;
+    let tlsOptions = Object.assign({}, effectiveTlsOptions);
     delete tlsOptions.key;
     delete tlsOptions.cert;
     let options = {
@@ -1505,7 +1506,7 @@ WebApp.prototype = {
     };
     if (!(host && port)) {
       //destined for agent rather than 3rd party server
-      const requestOptions = zluxUtil.getAgentRequestOptions(this.options.zoweConfig, this.options.tlsOptions, false, urlPrefix);
+      const requestOptions = zluxUtil.getAgentRequestOptions(this.options.zoweConfig, effectiveTlsOptions, false, urlPrefix);
       host = requestOptions.host;
       port = requestOptions.port;
       options.urlPrefix = requestOptions.path;
@@ -1525,7 +1526,7 @@ WebApp.prototype = {
   
   makeExternalProxy(host, port, urlPrefix, isHttps, noAuth, pluginID, serviceName) {
     const r = express.Router();
-    let tlsOptions = Object.assign({}, this.options.tlsOptions);
+    let tlsOptions = Object.assign({}, this.options.clientTlsOptions || this.options.tlsOptions);
     delete tlsOptions.key;
     delete tlsOptions.cert;
     isHttps = !zluxUtil.isClientAttls(this.options.zoweConfig) && isHttps;
@@ -1652,17 +1653,17 @@ WebApp.prototype = {
       }
       if (proxiedRootService.requiresAuth === false) {
         const _router = this.makeProxy(proxiedRootService.url, true,
-                                       getAgentProxyOptions(this.options.zoweConfig, this.options.tlsOptions, false));
+                                       getAgentProxyOptions(this.options.zoweConfig, this.options.clientTlsOptions || this.options.tlsOptions, false));
         middlewareArray.push(_router);
         this.expressApp.use(proxiedRootService.url, middlewareArray);
       } else {
         const _router = this.makeProxy(proxiedRootService.url, false,
-                                       getAgentProxyOptions(this.options.zoweConfig, this.options.tlsOptions, false));
+                                       getAgentProxyOptions(this.options.zoweConfig, this.options.clientTlsOptions || this.options.tlsOptions, false));
         middlewareArray.push(_router);
         this.expressApp.use(proxiedRootService.url, rootServicesMiddleware, this.auth.middleware, middlewareArray);
       }
       serviceHandleMap[name] = new WebServiceHandle(proxiedRootService.url, 
-                                                    this.wsEnvironment, true, undefined, this.options.tlsOptions);
+                                                    this.wsEnvironment, true, undefined, this.options.clientTlsOptions || this.options.tlsOptions);
     }
     this.expressApp.use(rootServicesMiddleware);
     
@@ -1678,24 +1679,25 @@ WebApp.prototype = {
         {needJson: true, needAuth: false, isPseudoSso: true});
     this._installRootService('/auth-logout', 'get', this.auth.doLogout, 
         {needJson: true, needAuth: false, isPseudoSso: true});
-    serviceHandleMap['auth'] = new WebServiceHandle('/auth', this.wsEnvironment, false, undefined, this.options.tlsOptions);
+    const _clientTlsOptions = this.options.clientTlsOptions || this.options.tlsOptions;
+    serviceHandleMap['auth'] = new WebServiceHandle('/auth', this.wsEnvironment, false, undefined, _clientTlsOptions);
     this._installRootService('/plugins', 'get', staticHandlers.plugins(this), 
         {needJson: false, needAuth: true, authType: "semi", isPseudoSso: false}); 
     this._installRootService('/plugins', 'use', staticHandlers.pluginLifecycle(pluginsArray, this.options.componentConfig.dataserviceAuthentication.rbac, this.options.componentConfig.pluginsDir),
       {needJson: true, needAuth: true, isPseudoSso: false});
-    serviceHandleMap['plugins'] = new WebServiceHandle('/plugins', this.wsEnvironment, false, undefined, this.options.tlsOptions);
+    serviceHandleMap['plugins'] = new WebServiceHandle('/plugins', this.wsEnvironment, false, undefined, _clientTlsOptions);
     this._installRootService('/server/proxies','get',staticHandlers.getServerProxies(this.options),
         {needJson: false, needAuth: false, isPseudoSso: false});
     this._installRootService('/server', 'use', staticHandlers.server(this.options), 
         {needJson: false, needAuth: true, isPseudoSso: false});
-    serviceHandleMap['server'] = new WebServiceHandle('/server', this.wsEnvironment, false, undefined, this.options.tlsOptions);
+    serviceHandleMap['server'] = new WebServiceHandle('/server', this.wsEnvironment, false, undefined, _clientTlsOptions);
     this._installRootService('/echo/*', 'get', staticHandlers.echo(),
         {needJson: false, needAuth: true, isPseudoSso: false});
-    serviceHandleMap['echo'] = new WebServiceHandle('/echo', this.wsEnvironment, false, undefined, this.options.tlsOptions);
+    serviceHandleMap['echo'] = new WebServiceHandle('/echo', this.wsEnvironment, false, undefined, _clientTlsOptions);
     this._installRootService('/apiManagement', 'use', staticHandlers.apiManagement(this),
         {needJson: false, needAuth: true, isPseudoSso: false});
     serviceHandleMap['apiManagement'] = new WebServiceHandle('/apiManagement', 
-        this.wsEnvironment, false, undefined, this.options.tlsOptions);
+        this.wsEnvironment, false, undefined, _clientTlsOptions);
     this.expressApp.use(staticHandlers.eureka());
     this.expressApp.use(staticHandlers.swagger(this.options.componentConfig.node.productCode));
   },
@@ -1815,7 +1817,7 @@ WebApp.prototype = {
     switch (service.type) {
     case "service":
       //installLog.info(`${plugin.identifier}: installing proxy at ${subUrl}`);
-      let agentProxyOptions = getAgentProxyOptions(this.options.zoweConfig, this.options.tlsOptions, false);
+      let agentProxyOptions = getAgentProxyOptions(this.options.zoweConfig, this.options.clientTlsOptions || this.options.tlsOptions, false);
       if (!agentProxyOptions) {
         throw new Error(`Cannot install service-type service because agent connection details not found`);
       }
@@ -1896,7 +1898,7 @@ WebApp.prototype = {
       for (const version of Object.keys(group.versions)) {
         const service = group.versions[version];
         const subUrl = urlBase + zLuxUrl.makeServiceSubURL(service);
-        const handle = new WebServiceHandle(subUrl, this.wsEnvironment, false, service, this.options.tlsOptions);
+        const handle = new WebServiceHandle(subUrl, this.wsEnvironment, false, service, this.options.clientTlsOptions || this.options.tlsOptions);
         versionHandles[version] = handle;
         if (version === group.highestVersion) {
           const defaultSubUrl = urlBase + zLuxUrl.makeServiceSubURL(service, true);

--- a/lib/webapp.js
+++ b/lib/webapp.js
@@ -84,7 +84,7 @@ function DataserviceContext(serviceDefinition, serviceConfiguration,
   this.plugin = pluginContext;
   this.storage = pluginStorage.PluginStorageFactory(this.plugin.pluginDef.identifier, utilLog);
   this.logger = createDataserviceLogger(pluginContext, serviceDefinition);
-  this.tlsOptions = Object.assign({},webapp.options.clientTlsOptions || webapp.options.tlsOptions);
+  this.tlsOptions = Object.assign({},webapp.options.clientTlsOptions);
   this.wsRouterPatcher = webapp.expressWs.applyTo;
 }
 
@@ -1492,8 +1492,7 @@ WebApp.prototype = {
   
   makeProxy(urlPrefix, noAuth, overrideOptions, host, port) {
     const r = express.Router();
-    const effectiveTlsOptions = this.options.clientTlsOptions || this.options.tlsOptions;
-    let tlsOptions = Object.assign({}, effectiveTlsOptions);
+    let tlsOptions = Object.assign({}, this.options.clientTlsOptions);
     delete tlsOptions.key;
     delete tlsOptions.cert;
     let options = {
@@ -1506,7 +1505,7 @@ WebApp.prototype = {
     };
     if (!(host && port)) {
       //destined for agent rather than 3rd party server
-      const requestOptions = zluxUtil.getAgentRequestOptions(this.options.zoweConfig, effectiveTlsOptions, false, urlPrefix);
+      const requestOptions = zluxUtil.getAgentRequestOptions(this.options.zoweConfig, this.options.clientTlsOptions, false, urlPrefix);
       host = requestOptions.host;
       port = requestOptions.port;
       options.urlPrefix = requestOptions.path;
@@ -1526,7 +1525,7 @@ WebApp.prototype = {
   
   makeExternalProxy(host, port, urlPrefix, isHttps, noAuth, pluginID, serviceName) {
     const r = express.Router();
-    let tlsOptions = Object.assign({}, this.options.clientTlsOptions || this.options.tlsOptions);
+    let tlsOptions = Object.assign({}, this.options.clientTlsOptions);
     delete tlsOptions.key;
     delete tlsOptions.cert;
     isHttps = !zluxUtil.isClientAttls(this.options.zoweConfig) && isHttps;
@@ -1653,17 +1652,17 @@ WebApp.prototype = {
       }
       if (proxiedRootService.requiresAuth === false) {
         const _router = this.makeProxy(proxiedRootService.url, true,
-                                       getAgentProxyOptions(this.options.zoweConfig, this.options.clientTlsOptions || this.options.tlsOptions, false));
+                                       getAgentProxyOptions(this.options.zoweConfig, this.options.clientTlsOptions, false));
         middlewareArray.push(_router);
         this.expressApp.use(proxiedRootService.url, middlewareArray);
       } else {
         const _router = this.makeProxy(proxiedRootService.url, false,
-                                       getAgentProxyOptions(this.options.zoweConfig, this.options.clientTlsOptions || this.options.tlsOptions, false));
+                                       getAgentProxyOptions(this.options.zoweConfig, this.options.clientTlsOptions, false));
         middlewareArray.push(_router);
         this.expressApp.use(proxiedRootService.url, rootServicesMiddleware, this.auth.middleware, middlewareArray);
       }
       serviceHandleMap[name] = new WebServiceHandle(proxiedRootService.url, 
-                                                    this.wsEnvironment, true, undefined, this.options.clientTlsOptions || this.options.tlsOptions);
+                                                    this.wsEnvironment, true, undefined, this.options.clientTlsOptions);
     }
     this.expressApp.use(rootServicesMiddleware);
     
@@ -1679,25 +1678,24 @@ WebApp.prototype = {
         {needJson: true, needAuth: false, isPseudoSso: true});
     this._installRootService('/auth-logout', 'get', this.auth.doLogout, 
         {needJson: true, needAuth: false, isPseudoSso: true});
-    const _clientTlsOptions = this.options.clientTlsOptions || this.options.tlsOptions;
-    serviceHandleMap['auth'] = new WebServiceHandle('/auth', this.wsEnvironment, false, undefined, _clientTlsOptions);
+    serviceHandleMap['auth'] = new WebServiceHandle('/auth', this.wsEnvironment, false, undefined, this.options.clientTlsOptions);
     this._installRootService('/plugins', 'get', staticHandlers.plugins(this), 
         {needJson: false, needAuth: true, authType: "semi", isPseudoSso: false}); 
     this._installRootService('/plugins', 'use', staticHandlers.pluginLifecycle(pluginsArray, this.options.componentConfig.dataserviceAuthentication.rbac, this.options.componentConfig.pluginsDir),
       {needJson: true, needAuth: true, isPseudoSso: false});
-    serviceHandleMap['plugins'] = new WebServiceHandle('/plugins', this.wsEnvironment, false, undefined, _clientTlsOptions);
+    serviceHandleMap['plugins'] = new WebServiceHandle('/plugins', this.wsEnvironment, false, undefined, this.options.clientTlsOptions);
     this._installRootService('/server/proxies','get',staticHandlers.getServerProxies(this.options),
         {needJson: false, needAuth: false, isPseudoSso: false});
     this._installRootService('/server', 'use', staticHandlers.server(this.options), 
         {needJson: false, needAuth: true, isPseudoSso: false});
-    serviceHandleMap['server'] = new WebServiceHandle('/server', this.wsEnvironment, false, undefined, _clientTlsOptions);
+    serviceHandleMap['server'] = new WebServiceHandle('/server', this.wsEnvironment, false, undefined, this.options.clientTlsOptions);
     this._installRootService('/echo/*', 'get', staticHandlers.echo(),
         {needJson: false, needAuth: true, isPseudoSso: false});
-    serviceHandleMap['echo'] = new WebServiceHandle('/echo', this.wsEnvironment, false, undefined, _clientTlsOptions);
+    serviceHandleMap['echo'] = new WebServiceHandle('/echo', this.wsEnvironment, false, undefined, this.options.clientTlsOptions);
     this._installRootService('/apiManagement', 'use', staticHandlers.apiManagement(this),
         {needJson: false, needAuth: true, isPseudoSso: false});
     serviceHandleMap['apiManagement'] = new WebServiceHandle('/apiManagement', 
-        this.wsEnvironment, false, undefined, _clientTlsOptions);
+        this.wsEnvironment, false, undefined, this.options.clientTlsOptions);
     this.expressApp.use(staticHandlers.eureka());
     this.expressApp.use(staticHandlers.swagger(this.options.componentConfig.node.productCode));
   },
@@ -1817,7 +1815,7 @@ WebApp.prototype = {
     switch (service.type) {
     case "service":
       //installLog.info(`${plugin.identifier}: installing proxy at ${subUrl}`);
-      let agentProxyOptions = getAgentProxyOptions(this.options.zoweConfig, this.options.clientTlsOptions || this.options.tlsOptions, false);
+      let agentProxyOptions = getAgentProxyOptions(this.options.zoweConfig, this.options.clientTlsOptions, false);
       if (!agentProxyOptions) {
         throw new Error(`Cannot install service-type service because agent connection details not found`);
       }
@@ -1898,7 +1896,7 @@ WebApp.prototype = {
       for (const version of Object.keys(group.versions)) {
         const service = group.versions[version];
         const subUrl = urlBase + zLuxUrl.makeServiceSubURL(service);
-        const handle = new WebServiceHandle(subUrl, this.wsEnvironment, false, service, this.options.clientTlsOptions || this.options.tlsOptions);
+        const handle = new WebServiceHandle(subUrl, this.wsEnvironment, false, service, this.options.clientTlsOptions);
         versionHandles[version] = handle;
         if (version === group.highestVersion) {
           const defaultSubUrl = urlBase + zLuxUrl.makeServiceSubURL(service, true);

--- a/lib/webapp.js
+++ b/lib/webapp.js
@@ -563,7 +563,7 @@ const staticHandlers = {
         addProxyAuthorizations: options.auth.addProxyAuthorizations,
         allowInvalidTLSProxy: options.componentConfig.node.allowInvalidTLSProxy
       };
-      proxyOptions = Object.assign(proxyOptions, getAgentProxyOptions(options.zoweConfig, options.clientTlsOptions || options.tlsOptions, true));
+      proxyOptions = Object.assign(proxyOptions, getAgentProxyOptions(options.zoweConfig, options.clientTlsOptions, true));
       proxyOptions.urlPrefix = proxyOptions.urlPrefix ?  proxyOptions.urlPrefix + '/server' : '/server';
 
       router.get('/agent*', proxy.makeSimpleProxy(options.proxiedHost, options.proxiedPort,
@@ -1405,7 +1405,7 @@ function WebApp(options){
   this.setValidReferrers();
   this.wsEnvironment = {
     loopbackConfig: this.loopbackConfig,
-    agentRequestOptions: zluxUtil.getAgentRequestOptions(options.zoweConfig, options.clientTlsOptions || options.tlsOptions, false),
+    agentRequestOptions: zluxUtil.getAgentRequestOptions(options.zoweConfig, options.clientTlsOptions, false),
     isClientAttls: zluxUtil.isClientAttls(options.zoweConfig)
   }
   this.auth = options.auth;

--- a/lib/webserver.js
+++ b/lib/webserver.js
@@ -216,6 +216,15 @@ function readTlsOptionsFromConfig(nodeConfig, httpsOptions, pass) {
       httpsOptions.key = loadPem(nodeConfig.https.keys, CRYPTO_CONTENT_KEY, keyrings, pass).content;
     }
   }
+  // Load optional client-specific certificates. When present, these will be used for
+  // outbound client TLS connections instead of the server certificates above.
+  if (nodeConfig.https.clientCertificates) {
+    httpsOptions.clientCert = loadPem(nodeConfig.https.clientCertificates, CRYPTO_CONTENT_CERT, keyrings, pass).content;
+    bootstrapLogger.info('ZWED0304I', nodeConfig.https.clientCertificates);
+  }
+  if (nodeConfig.https.clientKeys) {
+    httpsOptions.clientKey = loadPem(nodeConfig.https.clientKeys, CRYPTO_CONTENT_KEY, keyrings, pass).content;
+  }
   if (nodeConfig.https.certificateAuthorities) {
     httpsOptions.ca = loadPem(nodeConfig.https.certificateAuthorities, CRYPTO_CONTENT_CA, keyrings, pass).content;
   }
@@ -232,6 +241,11 @@ WebServer.prototype = {
   config: null,
   httpOptions: null,
   httpsOptions: null,
+  // serverTlsOptions contains the server certificate used for inbound TLS connections.
+  // clientTlsOptions contains the certificate used for outbound client TLS connections.
+  // When no separate client certificate is configured, both point to the same options object.
+  serverTlsOptions: null,
+  clientTlsOptions: null,
   httpsServers: [],
   httpServers: [],
   expressWsHttps: [],
@@ -263,8 +277,17 @@ WebServer.prototype = {
 
   },
   
+  // Returns the TLS options for outbound client connections. This is the default
+  // TLS options object and should be used in most situations, such as connecting
+  // to an agent, APIML, or other service.
   getTlsOptions() {
-    return this.httpsOptions;
+    return this.clientTlsOptions;
+  },
+
+  // Returns the TLS options for the inbound HTTPS server. Use this only when
+  // creating or configuring the HTTPS server itself.
+  getServerTlsOptions() {
+    return this.serverTlsOptions;
   },
 
   validateAndPreprocessConfig: Promise.coroutine(function *validateAndPreprocessConfig(zoweConfig) {
@@ -402,6 +425,29 @@ WebServer.prototype = {
       if (util.isServerHttps(zoweConfig) || !(util.isClientAttls(zoweConfig))) {
         readTlsOptionsFromConfig(nodeConfig, this.httpsOptions, zoweConfig.zowe?.certificate?.keystore?.password);
       }
+
+      // Split into server and client TLS options when distinct client certificates are configured.
+      // clientCert and clientKey are temporary properties used only during this split.
+      this.serverTlsOptions = this.httpsOptions;
+      if (this.httpsOptions.clientCert && this.httpsOptions.clientKey) {
+        this.clientTlsOptions = Object.assign({}, this.httpsOptions);
+        this.clientTlsOptions.cert = this.clientTlsOptions.clientCert;
+        this.clientTlsOptions.key = this.clientTlsOptions.clientKey;
+        delete this.clientTlsOptions.clientCert;
+        delete this.clientTlsOptions.clientKey;
+        delete this.serverTlsOptions.clientCert;
+        delete this.serverTlsOptions.clientKey;
+        bootstrapLogger.info('ZWED0305I');
+      } else {
+        // No separate client certificate; server certificate is used for both purposes.
+        delete this.httpsOptions.clientCert;
+        delete this.httpsOptions.clientKey;
+        this.clientTlsOptions = this.serverTlsOptions;
+      }
+      // Alias httpsOptions to clientTlsOptions for backward compatibility. Any pre-existing code
+      // that reads this.httpsOptions for non-server use (e.g., outbound connections, plugins) will
+      // naturally receive the client certificate, which is the correct default behavior.
+      this.httpsOptions = this.clientTlsOptions;
     }
   },  
 
@@ -411,7 +457,7 @@ WebServer.prototype = {
       for (let ipAddress of this.config.https.ipAddresses) {
         let listening = false;
         let httpsServer;
-        const httpsOptions = this.getTlsOptions();
+        const httpsOptions = this.getServerTlsOptions();
         while (!listening) {
           try {
             httpsServer = https.createServer(httpsOptions, webapp.expressApp);


### PR DESCRIPTION
<!-- Thank you for submitting a PR to Zowe! To help us understand, test, and give feedback on your code, please fill in the details below. -->

## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

This PR implements support for separate server and client TLS certificates in the zlux-server-framework. Previously, a single certificate from `zowe.certificate` was used for both inbound HTTPS connections and all outbound client connections (to ZSS/agent, APIML, auth plugins, etc.). This required the certificate to have an EKU permitting both server and client uses.

The changes allow deployments to specify:
- For keyrings: `zowe.certificate.keystore.clientCertificateAlias` to load a separate client certificate
- For PEM files: `zowe.certificate.pem.clientCertificate` and `zowe.certificate.pem.clientKey` to specify separate client files

When these optional properties are absent, behavior is identical to before (backward compatible). When present, the client certificate is used for all outbound connections while the server certificate is reserved for inbound HTTPS only.

Key design decision: `getTlsOptions()` returns **client TLS options by default**, ensuring that all plugins, dataservices, and internal code using TLS for outbound connections naturally receive the correct certificate without changes. `getServerTlsOptions()` is explicitly available for the rare case where inbound server TLS is needed.

This PR depends upon the following PRs:
- zlux-app-server: https://github.com/zowe/zlux-app-server/pull/365

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## PR Checklist
- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zlux/blob/master/CONTRIBUTING.md))
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
- [ ] video or image is included if visual changes are made
- [x] Relevant update to CHANGELOG.md
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works, or describe a test method below

## Testing

**Configuration loading:**
- Verify that when `clientCertificates` and `clientKeys` are configured in `node.https`, the server logs `ZWED0304I` ("Using client certificate: %s") and `ZWED0305I` ("Using separate certificates for server TLS and client TLS connections").
- Verify that when these properties are absent, neither message is logged and the single certificate path is used.

**Outbound connections (client uses):**
- Create a TLS client that expects a specific certificate subject.
- Configure the app-server with a server certificate that does **not** match the client expectation, and a client certificate that does.
- Verify that connections from the app-server (or any code using `getTlsOptions()`) succeed, proving they use the client certificate.
- Verify that the HTTPS server still presents the server certificate to incoming connections.

**Backward compatibility:**
- Run the app-server with a standard single-certificate configuration (no `clientCertificates`/`clientKeys`).
- Verify the server starts, `ZWED0305I` is not logged, and all outbound connections work.
- Verify that `this.httpsOptions` still references the certificate (it is aliased to `clientTlsOptions` for backward compatibility).

## Further comments

**Changes in this PR:**

1. **`lib/webserver.js`** (core implementation):
   - `readTlsOptionsFromConfig()`: Added loading of optional `clientCertificates` and `clientKeys` into temporary `clientCert`/`clientKey` properties on `httpsOptions`.
   - `WebServer.prototype`: Added `serverTlsOptions` and `clientTlsOptions` properties with explanatory comments.
   - `getTlsOptions()`: Returns `this.clientTlsOptions` (client cert by default; used by plugins, dataservices, API calls, etc.).
   - `getServerTlsOptions()` (new method): Returns `this.serverTlsOptions` (server cert; used only when creating inbound HTTPS server).
   - `setConfig()`: After loading TLS, splits `httpsOptions` into `serverTlsOptions` and `clientTlsOptions` when both `clientCert` and `clientKey` are present. `this.httpsOptions` is aliased to `this.clientTlsOptions` for backward compatibility.
   - `startListening()`: Uses `getServerTlsOptions()` explicitly when creating the HTTPS server.

2. **`lib/assets/i18n/log/messages_en.json`**:
   - `ZWED0304I`: `"Using client certificate: %s"` — logged when a client certificate is loaded.
   - `ZWED0305I`: `"Using separate certificates for server TLS and client TLS connections"` — logged when server and client certs differ.

3. **`CHANGELOG.md`**:
   - Added entry describing the feature and referencing PR #674.

**Design rationale:**

- **Default to client cert in `getTlsOptions()`**: The client certificate is used in far more places (outbound connections, plugins, auth, APIML registration, dataservices) than the server certificate. By making client the default, existing code works correctly without modification.
- **Explicit server getter**: Creates a clear, auditable boundary: only `getServerTlsOptions()` calls can be suspected of using the server cert. Code review can focus on these explicit calls.
- **Backward-compatible aliasing**: Code that predates this change and reads `this.httpsOptions` will naturally receive the client certificate, which is the correct default. No silent breakages occur.
- **Two-property requirement for client cert**: Both `clientCert` and `clientKey` must be present to trigger the split. This prevents accidental misconfiguration where only one is set.

**Optional future enhancements:**

- Add automated tests validating client/server certificate selection with mock TLS connections.
- Add CLI or admin API to query which certificate is active for each purpose.
- Performance profiling to ensure the shallow copy of `httpsOptions` has negligible overhead.
