### PR TITLE
Added attls check tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to the Zlux Server Framework package will be documented in this file.
 This repo is part of the app-server Zowe Component, and the change logs here may appear on Zowe.org in that section.
 
+## 3.6.0
+- Enhancement: Added a utility, "check-zowe-attls.js" that can be called with node provided with a pagent attls rule file and a zowe yaml, and it will give you an approximate summary of if your attls rules are compatible with zowe's configuration.
+
 ## 3.5.0
 - Enhancement: Improved SSH connection performance restoring use of Node.js built-in diffie-hellman logic. [(#669)](https://github.com/zowe/zlux-server-framework/pull/669) 
 - Bugfix: Fixed error ZWED0149E from occurring when using AT-TLS. This error did not mean something was wrong, so the message is no longer printed in that condition to avoid confusion. ([#633](https://github.com/zowe/zlux-server-framework/pull/633))

--- a/package.json
+++ b/package.json
@@ -34,7 +34,9 @@
   "scripts": {
     "build": "tsc",
     "start": "tsc --watch",
-    "test:storage": "mocha --timeout 10000 ./test/storage/*.js"
+    "test:storage": "mocha --timeout 10000 ./test/storage/*.js",
+    "test:attls": "mocha --timeout 10000 ./test/attls-checker/test.js",
+    "test": "npm run test:attls"
   },
   "dependencies": {
     "@apidevtools/swagger-parser": "12.1.0",

--- a/test/attls-checker/fixtures/attls-bad-cluster-appserver.txt
+++ b/test/attls-checker/fixtures/attls-bad-cluster-appserver.txt
@@ -1,0 +1,140 @@
+# attls-bad-cluster-appserver.txt
+#
+# BAD: All port/jobname coverage is correct EXCEPT the inbound rule for
+# app-server (port 7556) uses "Jobname ZWE1DS" rather than "Jobname ZWE1SV"
+# (or the wildcard ZWE1*).
+#
+# When cluster mode is ENABLED (default, no ZLUX_NO_CLUSTER), the inbound
+# socket on port 7556 is owned by the parent STC job "ZWE1SV" (zowe.job.name).
+# A rule with "Jobname ZWE1DS" will NOT be applied to ZWE1SV, so the inbound
+# connection will be missed.
+#
+# When cluster mode is DISABLED (ZLUX_NO_CLUSTER=1), "ZWE1DS" holds the port
+# and the rule is correct — no miss.
+
+TTLSGroupAction ZoweServerGroup
+{
+  TTLSEnabled On
+}
+
+TTLSGroupAction ZoweClientGroup
+{
+  TTLSEnabled On
+}
+
+TTLSEnvironmentAction ZoweServerEnvAction
+{
+  HandshakeRole ServerWithClientAuth
+  TTLSKeyringParmsRef ZoweKeyring
+}
+
+TTLSEnvironmentAction ZoweClientEnvAction
+{
+  HandshakeRole Client
+  TTLSKeyringParmsRef ZoweKeyring
+}
+
+TTLSConnectionAction ZoweServerConnAction
+{
+  HandshakeRole ServerWithClientAuth
+}
+
+TTLSConnectionAction ZoweClientConnAction
+{
+  HandshakeRole Client
+}
+
+TTLSKeyringParms ZoweKeyring
+{
+  Keyring ZOWE/ZOWE_RING
+}
+
+# ── Inbound: all APIML + ZAAS (ports 7552-7555, 7558) ────────────────────────
+
+TTLSRule ZoweInboundApiml
+{
+  LocalAddr ALL
+  RemoteAddr ALL
+  LocalPortRange 7552-7555
+  Jobname ZWE1*
+  Direction Inbound
+  Priority 100
+  TTLSGroupActionRef ZoweServerGroup
+  TTLSEnvironmentActionRef ZoweServerEnvAction
+  TTLSConnectionActionRef ZoweServerConnAction
+}
+
+TTLSRule ZoweInboundZaas
+{
+  LocalAddr ALL
+  RemoteAddr ALL
+  LocalPortRange 7558
+  Jobname ZWE1*
+  Direction Inbound
+  Priority 100
+  TTLSGroupActionRef ZoweServerGroup
+  TTLSEnvironmentActionRef ZoweServerEnvAction
+  TTLSConnectionActionRef ZoweServerConnAction
+}
+
+# ── Inbound: app-server (7556) — WRONG: uses ZWE1DS, not ZWE1SV ──────────────
+# In cluster mode ZWE1SV holds the port; this rule with ZWE1DS will NOT match
+# ZWE1SV → miss when cluster is enabled, ok when cluster is disabled.
+
+TTLSRule ZoweInboundAppServer
+{
+  LocalAddr ALL
+  RemoteAddr ALL
+  LocalPortRange 7556
+  Jobname ZWE1DS
+  Direction Inbound
+  Priority 100
+  TTLSGroupActionRef ZoweServerGroup
+  TTLSEnvironmentActionRef ZoweServerEnvAction
+  TTLSConnectionActionRef ZoweServerConnAction
+}
+
+# ── Inbound: zss (7557) ───────────────────────────────────────────────────────
+
+TTLSRule ZoweInboundZss
+{
+  LocalAddr ALL
+  RemoteAddr ALL
+  LocalPortRange 7557
+  Jobname ZWE1SZ
+  Direction Inbound
+  Priority 100
+  TTLSGroupActionRef ZoweServerGroup
+  TTLSEnvironmentActionRef ZoweServerEnvAction
+  TTLSConnectionActionRef ZoweServerConnAction
+}
+
+# ── Outbound ──────────────────────────────────────────────────────────────────
+
+TTLSRule ZoweOutboundInternal
+{
+  LocalAddr ALL
+  LocalPortRange 1024-65535
+  RemoteAddr ALL
+  RemotePortRange 7552-7601
+  Jobname ZWE1*
+  Direction Outbound
+  Priority 100
+  TTLSGroupActionRef ZoweClientGroup
+  TTLSEnvironmentActionRef ZoweClientEnvAction
+  TTLSConnectionActionRef ZoweClientConnAction
+}
+
+TTLSRule ZoweOutboundZosmf
+{
+  LocalAddr ALL
+  LocalPortRange 1024-65535
+  RemoteAddr ALL
+  RemotePortRange 443
+  Jobname ZWE1A*
+  Direction Outbound
+  Priority 100
+  TTLSGroupActionRef ZoweClientGroup
+  TTLSEnvironmentActionRef ZoweClientEnvAction
+  TTLSConnectionActionRef ZoweClientConnAction
+}

--- a/test/attls-checker/fixtures/attls-bad-empty.txt
+++ b/test/attls-checker/fixtures/attls-bad-empty.txt
@@ -1,0 +1,16 @@
+# attls-bad-empty.txt
+#
+# BAD: Contains only a TTLSGroupAction declaration — no TTLSRule declarations
+# at all.  The checker should report every required connection as status='miss'.
+
+TTLSGroupAction SomeGroupAction
+{
+  TTLSEnabled On
+}
+
+TTLSKeyringParms SomeKeyring
+{
+  Keyring ZOWE/ZOWE_RING
+}
+
+# No TTLSRule declarations.  All Zowe connections will be unmatched.

--- a/test/attls-checker/fixtures/attls-bad-missing-inbound.txt
+++ b/test/attls-checker/fixtures/attls-bad-missing-inbound.txt
@@ -1,0 +1,107 @@
+# attls-bad-missing-inbound.txt
+#
+# BAD: Only covers gateway (7554) and api-catalog (7552) inbound.
+# Missing inbound rules for: discovery (7553), caching-service (7555),
+# app-server (7556), zss (7557), zaas (7558).
+# Also has no infinispan coverage (7600/7601).
+# Outbound rules are present (so only INBOUND gaps are tested when used
+# with zowe-full-attls.yaml which has server.attls=true).
+
+TTLSGroupAction PartialServerGroup
+{
+  TTLSEnabled On
+}
+
+TTLSGroupAction PartialClientGroup
+{
+  TTLSEnabled On
+}
+
+TTLSEnvironmentAction PartialServerEnv
+{
+  HandshakeRole Server
+  TTLSKeyringParmsRef ZoweKeyring
+}
+
+TTLSEnvironmentAction PartialClientEnv
+{
+  HandshakeRole Client
+  TTLSKeyringParmsRef ZoweKeyring
+}
+
+TTLSConnectionAction PartialServerConn
+{
+  HandshakeRole Server
+}
+
+TTLSConnectionAction PartialClientConn
+{
+  HandshakeRole Client
+}
+
+TTLSKeyringParms ZoweKeyring
+{
+  Keyring ZOWE/ZOWE_RING
+}
+
+# ── Inbound: ONLY api-catalog (7552) and gateway (7554) ──────────────────────
+
+TTLSRule ZoweInboundApiCatalog
+{
+  LocalAddr ALL
+  RemoteAddr ALL
+  LocalPortRange 7552
+  Jobname ZWE1AC
+  Direction Inbound
+  Priority 100
+  TTLSGroupActionRef PartialServerGroup
+  TTLSEnvironmentActionRef PartialServerEnv
+  TTLSConnectionActionRef PartialServerConn
+}
+
+TTLSRule ZoweInboundGateway
+{
+  LocalAddr ALL
+  RemoteAddr ALL
+  LocalPortRange 7554
+  Jobname ZWE1AG
+  Direction Inbound
+  Priority 100
+  TTLSGroupActionRef PartialServerGroup
+  TTLSEnvironmentActionRef PartialServerEnv
+  TTLSConnectionActionRef PartialServerConn
+}
+
+# ── Outbound: broad rule covers all Zowe ports + z/OSMF ─────────────────────
+# (Outbound is "good" so it should not add misses in inbound-only test)
+
+TTLSRule ZoweOutboundAll
+{
+  LocalAddr ALL
+  LocalPortRange 1024-65535
+  RemoteAddr ALL
+  RemotePortRange 7552-7601
+  Jobname ZWE1*
+  Direction Outbound
+  Priority 100
+  TTLSGroupActionRef PartialClientGroup
+  TTLSEnvironmentActionRef PartialClientEnv
+  TTLSConnectionActionRef PartialClientConn
+}
+
+TTLSRule ZoweOutboundZosmf
+{
+  LocalAddr ALL
+  LocalPortRange 1024-65535
+  RemoteAddr ALL
+  RemotePortRange 443
+  Jobname ZWE1A*
+  Direction Outbound
+  Priority 100
+  TTLSGroupActionRef PartialClientGroup
+  TTLSEnvironmentActionRef PartialClientEnv
+  TTLSConnectionActionRef PartialClientConn
+}
+
+# NOTE: Missing coverage for discovery(7553), caching(7555), app-server(7556),
+#       zss(7557), zaas(7558), infinispan(7600, 7601) inbound connections.

--- a/test/attls-checker/fixtures/attls-bad-missing-outbound.txt
+++ b/test/attls-checker/fixtures/attls-bad-missing-outbound.txt
@@ -1,0 +1,58 @@
+# attls-bad-missing-outbound.txt
+#
+# BAD: All inbound rules are present but outbound rules are missing.
+# Specifically there are NO outbound rules at all.
+# When used with zowe-full-attls.yaml (client.attls=true), all outbound
+# connections (services calling each other + gateway->z/OSMF) will be missed.
+
+TTLSGroupAction ServerGroup
+{
+  TTLSEnabled On
+}
+
+TTLSEnvironmentAction ServerEnv
+{
+  HandshakeRole Server
+  TTLSKeyringParmsRef ZoweKeyring
+}
+
+TTLSConnectionAction ServerConn
+{
+  HandshakeRole Server
+}
+
+TTLSKeyringParms ZoweKeyring
+{
+  Keyring ZOWE/ZOWE_RING
+}
+
+# ── Inbound: complete coverage (all 7 components + infinispan) ────────────────
+
+TTLSRule ZoweInboundMain
+{
+  LocalAddr ALL
+  RemoteAddr ALL
+  LocalPortRange 7552-7558
+  Jobname ZWE1*
+  Direction Inbound
+  Priority 100
+  TTLSGroupActionRef ServerGroup
+  TTLSEnvironmentActionRef ServerEnv
+  TTLSConnectionActionRef ServerConn
+}
+
+TTLSRule ZoweInboundInfinispan
+{
+  LocalAddr ALL
+  RemoteAddr ALL
+  LocalPortRange 7600-7601
+  Jobname ZWE1CS
+  Direction Inbound
+  Priority 100
+  TTLSGroupActionRef ServerGroup
+  TTLSEnvironmentActionRef ServerEnv
+  TTLSConnectionActionRef ServerConn
+}
+
+# ── NO outbound rules ─────────────────────────────────────────────────────────
+# When client.attls=true, all outbound connections will be unmatched (miss).

--- a/test/attls-checker/fixtures/attls-bad-partial-shadow.txt
+++ b/test/attls-checker/fixtures/attls-bad-partial-shadow.txt
@@ -1,0 +1,140 @@
+# attls-bad-partial-shadow.txt
+#
+# BAD: A broad low-priority On rule covers all Zowe ports (7552-7558 + infinispan).
+# A separate high-priority Off rule disables AT-TLS for just the gateway (7554)
+# and ZAAS (7558) ports, effectively punching holes in the broad rule.
+#
+# Priority reminder: HIGHER numeric value = HIGHER priority.
+#   Priority 200 wins over Priority 100.
+#
+# The person writing this policy intended ZoweInboundBroad to protect everything.
+# But ZoweOffGatewayZaas (priority 200) silently overrides it for ports 7554+7558.
+#
+# Expected outcome:
+#   inbound:api-catalog    (7552) → ok      (only broad On rule matches)
+#   inbound:discovery      (7553) → ok      (only broad On rule matches)
+#   inbound:gateway        (7554) → warn    (Off rule at priority 200 shadows On rule)
+#   inbound:app-server     (7556) → warn    (Off rule has Jobname ZWE1SV — matches cluster STC)
+#   inbound:caching-service(7555) → ok      (only broad On rule matches)
+#   inbound:zaas           (7558) → warn    (Off rule at priority 200 shadows On rule)
+#   inbound:zss            (7557) → ok      (only broad On rule matches — ZWE1SZ not caught)
+
+TTLSGroupAction ZoweOnGroup
+{
+  TTLSEnabled On
+}
+
+TTLSGroupAction ZoweOffGroup
+{
+  TTLSEnabled Off
+}
+
+TTLSEnvironmentAction ZoweServerEnv
+{
+  HandshakeRole ServerWithClientAuth
+  TTLSKeyringParmsRef ZoweKeyring
+}
+
+TTLSConnectionAction ZoweServerConn
+{
+  HandshakeRole ServerWithClientAuth
+}
+
+TTLSKeyringParms ZoweKeyring
+{
+  Keyring ZOWE/ZOWE_RING
+}
+
+# ── Broad low-priority On rule: all Zowe inbound ports ───────────────────────
+# Priority 100 — intended to enable AT-TLS for everything Zowe-related.
+
+TTLSRule ZoweInboundBroad
+{
+  LocalAddr ALL
+  RemoteAddr ALL
+  LocalPortRange 7552-7558
+  Jobname ZWE1*
+  Direction Inbound
+  Priority 100
+  TTLSGroupActionRef ZoweOnGroup
+  TTLSEnvironmentActionRef ZoweServerEnv
+  TTLSConnectionActionRef ZoweServerConn
+}
+
+TTLSRule ZoweInboundInfinispan
+{
+  LocalAddr ALL
+  RemoteAddr ALL
+  LocalPortRange 7600-7601
+  Jobname ZWE1CS
+  Direction Inbound
+  Priority 100
+  TTLSGroupActionRef ZoweOnGroup
+  TTLSEnvironmentActionRef ZoweServerEnv
+  TTLSConnectionActionRef ZoweServerConn
+}
+
+# ── High-priority Off rule: disables AT-TLS for gateway and ZAAS ports ───────
+# Priority 200 — silently overrides ZoweInboundBroad for ports 7554 and 7558.
+# Also catches the cluster STC (ZWE1SV) on port 7556 (app-server).
+# Intended to exempt certain ports from AT-TLS, but the author may not have
+# realised this would break Zowe's inbound protection for those ports.
+
+TTLSRule ZoweOffGatewayZaasAppServer
+{
+  LocalAddr ALL
+  RemoteAddr ALL
+  LocalPortRange 7554
+  LocalPortRange 7556
+  LocalPortRange 7558
+  Jobname ZWE1*
+  Direction Inbound
+  Priority 200
+  TTLSGroupActionRef ZoweOffGroup
+}
+
+# ── Outbound: complete, separate from the inbound concern ────────────────────
+
+TTLSGroupAction ZoweClientGroup
+{
+  TTLSEnabled On
+}
+
+TTLSEnvironmentAction ZoweClientEnv
+{
+  HandshakeRole Client
+  TTLSKeyringParmsRef ZoweKeyring
+}
+
+TTLSConnectionAction ZoweClientConn
+{
+  HandshakeRole Client
+}
+
+TTLSRule ZoweOutboundInternal
+{
+  LocalAddr ALL
+  LocalPortRange 1024-65535
+  RemoteAddr ALL
+  RemotePortRange 7552-7601
+  Jobname ZWE1*
+  Direction Outbound
+  Priority 100
+  TTLSGroupActionRef ZoweClientGroup
+  TTLSEnvironmentActionRef ZoweClientEnv
+  TTLSConnectionActionRef ZoweClientConn
+}
+
+TTLSRule ZoweOutboundZosmf
+{
+  LocalAddr ALL
+  LocalPortRange 1024-65535
+  RemoteAddr ALL
+  RemotePortRange 443
+  Jobname ZWE1A*
+  Direction Outbound
+  Priority 100
+  TTLSGroupActionRef ZoweClientGroup
+  TTLSEnvironmentActionRef ZoweClientEnv
+  TTLSConnectionActionRef ZoweClientConn
+}

--- a/test/attls-checker/fixtures/attls-bad-priority-shadow.txt
+++ b/test/attls-checker/fixtures/attls-bad-priority-shadow.txt
@@ -1,0 +1,128 @@
+# attls-bad-priority-shadow.txt
+#
+# BAD: A high-priority rule with TTLSEnabled Off shadows a lower-priority
+# rule with TTLSEnabled On for the inbound gateway port (7554).
+#
+# Priority ordering in AT-TLS: HIGHER numeric value = HIGHER priority.
+# So priority 200 wins over priority 100.
+#
+# The checker should report status='warn' for the gateway inbound connection
+# because the best-matching rule (priority 200) has TTLSEnabled Off — meaning
+# AT-TLS is effectively disabled for that connection despite a TTLSEnabled On
+# rule also existing.
+
+TTLSGroupAction ZoweOnGroup
+{
+  TTLSEnabled On
+}
+
+TTLSGroupAction ZoweOffGroup
+{
+  TTLSEnabled Off
+}
+
+TTLSEnvironmentAction ZoweServerEnv
+{
+  HandshakeRole Server
+  TTLSKeyringParmsRef ZoweKeyring
+}
+
+TTLSConnectionAction ZoweServerConn
+{
+  HandshakeRole Server
+}
+
+TTLSKeyringParms ZoweKeyring
+{
+  Keyring ZOWE/ZOWE_RING
+}
+
+# ── Good inbound rule (priority 100) for most Zowe ports ─────────────────────
+
+TTLSRule ZoweInboundMain
+{
+  LocalAddr ALL
+  RemoteAddr ALL
+  LocalPortRange 7552-7558
+  Jobname ZWE1*
+  Direction Inbound
+  Priority 100
+  TTLSGroupActionRef ZoweOnGroup
+  TTLSEnvironmentActionRef ZoweServerEnv
+  TTLSConnectionActionRef ZoweServerConn
+}
+
+TTLSRule ZoweInboundInfinispan
+{
+  LocalAddr ALL
+  RemoteAddr ALL
+  LocalPortRange 7600-7601
+  Jobname ZWE1CS
+  Direction Inbound
+  Priority 100
+  TTLSGroupActionRef ZoweOnGroup
+  TTLSEnvironmentActionRef ZoweServerEnv
+  TTLSConnectionActionRef ZoweServerConn
+}
+
+# ── Shadowing rule: higher priority (200) disables AT-TLS for gateway ─────────
+# This catches ZWE1AG on port 7554 with TTLSEnabled Off.
+# Because priority 200 > priority 100, this rule wins and AT-TLS will be
+# disabled for the gateway, even though ZoweInboundMain would have covered it.
+
+TTLSRule GatewayShadow
+{
+  LocalAddr ALL
+  RemoteAddr ALL
+  LocalPortRange 7554
+  Jobname ZWE1AG
+  Direction Inbound
+  Priority 200
+  TTLSGroupActionRef ZoweOffGroup
+}
+
+# ── Outbound: complete (not the focus of this test) ──────────────────────────
+
+TTLSGroupAction ZoweClientGroup
+{
+  TTLSEnabled On
+}
+
+TTLSEnvironmentAction ZoweClientEnv
+{
+  HandshakeRole Client
+  TTLSKeyringParmsRef ZoweKeyring
+}
+
+TTLSConnectionAction ZoweClientConn
+{
+  HandshakeRole Client
+}
+
+TTLSRule ZoweOutboundInternal
+{
+  LocalAddr ALL
+  LocalPortRange 1024-65535
+  RemoteAddr ALL
+  RemotePortRange 7552-7601
+  Jobname ZWE1*
+  Direction Outbound
+  Priority 100
+  TTLSGroupActionRef ZoweClientGroup
+  TTLSEnvironmentActionRef ZoweClientEnv
+  TTLSConnectionActionRef ZoweClientConn
+}
+
+TTLSRule ZoweOutboundZosmf
+{
+  LocalAddr ALL
+  LocalPortRange 1024-65535
+  RemoteAddr ALL
+  RemotePortRange 443
+  Jobname ZWE1A*
+  Direction Outbound
+  Priority 100
+  TTLSGroupActionRef ZoweClientGroup
+  TTLSEnvironmentActionRef ZoweClientEnv
+  TTLSConnectionActionRef ZoweClientConn
+}

--- a/test/attls-checker/fixtures/attls-bad-wrong-jobname.txt
+++ b/test/attls-checker/fixtures/attls-bad-wrong-jobname.txt
@@ -1,0 +1,99 @@
+# attls-bad-wrong-jobname.txt
+#
+# BAD: Rules exist for the correct ports and directions but with a completely
+# wrong jobname pattern (MYCICS* instead of ZWE1*).  The checker should report
+# status='miss' for every Zowe connection because no rule matches the ZWE1*
+# jobname set.
+
+TTLSGroupAction WrongJobGroup
+{
+  TTLSEnabled On
+}
+
+TTLSEnvironmentAction WrongJobServerEnv
+{
+  HandshakeRole Server
+  TTLSKeyringParmsRef WrongKeyring
+}
+
+TTLSEnvironmentAction WrongJobClientEnv
+{
+  HandshakeRole Client
+  TTLSKeyringParmsRef WrongKeyring
+}
+
+TTLSConnectionAction WrongJobServerConn
+{
+  HandshakeRole Server
+}
+
+TTLSConnectionAction WrongJobClientConn
+{
+  HandshakeRole Client
+}
+
+TTLSKeyringParms WrongKeyring
+{
+  Keyring MYCICS/CICS_RING
+}
+
+# ── Inbound: correct ports, WRONG jobname ────────────────────────────────────
+
+TTLSRule CicsInbound
+{
+  LocalAddr ALL
+  RemoteAddr ALL
+  LocalPortRange 7552-7558
+  Jobname MYCICS*
+  Direction Inbound
+  Priority 100
+  TTLSGroupActionRef WrongJobGroup
+  TTLSEnvironmentActionRef WrongJobServerEnv
+  TTLSConnectionActionRef WrongJobServerConn
+}
+
+TTLSRule CicsInboundInfinispan
+{
+  LocalAddr ALL
+  RemoteAddr ALL
+  LocalPortRange 7600-7601
+  Jobname MYCSRV
+  Direction Inbound
+  Priority 100
+  TTLSGroupActionRef WrongJobGroup
+  TTLSEnvironmentActionRef WrongJobServerEnv
+  TTLSConnectionActionRef WrongJobServerConn
+}
+
+# ── Outbound: correct ports, WRONG jobname ───────────────────────────────────
+
+TTLSRule CicsOutbound
+{
+  LocalAddr ALL
+  LocalPortRange 1024-65535
+  RemoteAddr ALL
+  RemotePortRange 7552-7601
+  Jobname MYCICS*
+  Direction Outbound
+  Priority 100
+  TTLSGroupActionRef WrongJobGroup
+  TTLSEnvironmentActionRef WrongJobClientEnv
+  TTLSConnectionActionRef WrongJobClientConn
+}
+
+TTLSRule CicsOutboundZosmf
+{
+  LocalAddr ALL
+  LocalPortRange 1024-65535
+  RemoteAddr ALL
+  RemotePortRange 443
+  Jobname MYCICS*
+  Direction Outbound
+  Priority 100
+  TTLSGroupActionRef WrongJobGroup
+  TTLSEnvironmentActionRef WrongJobClientEnv
+  TTLSConnectionActionRef WrongJobClientConn
+}
+
+# All the above rules are for CICS jobs, not Zowe (ZWE1*) jobs.
+# None will match any Zowe connection => all connections miss.

--- a/test/attls-checker/fixtures/attls-bad-wrong-keyring.txt
+++ b/test/attls-checker/fixtures/attls-bad-wrong-keyring.txt
@@ -1,0 +1,113 @@
+# attls-bad-wrong-keyring.txt
+#
+# BAD: Identical port/jobname coverage to attls-good-complete.txt but all
+# TTLSKeyringParms declarations reference WRONG/KEYRING rather than ZOWE/ZOWE_RING.
+#
+# When used with zowe-full-attls.yaml (which specifies
+#   safkeyring://ZOWE/ZOWE_RING), all Zowe-to-Zowe connections will be
+# covered (correct ports + jobnames) but every matched rule will carry the
+# wrong keyring → status='warn', warnReasons=['keyring'].
+#
+# The one exception is the z/OSMF outbound connection: that rule is exempt from
+# the keyring check, so it stays 'ok' regardless of the keyring used.
+
+TTLSGroupAction ZoweServerGroup
+{
+  TTLSEnabled On
+}
+
+TTLSGroupAction ZoweClientGroup
+{
+  TTLSEnabled On
+}
+
+# Wrong keyring — should be ZOWE/ZOWE_RING for Zowe-to-Zowe connections
+
+TTLSEnvironmentAction ZoweServerEnvAction
+{
+  HandshakeRole ServerWithClientAuth
+  TTLSKeyringParmsRef WrongKeyring
+}
+
+TTLSEnvironmentAction ZoweClientEnvAction
+{
+  HandshakeRole Client
+  TTLSKeyringParmsRef WrongKeyring
+}
+
+TTLSConnectionAction ZoweServerConnAction
+{
+  HandshakeRole ServerWithClientAuth
+}
+
+TTLSConnectionAction ZoweClientConnAction
+{
+  HandshakeRole Client
+}
+
+TTLSKeyringParms WrongKeyring
+{
+  Keyring WRONG/KEYRING
+}
+
+# ── Inbound: core API ML + ZAAS (ports 7552-7558) ────────────────────────────
+
+TTLSRule ZoweInboundMain
+{
+  LocalAddr ALL
+  RemoteAddr ALL
+  LocalPortRange 7552-7558
+  Jobname ZWE1*
+  Direction Inbound
+  Priority 100
+  TTLSGroupActionRef ZoweServerGroup
+  TTLSEnvironmentActionRef ZoweServerEnvAction
+  TTLSConnectionActionRef ZoweServerConnAction
+}
+
+# ── Inbound: Caching Service infinispan (ports 7600-7601) ────────────────────
+
+TTLSRule ZoweInboundInfinispan
+{
+  LocalAddr ALL
+  RemoteAddr ALL
+  LocalPortRange 7600-7601
+  Jobname ZWE1CS
+  Direction Inbound
+  Priority 100
+  TTLSGroupActionRef ZoweServerGroup
+  TTLSEnvironmentActionRef ZoweServerEnvAction
+  TTLSConnectionActionRef ZoweServerConnAction
+}
+
+# ── Outbound: all inter-service communication within Zowe ─────────────────────
+
+TTLSRule ZoweOutboundInternal
+{
+  LocalAddr ALL
+  LocalPortRange 1024-65535
+  RemoteAddr ALL
+  RemotePortRange 7552-7601
+  Jobname ZWE1*
+  Direction Outbound
+  Priority 100
+  TTLSGroupActionRef ZoweClientGroup
+  TTLSEnvironmentActionRef ZoweClientEnvAction
+  TTLSConnectionActionRef ZoweClientConnAction
+}
+
+# ── Outbound: z/OSMF (exempt from keyring check — may use any trust keyring) ─
+
+TTLSRule ZoweOutboundZosmf
+{
+  LocalAddr ALL
+  LocalPortRange 1024-65535
+  RemoteAddr ALL
+  RemotePortRange 443
+  Jobname ZWE1A*
+  Direction Outbound
+  Priority 100
+  TTLSGroupActionRef ZoweClientGroup
+  TTLSEnvironmentActionRef ZoweClientEnvAction
+  TTLSConnectionActionRef ZoweClientConnAction
+}

--- a/test/attls-checker/fixtures/attls-good-complete.txt
+++ b/test/attls-checker/fixtures/attls-good-complete.txt
@@ -1,0 +1,107 @@
+# attls-good-complete.txt
+#
+# GOOD: Complete AT-TLS coverage for a standard Zowe deployment.
+# ALL inbound ports (7552-7558) and infinispan ports are covered.
+# ALL required outbound connections are covered.
+# Uses wildcard jobname ZWE1* for simplicity.
+
+# ── Shared actions ────────────────────────────────────────────────────────────
+
+TTLSGroupAction ZoweServerGroup
+{
+  TTLSEnabled On
+}
+
+TTLSGroupAction ZoweClientGroup
+{
+  TTLSEnabled On
+}
+
+TTLSEnvironmentAction ZoweServerEnvAction
+{
+  HandshakeRole ServerWithClientAuth
+  TTLSKeyringParmsRef ZoweKeyring
+}
+
+TTLSEnvironmentAction ZoweClientEnvAction
+{
+  HandshakeRole Client
+  TTLSKeyringParmsRef ZoweKeyring
+}
+
+TTLSConnectionAction ZoweServerConnAction
+{
+  HandshakeRole ServerWithClientAuth
+}
+
+TTLSConnectionAction ZoweClientConnAction
+{
+  HandshakeRole Client
+}
+
+TTLSKeyringParms ZoweKeyring
+{
+  Keyring ZOWE/ZOWE_RING
+}
+
+# ── Inbound: core API ML + ZAAS (ports 7552-7558) ────────────────────────────
+
+TTLSRule ZoweInboundMain
+{
+  LocalAddr ALL
+  RemoteAddr ALL
+  LocalPortRange 7552-7558
+  Jobname ZWE1*
+  Direction Inbound
+  Priority 100
+  TTLSGroupActionRef ZoweServerGroup
+  TTLSEnvironmentActionRef ZoweServerEnvAction
+  TTLSConnectionActionRef ZoweServerConnAction
+}
+
+# ── Inbound: Caching Service infinispan (ports 7600-7601) ────────────────────
+
+TTLSRule ZoweInboundInfinispan
+{
+  LocalAddr ALL
+  RemoteAddr ALL
+  LocalPortRange 7600-7601
+  Jobname ZWE1CS
+  Direction Inbound
+  Priority 100
+  TTLSGroupActionRef ZoweServerGroup
+  TTLSEnvironmentActionRef ZoweServerEnvAction
+  TTLSConnectionActionRef ZoweServerConnAction
+}
+
+# ── Outbound: all inter-service communication within Zowe ─────────────────────
+
+TTLSRule ZoweOutboundInternal
+{
+  LocalAddr ALL
+  LocalPortRange 1024-65535
+  RemoteAddr ALL
+  RemotePortRange 7552-7601
+  Jobname ZWE1*
+  Direction Outbound
+  Priority 100
+  TTLSGroupActionRef ZoweClientGroup
+  TTLSEnvironmentActionRef ZoweClientEnvAction
+  TTLSConnectionActionRef ZoweClientConnAction
+}
+
+# ── Outbound: Gateway and ZAAS to z/OSMF ────────────────────────────────────
+
+TTLSRule ZoweOutboundZosmf
+{
+  LocalAddr ALL
+  LocalPortRange 1024-65535
+  RemoteAddr ALL
+  RemotePortRange 443
+  Jobname ZWE1A*
+  Direction Outbound
+  Priority 100
+  TTLSGroupActionRef ZoweClientGroup
+  TTLSEnvironmentActionRef ZoweClientEnvAction
+  TTLSConnectionActionRef ZoweClientConnAction
+}

--- a/test/attls-checker/fixtures/attls-good-custom-ports.txt
+++ b/test/attls-checker/fixtures/attls-good-custom-ports.txt
@@ -1,0 +1,93 @@
+# attls-good-custom-ports.txt
+#
+# GOOD: Full coverage for zowe-custom-ports.yaml.
+# That config uses:
+#   jobPrefix: ZPRD (jobs: ZPRDAC, ZPRDAD, ZPRDSG, ZPRDCS, ZPRDDS, ZPRDSZ, ZPRDAZ)
+#   Ports : api-catalog=8552, discovery=8553, gateway=8554, caching=8555,
+#           app-server=8556, zss=8557, zaas=8558
+#   z/OSMF: port 10443
+#   No infinispan entries in that fixture.
+
+TTLSGroupAction ZoweCustomServerGroup
+{
+  TTLSEnabled On
+}
+
+TTLSGroupAction ZoweCustomClientGroup
+{
+  TTLSEnabled On
+}
+
+TTLSEnvironmentAction ZoweCustomServerEnv
+{
+  HandshakeRole ServerWithClientAuth
+  TTLSKeyringParmsRef ZoweCustomKeyring
+}
+
+TTLSEnvironmentAction ZoweCustomClientEnv
+{
+  HandshakeRole Client
+  TTLSKeyringParmsRef ZoweCustomKeyring
+}
+
+TTLSConnectionAction ZoweCustomServerConn
+{
+  HandshakeRole ServerWithClientAuth
+}
+
+TTLSConnectionAction ZoweCustomClientConn
+{
+  HandshakeRole Client
+}
+
+TTLSKeyringParms ZoweCustomKeyring
+{
+  Keyring ZPRD/ZPRD_RING
+}
+
+# ── Inbound: custom Zowe ports 8552-8558 with ZPRD* jobname ──────────────────
+
+TTLSRule ZoweCustomInbound
+{
+  LocalAddr ALL
+  RemoteAddr ALL
+  LocalPortRange 8552-8558
+  Jobname ZPRD*
+  Direction Inbound
+  Priority 100
+  TTLSGroupActionRef ZoweCustomServerGroup
+  TTLSEnvironmentActionRef ZoweCustomServerEnv
+  TTLSConnectionActionRef ZoweCustomServerConn
+}
+
+# ── Outbound: internal traffic between custom Zowe services ──────────────────
+
+TTLSRule ZoweCustomOutboundInternal
+{
+  LocalAddr ALL
+  LocalPortRange 1024-65535
+  RemoteAddr ALL
+  RemotePortRange 8552-8558
+  Jobname ZPRD*
+  Direction Outbound
+  Priority 100
+  TTLSGroupActionRef ZoweCustomClientGroup
+  TTLSEnvironmentActionRef ZoweCustomClientEnv
+  TTLSConnectionActionRef ZoweCustomClientConn
+}
+
+# ── Outbound: z/OSMF on custom port 10443 ────────────────────────────────────
+
+TTLSRule ZoweCustomOutboundZosmf
+{
+  LocalAddr ALL
+  LocalPortRange 1024-65535
+  RemoteAddr ALL
+  RemotePortRange 10443
+  Jobname ZPRD*
+  Direction Outbound
+  Priority 100
+  TTLSGroupActionRef ZoweCustomClientGroup
+  TTLSEnvironmentActionRef ZoweCustomClientEnv
+  TTLSConnectionActionRef ZoweCustomClientConn
+}

--- a/test/attls-checker/fixtures/attls-good-inbound-only.txt
+++ b/test/attls-checker/fixtures/attls-good-inbound-only.txt
@@ -1,0 +1,56 @@
+# attls-good-inbound-only.txt
+#
+# GOOD: Inbound-only rules for use with zowe-server-attls-only.yaml
+# (server.attls=true, client.attls=false).  Only inbound rules are required.
+# There are NO outbound rules — that is intentional and correct for this config.
+
+TTLSGroupAction ZoweServerGroup
+{
+  TTLSEnabled On
+}
+
+TTLSEnvironmentAction ZoweServerEnvAction
+{
+  HandshakeRole Server
+  TTLSKeyringParmsRef ZoweKeyring
+}
+
+TTLSConnectionAction ZoweServerConnAction
+{
+  HandshakeRole Server
+}
+
+TTLSKeyringParms ZoweKeyring
+{
+  Keyring ZOWE/ZOWE_RING
+}
+
+# ── Inbound: all core Zowe API ML + app-server + zss + zaas ──────────────────
+
+TTLSRule ZoweInboundMain
+{
+  LocalAddr ALL
+  RemoteAddr ALL
+  LocalPortRange 7552-7558
+  Jobname ZWE1*
+  Direction Inbound
+  Priority 100
+  TTLSGroupActionRef ZoweServerGroup
+  TTLSEnvironmentActionRef ZoweServerEnvAction
+  TTLSConnectionActionRef ZoweServerConnAction
+}
+
+# ── Inbound: caching service infinispan (peer replication) ────────────────────
+
+TTLSRule ZoweInboundInfinispan
+{
+  LocalAddr ALL
+  RemoteAddr ALL
+  LocalPortRange 7600-7601
+  Jobname ZWE1CS
+  Direction Inbound
+  Priority 100
+  TTLSGroupActionRef ZoweServerGroup
+  TTLSEnvironmentActionRef ZoweServerEnvAction
+  TTLSConnectionActionRef ZoweServerConnAction
+}

--- a/test/attls-checker/fixtures/attls-good-portref.txt
+++ b/test/attls-checker/fixtures/attls-good-portref.txt
@@ -1,0 +1,131 @@
+# attls-good-portref.txt
+#
+# GOOD: Same coverage as attls-good-complete.txt but uses PortRange declarations
+# (referenced via LocalPortRangeRef / RemotePortRangeRef) instead of inline port
+# ranges.  Tests the PortRange declaration resolution path.
+
+TTLSGroupAction ZoweServerGroup
+{
+  TTLSEnabled On
+}
+
+TTLSGroupAction ZoweClientGroup
+{
+  TTLSEnabled On
+}
+
+TTLSEnvironmentAction ZoweServerEnvAction
+{
+  HandshakeRole ServerWithClientAuth
+  TTLSKeyringParmsRef ZoweKeyring
+}
+
+TTLSEnvironmentAction ZoweClientEnvAction
+{
+  HandshakeRole Client
+  TTLSKeyringParmsRef ZoweKeyring
+}
+
+TTLSConnectionAction ZoweServerConnAction
+{
+  HandshakeRole ServerWithClientAuth
+}
+
+TTLSConnectionAction ZoweClientConnAction
+{
+  HandshakeRole Client
+}
+
+TTLSKeyringParms ZoweKeyring
+{
+  Keyring ZOWE/ZOWE_RING
+}
+
+# ── PortRange declarations ────────────────────────────────────────────────────
+
+PortRange zoweInboundPorts
+{
+  Port 7552-7558
+}
+
+PortRange zoweInfinispanPorts
+{
+  Port 7600-7601
+}
+
+PortRange zoweAllPorts
+{
+  Port 7552-7601
+}
+
+PortRange zosmfPort
+{
+  Port 443
+}
+
+PortRange ephemeralPorts
+{
+  Port 1024-65535
+}
+
+# ── Inbound: core services via PortRange ref ──────────────────────────────────
+
+TTLSRule ZoweInboundMain
+{
+  LocalAddr ALL
+  RemoteAddr ALL
+  LocalPortRangeRef zoweInboundPorts
+  Jobname ZWE1*
+  Direction Inbound
+  Priority 100
+  TTLSGroupActionRef ZoweServerGroup
+  TTLSEnvironmentActionRef ZoweServerEnvAction
+  TTLSConnectionActionRef ZoweServerConnAction
+}
+
+# ── Inbound: infinispan via PortRange ref ──────────────────────────────────────
+
+TTLSRule ZoweInboundInfinispan
+{
+  LocalAddr ALL
+  RemoteAddr ALL
+  LocalPortRangeRef zoweInfinispanPorts
+  Jobname ZWE1CS
+  Direction Inbound
+  Priority 100
+  TTLSGroupActionRef ZoweServerGroup
+  TTLSEnvironmentActionRef ZoweServerEnvAction
+  TTLSConnectionActionRef ZoweServerConnAction
+}
+
+# ── Outbound: internal Zowe traffic via PortRange ref ────────────────────────
+
+TTLSRule ZoweOutboundInternal
+{
+  LocalAddr ALL
+  LocalPortRangeRef ephemeralPorts
+  RemoteAddr ALL
+  RemotePortRangeRef zoweAllPorts
+  Jobname ZWE1*
+  Direction Outbound
+  Priority 100
+  TTLSGroupActionRef ZoweClientGroup
+  TTLSEnvironmentActionRef ZoweClientEnvAction
+  TTLSConnectionActionRef ZoweClientConnAction
+}
+
+# ── Outbound: z/OSMF via PortRange ref ───────────────────────────────────────
+
+TTLSRule ZoweOutboundZosmf
+{
+  LocalAddr ALL
+  LocalPortRangeRef ephemeralPorts
+  RemoteAddr ALL
+  RemotePortRangeRef zosmfPort
+  Jobname ZWE1A*
+  Direction Outbound
+  Priority 100
+  TTLSGroupActionRef ZoweClientGroup
+  TTLSEnvironmentActionRef ZoweClientEnvAction
+  TTLSConnectionActionRef ZoweClientConnAction
+}

--- a/test/attls-checker/fixtures/attls-good-single-service.txt
+++ b/test/attls-checker/fixtures/attls-good-single-service.txt
@@ -1,0 +1,181 @@
+# attls-good-single-service.txt
+#
+# GOOD: Complete AT-TLS coverage for Zowe running in single-service deployment
+# mode (components.apiml.enabled: true).
+#
+# In single-service mode:
+#   - api-catalog, discovery, gateway, caching-service, and zaas all run inside
+#     the single ZWE1AG job.
+#   - Only discovery (7553) and gateway (7554) have externally-exposed inbound
+#     ports.  api-catalog (7552), caching-service (7555), and zaas (7558) are
+#     internal to the process and require NO separate inbound rules.
+#   - app-server (ZWE1DS, 7556) and zss (ZWE1SZ, 7557) are unaffected and still
+#     need their own inbound rules.
+#   - Infinispan (7600/7601) runs inside ZWE1AG and needs inbound/outbound rules.
+#   - Cross-APIML outbound connections (gw→zaas, zaas→gw, →caching, etc.) do
+#     NOT need rules because they are in-process in the single service.
+#   - Required outbound: ZWE1AG→discovery (HA), ZWE1AG→app-server,
+#     ZWE1AG→zss, ZWE1AG→z/OSMF, ZWE1AG→infinispan.
+
+TTLSGroupAction ZoweServerGroup
+{
+  TTLSEnabled On
+}
+
+TTLSGroupAction ZoweClientGroup
+{
+  TTLSEnabled On
+}
+
+TTLSEnvironmentAction ZoweServerEnvAction
+{
+  HandshakeRole ServerWithClientAuth
+  TTLSKeyringParmsRef ZoweKeyring
+}
+
+TTLSEnvironmentAction ZoweClientEnvAction
+{
+  HandshakeRole Client
+  TTLSKeyringParmsRef ZoweKeyring
+}
+
+TTLSConnectionAction ZoweServerConnAction
+{
+  HandshakeRole ServerWithClientAuth
+}
+
+TTLSConnectionAction ZoweClientConnAction
+{
+  HandshakeRole Client
+}
+
+TTLSKeyringParms ZoweKeyring
+{
+  Keyring ZOWE/ZOWE_RING
+}
+
+# ── Inbound: discovery (7553) and gateway (7554) under ZWE1AG ─────────────────
+# Note: api-catalog (7552), caching-service (7555), zaas (7558) are internal
+# to the single-service process — NO inbound rules needed for those ports.
+
+TTLSRule ZoweInboundApiml
+{
+  LocalAddr ALL
+  RemoteAddr ALL
+  LocalPortRange 7553-7554
+  Jobname ZWE1AG
+  Direction Inbound
+  Priority 100
+  TTLSGroupActionRef ZoweServerGroup
+  TTLSEnvironmentActionRef ZoweServerEnvAction
+  TTLSConnectionActionRef ZoweServerConnAction
+}
+
+# ── Inbound: app-server (ZWE1SV, 7556) — cluster mode: STC holds the port ────
+
+TTLSRule ZoweInboundAppServer
+{
+  LocalAddr ALL
+  RemoteAddr ALL
+  LocalPortRange 7556
+  Jobname ZWE1SV
+  Direction Inbound
+  Priority 100
+  TTLSGroupActionRef ZoweServerGroup
+  TTLSEnvironmentActionRef ZoweServerEnvAction
+  TTLSConnectionActionRef ZoweServerConnAction
+}
+
+# ── Inbound: zss (ZWE1SZ, 7557) ──────────────────────────────────────────────
+
+TTLSRule ZoweInboundZss
+{
+  LocalAddr ALL
+  RemoteAddr ALL
+  LocalPortRange 7557
+  Jobname ZWE1SZ
+  Direction Inbound
+  Priority 100
+  TTLSGroupActionRef ZoweServerGroup
+  TTLSEnvironmentActionRef ZoweServerEnvAction
+  TTLSConnectionActionRef ZoweServerConnAction
+}
+
+# ── Inbound: caching-service infinispan (ZWE1AG, 7600-7601) ──────────────────
+
+TTLSRule ZoweInboundInfinispan
+{
+  LocalAddr ALL
+  RemoteAddr ALL
+  LocalPortRange 7600-7601
+  Jobname ZWE1AG
+  Direction Inbound
+  Priority 100
+  TTLSGroupActionRef ZoweServerGroup
+  TTLSEnvironmentActionRef ZoweServerEnvAction
+  TTLSConnectionActionRef ZoweServerConnAction
+}
+
+# ── Outbound: ZWE1AG → discovery (7553) for HA replica ───────────────────────
+
+TTLSRule ZoweOutboundDiscovery
+{
+  LocalAddr ALL
+  LocalPortRange 1024-65535
+  RemoteAddr ALL
+  RemotePortRange 7553
+  Jobname ZWE1AG
+  Direction Outbound
+  Priority 110
+  TTLSGroupActionRef ZoweClientGroup
+  TTLSEnvironmentActionRef ZoweClientEnvAction
+  TTLSConnectionActionRef ZoweClientConnAction
+}
+
+# ── Outbound: ZWE1AG → app-server (7556) and zss (7557) ──────────────────────
+
+TTLSRule ZoweOutboundAppZss
+{
+  LocalAddr ALL
+  LocalPortRange 1024-65535
+  RemoteAddr ALL
+  RemotePortRange 7556-7557
+  Jobname ZWE1*
+  Direction Outbound
+  Priority 100
+  TTLSGroupActionRef ZoweClientGroup
+  TTLSEnvironmentActionRef ZoweClientEnvAction
+  TTLSConnectionActionRef ZoweClientConnAction
+}
+
+# ── Outbound: ZWE1AG → infinispan (7600-7601) ────────────────────────────────
+
+TTLSRule ZoweOutboundInfinispan
+{
+  LocalAddr ALL
+  LocalPortRange 1024-65535
+  RemoteAddr ALL
+  RemotePortRange 7600-7601
+  Jobname ZWE1AG
+  Direction Outbound
+  Priority 100
+  TTLSGroupActionRef ZoweClientGroup
+  TTLSEnvironmentActionRef ZoweClientEnvAction
+  TTLSConnectionActionRef ZoweClientConnAction
+}
+
+# ── Outbound: ZWE1AG → z/OSMF (443) ─────────────────────────────────────────
+
+TTLSRule ZoweOutboundZosmf
+{
+  LocalAddr ALL
+  LocalPortRange 1024-65535
+  RemoteAddr ALL
+  RemotePortRange 443
+  Jobname ZWE1A*
+  Direction Outbound
+  Priority 100
+  TTLSGroupActionRef ZoweClientGroup
+  TTLSEnvironmentActionRef ZoweClientEnvAction
+  TTLSConnectionActionRef ZoweClientConnAction
+}

--- a/test/attls-checker/fixtures/zowe-apiml-single-service.yaml
+++ b/test/attls-checker/fixtures/zowe-apiml-single-service.yaml
@@ -1,0 +1,64 @@
+# Zowe zowe.yaml fixture: single-service deployment mode (components.apiml.enabled: true).
+#
+# When apiml.enabled is true, api-catalog, discovery, gateway, caching-service,
+# and zaas ALL run under the single ZWE1AG job.  Their individual enabled flags
+# are ignored by the AT-TLS checker.
+#
+# app-server (ZWE1DS) and zss (ZWE1SZ) are unaffected by single-service mode
+# and continue to run under their own job names.
+
+zowe:
+  job:
+    name: ZWE1SV
+    prefix: ZWE1
+  certificate:
+    keystore:
+      type: JCERACFKS
+      file: "safkeyring://ZOWE/ZOWE_RING"
+      alias: localhost
+    truststore:
+      type: JCERACFKS
+      file: "safkeyring://ZOWE/ZOWE_RING"
+  network:
+    server:
+      tls:
+        attls: true
+    client:
+      tls:
+        attls: true
+
+zOSMF:
+  host: zosmf.example.com
+  port: 443
+
+components:
+  apiml:
+    enabled: true
+
+  # Individual APIML component ports can still be configured in single-service
+  # mode. The enabled flags below are intentionally absent / irrelevant.
+  gateway:
+    port: 7554
+  discovery:
+    port: 7553
+  api-catalog:
+    port: 7552       # NOT an externally exposed inbound port in single-service
+  caching-service:
+    port: 7555       # NOT an externally exposed inbound port in single-service
+    storage:
+      mode: infinispan
+      infinispan:
+        jgroups:
+          port: 7600
+          keyExchange:
+            port: 7601
+  zaas:
+    port: 7558       # NOT an externally exposed inbound port in single-service
+
+  # app-server and zss are separate jobs, unaffected by apiml single-service
+  app-server:
+    enabled: true
+    port: 7556
+  zss:
+    enabled: true
+    port: 7557

--- a/test/attls-checker/fixtures/zowe-attls-disabled.yaml
+++ b/test/attls-checker/fixtures/zowe-attls-disabled.yaml
@@ -1,0 +1,41 @@
+# Zowe zowe.yaml fixture: AT-TLS disabled (default state).
+# Expected: checker reports "AT-TLS is disabled" and exits 0 — no rule checks needed.
+
+zowe:
+  job:
+    name: ZWE1SV
+    prefix: ZWE1
+  network:
+    server:
+      tls:
+        attls: false
+    client:
+      tls:
+        attls: false
+
+zOSMF:
+  host: zosmf.example.com
+  port: 443
+
+components:
+  gateway:
+    enabled: true
+    port: 7554
+  zaas:
+    enabled: true
+    port: 7558
+  api-catalog:
+    enabled: true
+    port: 7552
+  discovery:
+    enabled: true
+    port: 7553
+  caching-service:
+    enabled: true
+    port: 7555
+  app-server:
+    enabled: true
+    port: 7556
+  zss:
+    enabled: true
+    port: 7557

--- a/test/attls-checker/fixtures/zowe-custom-ports.yaml
+++ b/test/attls-checker/fixtures/zowe-custom-ports.yaml
@@ -1,0 +1,50 @@
+# Zowe zowe.yaml fixture: non-standard job prefix and custom ports.
+# job.prefix = ZPRD means job names are ZPRD + AG, ZPRD + AZ, etc.
+# Used to verify that the checker uses the prefix correctly.
+
+zowe:
+  job:
+    name: ZPRDSV
+    prefix: ZPRD
+  certificate:
+    keystore:
+      type: JCERACFKS
+      file: "safkeyring://ZPRD/ZPRD_RING"
+      alias: localhost
+    truststore:
+      type: JCERACFKS
+      file: "safkeyring://ZPRD/ZPRD_RING"
+  network:
+    server:
+      tls:
+        attls: true
+    client:
+      tls:
+        attls: true
+
+zOSMF:
+  host: zosmf.example.com
+  port: 10443
+
+components:
+  gateway:
+    enabled: true
+    port: 8554
+  zaas:
+    enabled: true
+    port: 8558
+  api-catalog:
+    enabled: true
+    port: 8552
+  discovery:
+    enabled: true
+    port: 8553
+  caching-service:
+    enabled: true
+    port: 8555
+  app-server:
+    enabled: true
+    port: 8556
+  zss:
+    enabled: true
+    port: 8557

--- a/test/attls-checker/fixtures/zowe-full-attls.yaml
+++ b/test/attls-checker/fixtures/zowe-full-attls.yaml
@@ -1,0 +1,56 @@
+# Zowe zowe.yaml fixture: AT-TLS fully enabled, all standard components on default ports.
+# Used by: scenario-complete tests (all-good cases).
+
+zowe:
+  job:
+    name: ZWE1SV
+    prefix: ZWE1
+  certificate:
+    keystore:
+      type: JCERACFKS
+      file: "safkeyring://ZOWE/ZOWE_RING"
+      alias: localhost
+    truststore:
+      type: JCERACFKS
+      file: "safkeyring://ZOWE/ZOWE_RING"
+  network:
+    server:
+      tls:
+        attls: true
+    client:
+      tls:
+        attls: true
+
+zOSMF:
+  host: zosmf.example.com
+  port: 443
+
+components:
+  gateway:
+    enabled: true
+    port: 7554
+  zaas:
+    enabled: true
+    port: 7558
+  api-catalog:
+    enabled: true
+    port: 7552
+  discovery:
+    enabled: true
+    port: 7553
+  caching-service:
+    enabled: true
+    port: 7555
+    storage:
+      mode: infinispan
+      infinispan:
+        jgroups:
+          port: 7600
+          keyExchange:
+            port: 7601
+  app-server:
+    enabled: true
+    port: 7556
+  zss:
+    enabled: true
+    port: 7557

--- a/test/attls-checker/fixtures/zowe-legacy-attls.yaml
+++ b/test/attls-checker/fixtures/zowe-legacy-attls.yaml
@@ -1,0 +1,79 @@
+# zowe-legacy-attls.yaml
+#
+# Fixture representing a pre-v2.18.4 Zowe AT-TLS configuration.
+# Old Zowe used:  components.<id>.server.ssl.enabled: false
+# instead of the current:  zowe.network.server.tls.attls: true
+#
+# The global zowe.network.server.tls.attls property did not exist in those
+# versions.  The checker must detect the legacy indicator on each component,
+# treat it as attls=true, and emit a strong upgrade warning.
+
+zowe:
+  job:
+    name: ZWE1SV
+    prefix: ZWE1
+  certificate:
+    keystore:
+      type: JCERACFKS
+      file: "safkeyring://ZOWE/ZOWE_RING"
+      alias: localhost
+    truststore:
+      type: JCERACFKS
+      file: "safkeyring://ZOWE/ZOWE_RING"
+
+zOSMF:
+  host: zosmf.example.com
+  port: 443
+
+components:
+  gateway:
+    enabled: true
+    port: 7554
+    server:
+      ssl:
+        enabled: false
+
+  zaas:
+    enabled: true
+    port: 7558
+    server:
+      ssl:
+        enabled: false
+
+  api-catalog:
+    enabled: true
+    port: 7552
+    server:
+      ssl:
+        enabled: false
+
+  discovery:
+    enabled: true
+    port: 7553
+    server:
+      ssl:
+        enabled: false
+
+  caching-service:
+    enabled: true
+    port: 7555
+    storage:
+      mode: infinispan
+      infinispan:
+        jgroups:
+          port: 7600
+          keyExchange:
+            port: 7601
+    server:
+      ssl:
+        enabled: false
+
+  # app-server and zss did not use server.ssl.enabled in old Zowe;
+  # they are not AT-TLS–enabled in this legacy configuration.
+  app-server:
+    enabled: true
+    port: 7556
+
+  zss:
+    enabled: true
+    port: 7557

--- a/test/attls-checker/fixtures/zowe-no-cluster.yaml
+++ b/test/attls-checker/fixtures/zowe-no-cluster.yaml
@@ -1,0 +1,54 @@
+# Zowe zowe.yaml fixture: app-server cluster mode DISABLED (ZLUX_NO_CLUSTER=1).
+#
+# When ZLUX_NO_CLUSTER=1, the app-server runs as a single non-clustered process
+# under ${prefix}DS (ZWE1DS).  There is no parent STC child-process split, so
+# the AT-TLS inbound rule for port 7556 must match ZWE1DS — NOT ZWE1SV.
+
+zowe:
+  job:
+    name: ZWE1SV
+    prefix: ZWE1
+  certificate:
+    keystore:
+      type: JCERACFKS
+      file: "safkeyring://ZOWE/ZOWE_RING"
+      alias: localhost
+    truststore:
+      type: JCERACFKS
+      file: "safkeyring://ZOWE/ZOWE_RING"
+  network:
+    server:
+      tls:
+        attls: true
+    client:
+      tls:
+        attls: true
+  environments:
+    ZLUX_NO_CLUSTER: 1
+
+zOSMF:
+  host: zosmf.example.com
+  port: 443
+
+components:
+  gateway:
+    enabled: true
+    port: 7554
+  zaas:
+    enabled: true
+    port: 7558
+  api-catalog:
+    enabled: true
+    port: 7552
+  discovery:
+    enabled: true
+    port: 7553
+  caching-service:
+    enabled: true
+    port: 7555
+  app-server:
+    enabled: true
+    port: 7556
+  zss:
+    enabled: true
+    port: 7557

--- a/test/attls-checker/fixtures/zowe-partial-attls.yaml
+++ b/test/attls-checker/fixtures/zowe-partial-attls.yaml
@@ -1,0 +1,61 @@
+# Zowe zowe.yaml fixture: per-component AT-TLS override.
+#
+# Global: zowe.network.server.tls.attls = true (AT-TLS on by default)
+# Override: components.api-catalog.zowe.network.server.tls.attls = false
+#           (API Catalog runs without AT-TLS — e.g. for testing or a legacy client)
+#
+# Expected behaviour:
+#   - All components except api-catalog have attls=true
+#   - api-catalog has attls=false → no inbound:api-catalog requirement
+#   - No mismatch warnings (no client.attls set anywhere)
+
+zowe:
+  job:
+    prefix: ZWE1
+    name: ZWE1SV
+  network:
+    server:
+      tls:
+        attls: true
+  certificate:
+    keystore:
+      type: JCERACFKS
+      file: "safkeyring://ZOWE/ZOWE_RING"
+
+zOSMF:
+  host: zosmf.example.com
+  port: 443
+
+components:
+  api-catalog:
+    enabled: true
+    port: 7552
+    zowe:
+      network:
+        server:
+          tls:
+            attls: false   # override: API Catalog does NOT use AT-TLS
+  discovery:
+    enabled: true
+    port: 7553
+  gateway:
+    enabled: true
+    port: 7554
+    storage:
+      infinispan:
+        jgroups:
+          port: 7600
+          keyExchange:
+            port: 7601
+  caching-service:
+    enabled: true
+    port: 7555
+  app-server:
+    enabled: true
+    port: 7556
+  zss:
+    enabled: true
+    port: 7557
+  zaas:
+    enabled: true
+    port: 7558

--- a/test/attls-checker/fixtures/zowe-server-attls-only.yaml
+++ b/test/attls-checker/fixtures/zowe-server-attls-only.yaml
@@ -1,0 +1,49 @@
+# Zowe zowe.yaml fixture: only inbound AT-TLS enabled, no outbound.
+# Used to verify that outbound checks are skipped when client.attls=false.
+
+zowe:
+  job:
+    name: ZWE1SV
+    prefix: ZWE1
+  certificate:
+    keystore:
+      type: JCERACFKS
+      file: "safkeyring://ZOWE/ZOWE_RING"
+      alias: localhost
+    truststore:
+      type: JCERACFKS
+      file: "safkeyring://ZOWE/ZOWE_RING"
+  network:
+    server:
+      tls:
+        attls: true
+    client:
+      tls:
+        attls: false
+
+zOSMF:
+  host: zosmf.example.com
+  port: 443
+
+components:
+  gateway:
+    enabled: true
+    port: 7554
+  zaas:
+    enabled: true
+    port: 7558
+  api-catalog:
+    enabled: true
+    port: 7552
+  discovery:
+    enabled: true
+    port: 7553
+  caching-service:
+    enabled: true
+    port: 7555
+  app-server:
+    enabled: true
+    port: 7556
+  zss:
+    enabled: true
+    port: 7557

--- a/test/attls-checker/fixtures/zowe-with-extension.yaml
+++ b/test/attls-checker/fixtures/zowe-with-extension.yaml
@@ -1,0 +1,58 @@
+# Zowe zowe.yaml fixture: includes unknown extension components.
+#
+# The "widget" component is a hypothetical Zowe plugin at port 7590.
+# It is enabled but not in the known COMPONENT_META list — the checker
+# cannot validate its AT-TLS coverage, but should warn about it.
+#
+# "foobar" is another hypothetical plugin that is DISABLED — should be
+# ignored (not appear in unknownComponents).
+#
+# "noport" is an enabled plugin with no port configured — should also be
+# ignored since it has no AT-TLS relevance.
+#
+# Standard AT-TLS is enabled globally; known components use default ports.
+
+zowe:
+  job:
+    prefix: ZWE1
+    name: ZWE1SV
+  network:
+    server:
+      tls:
+        attls: true
+  certificate:
+    keystore:
+      type: JCERACFKS
+      file: "safkeyring://ZOWE/ZOWE_RING"
+
+zOSMF:
+  host: zosmf.example.com
+  port: 443
+
+components:
+  gateway:
+    enabled: true
+    port: 7554
+  discovery:
+    enabled: true
+    port: 7553
+  app-server:
+    enabled: true
+    port: 7556
+  zss:
+    enabled: true
+    port: 7557
+
+  # Unknown extension component — enabled, should appear in unknownComponents
+  widget:
+    enabled: true
+    port: 7590
+
+  # Unknown extension component — disabled, should NOT appear in unknownComponents
+  foobar:
+    enabled: false
+    port: 7591
+
+  # Unknown extension component — enabled but no port, should NOT appear
+  noport:
+    enabled: true

--- a/test/attls-checker/test.js
+++ b/test/attls-checker/test.js
@@ -1,0 +1,1399 @@
+/*
+  This program and the accompanying materials are
+  made available under the terms of the Eclipse Public License v2.0 which accompanies
+  this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
+
+  SPDX-License-Identifier: EPL-2.0
+
+  Copyright Contributors to the Zowe Project.
+*/
+
+'use strict';
+
+const path   = require('path');
+const fs     = require('fs');
+const chai   = require('chai');
+const expect = chai.expect;
+
+const checker = require('../../utils/attlsChecker');
+const {
+  parseAttlsFile,
+  parseZoweYaml,
+  buildRequiredConnections,
+  checkCoverage,
+  summariseResults,
+  findRulesAffectingExtensions,
+  _internal,
+} = checker;
+
+// ── Fixture loader ────────────────────────────────────────────────────────────
+
+const FIX = path.join(__dirname, 'fixtures');
+
+function loadAttls(name) {
+  return fs.readFileSync(path.join(FIX, name), 'utf8');
+}
+
+function loadYaml(name) {
+  return fs.readFileSync(path.join(FIX, name), 'utf8');
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// _internal.portRangeCoversPort
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('_internal.portRangeCoversPort', function () {
+  const { portRangeCoversPort } = _internal;
+
+  it('returns true for "ALL"', function () {
+    expect(portRangeCoversPort('ALL', 7554)).to.be.true;
+    expect(portRangeCoversPort('all', 80)).to.be.true;
+  });
+
+  it('returns true for exact single-port match', function () {
+    expect(portRangeCoversPort('7554', 7554)).to.be.true;
+  });
+
+  it('returns false for exact single-port non-match', function () {
+    expect(portRangeCoversPort('7554', 7553)).to.be.false;
+  });
+
+  it('returns true when port falls inside range', function () {
+    expect(portRangeCoversPort('7552-7558', 7552)).to.be.true;
+    expect(portRangeCoversPort('7552-7558', 7555)).to.be.true;
+    expect(portRangeCoversPort('7552-7558', 7558)).to.be.true;
+  });
+
+  it('returns false when port is outside range', function () {
+    expect(portRangeCoversPort('7552-7558', 7551)).to.be.false;
+    expect(portRangeCoversPort('7552-7558', 7559)).to.be.false;
+  });
+
+  it('returns false for falsy portStr', function () {
+    expect(portRangeCoversPort('', 7554)).to.be.false;
+    expect(portRangeCoversPort(null, 7554)).to.be.false;
+    expect(portRangeCoversPort(undefined, 7554)).to.be.false;
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// _internal.jobnameMatches
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('_internal.jobnameMatches', function () {
+  const { jobnameMatches } = _internal;
+
+  it('returns true for exact match (case-insensitive)', function () {
+    expect(jobnameMatches('ZWE1AG', 'ZWE1AG')).to.be.true;
+    expect(jobnameMatches('zwe1ag', 'ZWE1AG')).to.be.true;
+  });
+
+  it('returns false for exact non-match', function () {
+    expect(jobnameMatches('ZWE1AG', 'ZWE1AC')).to.be.false;
+  });
+
+  it('matches with trailing wildcard', function () {
+    expect(jobnameMatches('ZWE1*', 'ZWE1AG')).to.be.true;
+    expect(jobnameMatches('ZWE1*', 'ZWE1CS')).to.be.true;
+    expect(jobnameMatches('ZWE1A*', 'ZWE1AG')).to.be.true;
+    expect(jobnameMatches('ZWE1A*', 'ZWE1AZ')).to.be.true;
+  });
+
+  it('does not match when wildcard prefix does not match', function () {
+    expect(jobnameMatches('ZWE1A*', 'ZWE1CS')).to.be.false;
+    expect(jobnameMatches('MYCICS*', 'ZWE1AG')).to.be.false;
+  });
+
+  it('returns true for empty / absent pattern (matches all)', function () {
+    expect(jobnameMatches('', 'ZWE1AG')).to.be.true;
+    expect(jobnameMatches(null, 'ZWE1AG')).to.be.true;
+    expect(jobnameMatches(undefined, 'ZWE1AG')).to.be.true;
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// parseAttlsFile
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('parseAttlsFile', function () {
+  it('parses a minimal TTLSGroupAction declaration', function () {
+    const content = `TTLSGroupAction MyGroup\n{\n  TTLSEnabled On\n}\n`;
+    const { declarations } = parseAttlsFile(content);
+    expect(declarations.has('MyGroup')).to.be.true;
+    const decl = declarations.get('MyGroup');
+    expect(decl.typeName).to.equal('TTLSGroupAction');
+    expect(decl.props['TTLSEnabled']).to.equal('On');
+  });
+
+  it('strips comments before parsing', function () {
+    const content = `# leading comment\nTTLSGroupAction Grp1\n{\n  TTLSEnabled On # inline\n}\n`;
+    const { declarations } = parseAttlsFile(content);
+    expect(declarations.has('Grp1')).to.be.true;
+  });
+
+  it('parses nested block without absorbing its outer block', function () {
+    const content = [
+      'TTLSGroupAction GrpOuter',
+      '{',
+      '  TTLSEnabled On',
+      '}',
+      'TTLSRule MyRule',
+      '{',
+      '  LocalPortRange 7554',
+      '  Jobname ZWE1AG',
+      '  Direction Inbound',
+      '  Priority 100',
+      '  TTLSGroupActionRef GrpOuter',
+      '}',
+    ].join('\n');
+    const { declarations } = parseAttlsFile(content);
+    expect(declarations.has('GrpOuter')).to.be.true;
+    expect(declarations.has('MyRule')).to.be.true;
+    expect(declarations.get('MyRule').props['LocalPortRange']).to.equal('7554');
+  });
+
+  it('uses the first declaration when duplicate names appear', function () {
+    const content = [
+      'TTLSGroupAction Dup\n{\n  TTLSEnabled On\n}',
+      'TTLSGroupAction Dup\n{\n  TTLSEnabled Off\n}',
+    ].join('\n');
+    const { declarations } = parseAttlsFile(content);
+    expect(declarations.get('Dup').props['TTLSEnabled']).to.equal('On');
+  });
+
+  it('preserves # embedded in a rule name (not treated as comment start)', function () {
+    // AT-TLS policy files use '#' as a numbering convention in names like
+    // "MyRule#2_Client".  The comment-stripper must only treat '#' as a
+    // comment delimiter when it is at the start of the line or preceded by
+    // whitespace, NOT when it is embedded in an identifier.
+    const content = [
+      'TTLSGroupAction Grp\n{\n  TTLSEnabled On\n}',
+      'TTLSRule MyRule#1_Client\n{\n  Jobname AAA*\n  Direction Outbound\n  Priority 250\n  TTLSGroupActionRef Grp\n}',
+      'TTLSRule MyRule#2_Client\n{\n  Jobname BBB*\n  Direction Outbound\n  Priority 250\n  TTLSGroupActionRef Grp\n}',
+    ].join('\n');
+    const { declarations } = parseAttlsFile(content);
+    expect(declarations.has('MyRule#1_Client')).to.be.true;
+    expect(declarations.has('MyRule#2_Client')).to.be.true;
+    expect(declarations.get('MyRule#1_Client').props['Jobname']).to.equal('AAA*');
+    expect(declarations.get('MyRule#2_Client').props['Jobname']).to.equal('BBB*');
+  });
+
+  it('still strips a trailing inline comment separated by whitespace', function () {
+    const content = 'TTLSGroupAction Grp\n{\n  TTLSEnabled On # this is a comment\n}\n';
+    const { declarations } = parseAttlsFile(content);
+    // TTLSEnabled value should not include "# this is a comment"
+    expect(declarations.get('Grp').props['TTLSEnabled']).to.equal('On');
+  });
+
+  it('parses all declarations in attls-good-complete.txt', function () {
+    const { declarations } = parseAttlsFile(loadAttls('attls-good-complete.txt'));
+    expect(declarations.has('ZoweServerGroup')).to.be.true;
+    expect(declarations.has('ZoweClientGroup')).to.be.true;
+    expect(declarations.has('ZoweInboundMain')).to.be.true;
+    expect(declarations.has('ZoweInboundInfinispan')).to.be.true;
+    expect(declarations.has('ZoweOutboundInternal')).to.be.true;
+    expect(declarations.has('ZoweOutboundZosmf')).to.be.true;
+  });
+
+  it('parses PortRange declarations from attls-good-portref.txt', function () {
+    const { declarations } = parseAttlsFile(loadAttls('attls-good-portref.txt'));
+    expect(declarations.has('zoweInboundPorts')).to.be.true;
+    expect(declarations.get('zoweInboundPorts').typeName).to.equal('PortRange');
+    expect(declarations.get('zoweInboundPorts').props['Port']).to.equal('7552-7558');
+  });
+
+  it('returns empty declarations for attls-bad-empty.txt (no TTLSRule)', function () {
+    const { declarations } = parseAttlsFile(loadAttls('attls-bad-empty.txt'));
+    // Should have non-TTLSRule declarations but zero TTLSRule entries
+    let ruleCount = 0;
+    for (const [, d] of declarations) if (d.typeName === 'TTLSRule') ruleCount++;
+    expect(ruleCount).to.equal(0);
+  });
+
+  // ── Indented declarations ──────────────────────────────────────────────────
+  // Some production AT-TLS files indent all stanzas (e.g. pagent_TTLS.conf.txt).
+  // The parser must not silently drop such rules.
+
+  it('parses declarations that are indented with leading spaces', function () {
+    const content = [
+      ' TTLSGroupAction IndentedGroup',
+      ' {',
+      '   TTLSEnabled On',
+      ' }',
+      ' TTLSRule IndentedRule',
+      ' {',
+      '   LocalPortRange 7554',
+      '   Direction Inbound',
+      '   Priority 100',
+      '   TTLSGroupActionRef IndentedGroup',
+      ' }',
+    ].join('\n');
+    const { declarations } = parseAttlsFile(content);
+    expect(declarations.has('IndentedGroup')).to.be.true;
+    expect(declarations.has('IndentedRule')).to.be.true;
+    expect(declarations.get('IndentedRule').props['LocalPortRange']).to.equal('7554');
+  });
+
+  it('parses declarations indented with tabs', function () {
+    const content = '\tTTLSGroupAction TabGroup\n\t{\n\t  TTLSEnabled On\n\t}\n';
+    const { declarations } = parseAttlsFile(content);
+    expect(declarations.has('TabGroup')).to.be.true;
+  });
+
+  // ── Parse warnings ─────────────────────────────────────────────────────────
+
+  it('returns empty parseWarnings for a well-formed file', function () {
+    const { parseWarnings } = parseAttlsFile(loadAttls('attls-good-complete.txt'));
+    expect(parseWarnings).to.have.length(0);
+  });
+
+  it('warns about bare "..." lines (unexpected syntax outside a block)', function () {
+    const content = [
+      'TTLSGroupAction Grp\n{\n  TTLSEnabled On\n}',
+      '...',
+      'TTLSRule MyRule\n{\n  LocalPortRange 7554\n  Direction Inbound\n  Priority 100\n  TTLSGroupActionRef Grp\n}',
+    ].join('\n');
+    const { declarations, parseWarnings } = parseAttlsFile(content);
+    // The rule and group must still be parsed
+    expect(declarations.has('MyRule')).to.be.true;
+    expect(declarations.has('Grp')).to.be.true;
+    // And we must get one unexpected-syntax warning for the "..." line
+    const syntaxWarns = parseWarnings.filter(w => w.type === 'unexpected-syntax');
+    expect(syntaxWarns).to.have.length(1);
+    expect(syntaxWarns[0].content).to.equal('...');
+  });
+
+  it('warns for each unexpected-syntax line and records its line number', function () {
+    // Use lines that cannot be mistaken for a TypeName ItemName declaration
+    const content = 'TTLSGroupAction G\n{\n  TTLSEnabled On\n}\n???\n===section===\n';
+    const { parseWarnings } = parseAttlsFile(content);
+    const syntaxWarns = parseWarnings.filter(w => w.type === 'unexpected-syntax');
+    expect(syntaxWarns).to.have.length(2);
+    expect(syntaxWarns.map(w => w.content)).to.include.members(['???', '===section===']);
+  });
+
+  it('does not warn for blank lines outside blocks', function () {
+    const content = 'TTLSGroupAction G\n{\n  TTLSEnabled On\n}\n\n\n';
+    const { parseWarnings } = parseAttlsFile(content);
+    expect(parseWarnings.filter(w => w.type === 'unexpected-syntax')).to.have.length(0);
+  });
+
+  // ── Invalid Jobname warnings ───────────────────────────────────────────────
+
+  it('warns about Jobname patterns containing "." (regex/glob confusion)', function () {
+    const content = [
+      'TTLSGroupAction Grp\n{\n  TTLSEnabled On\n}',
+      'TTLSRule BadJobname\n{\n  Jobname ZWE1AG.*\n  Direction Outbound\n  Priority 100\n  TTLSGroupActionRef Grp\n}',
+    ].join('\n');
+    const { parseWarnings } = parseAttlsFile(content);
+    const jnWarns = parseWarnings.filter(w => w.type === 'invalid-jobname');
+    expect(jnWarns).to.have.length(1);
+    expect(jnWarns[0].rule).to.equal('BadJobname');
+    expect(jnWarns[0].jobname).to.equal('ZWE1AG.*');
+  });
+
+  it('does not warn for valid Jobname patterns (ZWE*, ZWE1AG, ZWE1*)', function () {
+    const content = [
+      'TTLSGroupAction Grp\n{\n  TTLSEnabled On\n}',
+      'TTLSRule R1\n{\n  Jobname ZWE*\n  Direction Outbound\n  Priority 100\n  TTLSGroupActionRef Grp\n}',
+      'TTLSRule R2\n{\n  Jobname ZWE1AG\n  Direction Inbound\n  Priority 100\n  TTLSGroupActionRef Grp\n}',
+    ].join('\n');
+    const { parseWarnings } = parseAttlsFile(content);
+    expect(parseWarnings.filter(w => w.type === 'invalid-jobname')).to.have.length(0);
+  });
+
+  it('warns for rules with no Jobname that would shadow via unexpected-syntax orphans', function () {
+    // Regression: a rule with no Jobname is valid (matches any job) — should not warn
+    const content = 'TTLSGroupAction G\n{\n  TTLSEnabled On\n}\nTTLSRule NoJobname\n{\n  Direction Inbound\n  Priority 100\n  TTLSGroupActionRef G\n}\n';
+    const { parseWarnings } = parseAttlsFile(content);
+    expect(parseWarnings.filter(w => w.type === 'invalid-jobname')).to.have.length(0);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// parseZoweYaml
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('parseZoweYaml', function () {
+  it('reads serverAttls and no clientAttlsMismatches from zowe-full-attls.yaml', function () {
+    const cfg = parseZoweYaml(loadYaml('zowe-full-attls.yaml'));
+    expect(cfg.serverAttls).to.be.true;
+    // client.attls matches server.attls — no mismatches
+    expect(cfg.clientAttlsMismatches).to.have.length(0);
+  });
+
+  it('reads job prefix and all 7 components from zowe-full-attls.yaml', function () {
+    const cfg = parseZoweYaml(loadYaml('zowe-full-attls.yaml'));
+    expect(cfg.jobPrefix).to.equal('ZWE1');
+    expect(cfg.enabledComponents).to.have.length(7);
+  });
+
+  it('reads infinispan ports from zowe-full-attls.yaml', function () {
+    const cfg = parseZoweYaml(loadYaml('zowe-full-attls.yaml'));
+    expect(cfg.infinispanPorts).to.have.length(2);
+    const ports = cfg.infinispanPorts.map(p => p.port);
+    expect(ports).to.include(7600);
+    expect(ports).to.include(7601);
+  });
+
+  it('reports serverAttls=false and no mismatches for zowe-attls-disabled.yaml', function () {
+    const cfg = parseZoweYaml(loadYaml('zowe-attls-disabled.yaml'));
+    expect(cfg.serverAttls).to.be.false;
+    // No client attls key in that fixture at all
+    expect(cfg.clientAttlsMismatches).to.have.length(0);
+  });
+
+  it('reads custom prefix and ports from zowe-custom-ports.yaml', function () {
+    const cfg = parseZoweYaml(loadYaml('zowe-custom-ports.yaml'));
+    expect(cfg.jobPrefix).to.equal('ZPRD');
+    const gw = cfg.enabledComponents.find(c => c.id === 'gateway');
+    expect(gw).to.exist;
+    expect(gw.port).to.equal(8554);
+    expect(gw.jobName).to.equal('ZPRDAG');
+  });
+
+  it('throws on invalid YAML', function () {
+    expect(() => parseZoweYaml(': bad:\n  {{oops')).to.throw(/YAML parse error/);
+  });
+
+  it('reads z/OSMF port from zowe-custom-ports.yaml', function () {
+    const cfg = parseZoweYaml(loadYaml('zowe-custom-ports.yaml'));
+    expect(cfg.zosmf.port).to.equal(10443);
+  });
+
+  it('reads zoweKeyring from SAF keyring URI in zowe-full-attls.yaml', function () {
+    const cfg = parseZoweYaml(loadYaml('zowe-full-attls.yaml'));
+    expect(cfg.zoweKeyring).to.equal('ZOWE/ZOWE_RING');
+  });
+
+  it('reads zoweKeyring from custom-prefix yaml ZPRD/ZPRD_RING', function () {
+    const cfg = parseZoweYaml(loadYaml('zowe-custom-ports.yaml'));
+    expect(cfg.zoweKeyring).to.equal('ZPRD/ZPRD_RING');
+  });
+
+  it('returns null zoweKeyring when no certificate section is present', function () {
+    const cfg = parseZoweYaml(loadYaml('zowe-attls-disabled.yaml'));
+    expect(cfg.zoweKeyring).to.be.null;
+  });
+
+  it('detects single-service mode when components.apiml.enabled is true', function () {
+    const cfg = parseZoweYaml(loadYaml('zowe-apiml-single-service.yaml'));
+    expect(cfg.apimlSingleService).to.be.true;
+  });
+
+  it('reports apimlSingleService=false for multi-service yaml', function () {
+    const cfg = parseZoweYaml(loadYaml('zowe-full-attls.yaml'));
+    expect(cfg.apimlSingleService).to.be.false;
+  });
+
+  it('sets jobName to ${prefix}AG for all bundled APIML components in single-service mode', function () {
+    const cfg = parseZoweYaml(loadYaml('zowe-apiml-single-service.yaml'));
+    const bundled = ['api-catalog', 'discovery', 'gateway', 'caching-service', 'zaas'];
+    for (const id of bundled) {
+      const c = cfg.enabledComponents.find(e => e.id === id);
+      expect(c, `${id} should be in enabledComponents`).to.exist;
+      expect(c.jobName, `${id} should run under ZWE1AG`).to.equal('ZWE1AG');
+    }
+  });
+
+  it('keeps app-server and zss under their own jobs in single-service mode', function () {
+    const cfg = parseZoweYaml(loadYaml('zowe-apiml-single-service.yaml'));
+    const app = cfg.enabledComponents.find(c => c.id === 'app-server');
+    const zss = cfg.enabledComponents.find(c => c.id === 'zss');
+    expect(app).to.exist;
+    expect(app.jobName).to.equal('ZWE1DS');
+    expect(zss).to.exist;
+    expect(zss.jobName).to.equal('ZWE1SZ');
+  });
+
+  it('detects infinispan ports from caching-service config in single-service mode', function () {
+    const cfg = parseZoweYaml(loadYaml('zowe-apiml-single-service.yaml'));
+    expect(cfg.infinispanPorts).to.have.length(2);
+    const ports = cfg.infinispanPorts.map(p => p.port);
+    expect(ports).to.include(7600);
+    expect(ports).to.include(7601);
+  });
+
+  describe('per-component AT-TLS overrides', function () {
+    let cfg;
+    before(function () {
+      cfg = parseZoweYaml(loadYaml('zowe-partial-attls.yaml'));
+    });
+
+    it('api-catalog has attls=false when components.api-catalog.zowe.network.server.tls.attls is false', function () {
+      const ac = cfg.enabledComponents.find(c => c.id === 'api-catalog');
+      expect(ac).to.exist;
+      expect(ac.attls).to.be.false;
+    });
+
+    it('all other components inherit the global serverAttls=true', function () {
+      const others = cfg.enabledComponents.filter(c => c.id !== 'api-catalog');
+      for (const c of others) {
+        expect(c.attls, `${c.id} should have attls=true`).to.be.true;
+      }
+    });
+
+    it('records no clientAttlsMismatches when no client.attls key is set', function () {
+      expect(cfg.clientAttlsMismatches).to.have.length(0);
+    });
+  });
+
+  describe('client/server attls mismatch detection', function () {
+    it('records a global mismatch when client.attls differs from server.attls', function () {
+      const cfg = parseZoweYaml(loadYaml('zowe-server-attls-only.yaml'));
+      expect(cfg.clientAttlsMismatches).to.have.length(1);
+      expect(cfg.clientAttlsMismatches[0].context).to.equal('global (zowe.network)');
+      expect(cfg.clientAttlsMismatches[0].serverAttls).to.be.true;
+      expect(cfg.clientAttlsMismatches[0].clientAttls).to.be.false;
+    });
+
+    it('records no mismatch when client.attls matches server.attls', function () {
+      const cfg = parseZoweYaml(loadYaml('zowe-full-attls.yaml'));
+      expect(cfg.clientAttlsMismatches).to.have.length(0);
+    });
+
+    it('records no mismatch when client.attls is absent', function () {
+      const cfg = parseZoweYaml(loadYaml('zowe-partial-attls.yaml'));
+      expect(cfg.clientAttlsMismatches).to.have.length(0);
+    });
+  });
+
+  // ─── Legacy AT-TLS (pre-v2.18.4): components.<id>.server.ssl.enabled: false ─
+
+  describe('legacy AT-TLS detection (pre-v2.18.4: server.ssl.enabled: false)', function () {
+    let cfg;
+    before(function () {
+      cfg = parseZoweYaml(loadYaml('zowe-legacy-attls.yaml'));
+    });
+
+    it('populates legacyAttlsComponents for each component using the old flag', function () {
+      expect(cfg.legacyAttlsComponents).to.be.an('array');
+      expect(cfg.legacyAttlsComponents).to.include('gateway');
+      expect(cfg.legacyAttlsComponents).to.include('discovery');
+      expect(cfg.legacyAttlsComponents).to.include('api-catalog');
+      expect(cfg.legacyAttlsComponents).to.include('zaas');
+      expect(cfg.legacyAttlsComponents).to.include('caching-service');
+    });
+
+    it('does not include app-server or zss in legacyAttlsComponents (they lack the flag)', function () {
+      expect(cfg.legacyAttlsComponents).to.not.include('app-server');
+      expect(cfg.legacyAttlsComponents).to.not.include('zss');
+    });
+
+    it('treats legacy components as attls=true', function () {
+      for (const id of ['gateway', 'discovery', 'api-catalog', 'zaas', 'caching-service']) {
+        const c = cfg.enabledComponents.find(e => e.id === id);
+        expect(c, `component ${id} missing`).to.exist;
+        expect(c.attls, `${id} should have attls=true`).to.be.true;
+      }
+    });
+
+    it('leaves app-server and zss with attls=false (no legacy or new-style flag)', function () {
+      const app = cfg.enabledComponents.find(e => e.id === 'app-server');
+      const zss = cfg.enabledComponents.find(e => e.id === 'zss');
+      expect(app.attls).to.be.false;
+      expect(zss.attls).to.be.false;
+    });
+
+    it('returns legacyAttlsComponents=[] for a modern config (no ssl.enabled flag)', function () {
+      const modernCfg = parseZoweYaml(loadYaml('zowe-full-attls.yaml'));
+      expect(modernCfg.legacyAttlsComponents).to.have.length(0);
+    });
+
+    it('works with inline yaml: single old-style component produces legacyAttlsComponents entry', function () {
+      const content = [
+        'zowe:',
+        '  job:',
+        '    name: ZWE1SV',
+        '    prefix: ZWE1',
+        'components:',
+        '  gateway:',
+        '    enabled: true',
+        '    port: 7554',
+        '    server:',
+        '      ssl:',
+        '        enabled: false',
+      ].join('\n');
+      const c = parseZoweYaml(content);
+      expect(c.legacyAttlsComponents).to.deep.equal(['gateway']);
+      const gw = c.enabledComponents.find(e => e.id === 'gateway');
+      expect(gw.attls).to.be.true;
+    });
+
+    it('new-style zowe.network.server.tls.attls takes precedence over legacy flag', function () {
+      // If both old and new flags are present, the new-style value wins for attls,
+      // but the component is still recorded in legacyAttlsComponents for the warning.
+      const content = [
+        'zowe:',
+        '  job:',
+        '    name: ZWE1SV',
+        '    prefix: ZWE1',
+        '  network:',
+        '    server:',
+        '      tls:',
+        '        attls: true',
+        'components:',
+        '  gateway:',
+        '    enabled: true',
+        '    port: 7554',
+        '    server:',
+        '      ssl:',
+        '        enabled: false',
+        '  discovery:',
+        '    enabled: true',
+        '    port: 7553',
+        '    zowe:',
+        '      network:',
+        '        server:',
+        '          tls:',
+        '            attls: false',
+        '    server:',
+        '      ssl:',
+        '        enabled: false',
+      ].join('\n');
+      const c = parseZoweYaml(content);
+      // gateway has legacy flag + global new-style=true → attls=true (global wins via fallback)
+      const gw = c.enabledComponents.find(e => e.id === 'gateway');
+      expect(gw.attls).to.be.true;
+      // discovery has per-component new-style=false → attls=false (new-style takes precedence)
+      const disc = c.enabledComponents.find(e => e.id === 'discovery');
+      expect(disc.attls).to.be.false;
+      // both should be in legacyAttlsComponents since they both have ssl.enabled: false
+      expect(c.legacyAttlsComponents).to.include('gateway');
+      expect(c.legacyAttlsComponents).to.include('discovery');
+    });
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// parseZoweYaml — unknown/extension components
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('parseZoweYaml — unknown extension components', function () {
+  it('collects enabled unknown components in unknownComponents', function () {
+    const cfg = parseZoweYaml(loadYaml('zowe-with-extension.yaml'));
+    expect(cfg.unknownComponents).to.have.length(1);
+    expect(cfg.unknownComponents[0].id).to.equal('widget');
+    expect(cfg.unknownComponents[0].port).to.equal(7590);
+  });
+
+  it('does not include disabled unknown components', function () {
+    const cfg = parseZoweYaml(loadYaml('zowe-with-extension.yaml'));
+    expect(cfg.unknownComponents.map(c => c.id)).to.not.include('foobar');
+  });
+
+  it('does not include portless unknown components', function () {
+    const cfg = parseZoweYaml(loadYaml('zowe-with-extension.yaml'));
+    expect(cfg.unknownComponents.map(c => c.id)).to.not.include('noport');
+  });
+
+  it('returns an empty unknownComponents array when all components are known', function () {
+    const cfg = parseZoweYaml(loadYaml('zowe-full-attls.yaml'));
+    expect(cfg.unknownComponents).to.have.length(0);
+  });
+
+  it('does not include "apiml" in unknownComponents (it is a deployment-mode flag)', function () {
+    const cfg = parseZoweYaml(loadYaml('zowe-apiml-single-service.yaml'));
+    expect(cfg.unknownComponents.map(c => c.id)).to.not.include('apiml');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// _internal.findRulesAffectingExtensions
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('_internal.findRulesAffectingExtensions', function () {
+  const { findRulesAffectingExtensions } = _internal;
+  // The widget extension component is on port 7590 (from zowe-with-extension.yaml).
+  // ZoweInboundMain covers 7552-7558, ZoweOutboundInternal covers all outbound.
+  // Port 7590 is NOT inside 7552-7558, but ZoweOutboundInternal has no LocalPortRange
+  // restriction → resolves to 0-65535 → covers 7590.
+  // We use port 7590 throughout so it matches the fixture intent.
+  const EXT_PORTS = [7590];
+
+  it('returns rules whose jobname pattern matches the extension probe job (ZWE1X*) AND cover an extension port', function () {
+    const { declarations } = parseAttlsFile(loadAttls('attls-good-complete.txt'));
+    const rules = findRulesAffectingExtensions(declarations, 'ZWE1', EXT_PORTS);
+    const names = rules.map(r => r.name);
+    // ZoweOutboundInternal: Jobname ZWE1*, no LocalPortRange → covers all ports → matches
+    expect(names).to.include('ZoweOutboundInternal');
+  });
+
+  it('excludes rules whose port range does not cover any extension port', function () {
+    const { declarations } = parseAttlsFile(loadAttls('attls-good-complete.txt'));
+    const rules = findRulesAffectingExtensions(declarations, 'ZWE1', EXT_PORTS);
+    const names = rules.map(r => r.name);
+    // ZoweInboundMain covers 7552-7558 — port 7590 is outside that range
+    expect(names).to.not.include('ZoweInboundMain');
+    // ZoweInboundInfinispan: Jobname ZWE1CS — already excluded by jobname; port 7590 outside 7600-7601 too
+    expect(names).to.not.include('ZoweInboundInfinispan');
+  });
+
+  it('does not return rules with specific jobname patterns that cannot match ZWE1X*', function () {
+    const { declarations } = parseAttlsFile(loadAttls('attls-good-complete.txt'));
+    const rules = findRulesAffectingExtensions(declarations, 'ZWE1', [443]);
+    const names = rules.map(r => r.name);
+    // ZoweOutboundZosmf uses Jobname ZWE1A* — cannot match ZWE1XEXT
+    expect(names).to.not.include('ZoweOutboundZosmf');
+  });
+
+  it('returns an empty array when no rules exist', function () {
+    const { declarations } = parseAttlsFile(loadAttls('attls-bad-empty.txt'));
+    const rules = findRulesAffectingExtensions(declarations, 'ZWE1', EXT_PORTS);
+    expect(rules).to.have.length(0);
+  });
+
+  it('returns an empty array when extensionPorts is empty', function () {
+    const { declarations } = parseAttlsFile(loadAttls('attls-good-complete.txt'));
+    expect(findRulesAffectingExtensions(declarations, 'ZWE1', [])).to.have.length(0);
+    expect(findRulesAffectingExtensions(declarations, 'ZWE1')).to.have.length(0);
+  });
+
+  it('includes correct ttlsEnabled status for each rule', function () {
+    const { declarations } = parseAttlsFile(loadAttls('attls-good-complete.txt'));
+    const rules = findRulesAffectingExtensions(declarations, 'ZWE1', EXT_PORTS);
+    for (const r of rules) {
+      expect(r.ttlsEnabled).to.be.a('boolean');
+    }
+  });
+
+  it('returns Off rules too — detects when extension jobs are explicitly disabled', function () {
+    // attls-bad-partial-shadow.txt: ZoweOffGatewayZaasAppServer has Jobname ZWE1* +
+    // LocalPortRange 7554/7556/7558 — none of which are 7590, so it won't match.
+    // ZoweInboundBroad covers 7552-7558 which also doesn't include 7590.
+    // ZoweOutboundInternal (no local port restriction) WILL match.
+    const { declarations } = parseAttlsFile(loadAttls('attls-bad-partial-shadow.txt'));
+    const rules = findRulesAffectingExtensions(declarations, 'ZWE1', EXT_PORTS);
+    // The Off rule for 7554/7556/7558 should NOT appear for port 7590
+    const offRule = rules.find(r => r.name === 'ZoweOffGatewayZaasAppServer');
+    expect(offRule).to.be.undefined;
+    // But a broad outbound On rule (ZoweOutboundInternal) should appear
+    const outbound = rules.find(r => r.name === 'ZoweOutboundInternal');
+    expect(outbound).to.exist;
+    expect(outbound.ttlsEnabled).to.be.true;
+  });
+
+  it('correctly finds an Off rule when it covers the extension port', function () {
+    // Build a synthetic rule set: ZWE1* Off rule on port 7590 (the extension port)
+    const content = [
+      'TTLSGroupAction OffGrp\n{\n  TTLSEnabled Off\n}',
+      'TTLSRule WideOff\n{\n  LocalPortRange 7580-7600\n  Jobname ZWE1*\n  Direction Inbound\n  Priority 100\n  TTLSGroupActionRef OffGrp\n}',
+    ].join('\n');
+    const { declarations } = parseAttlsFile(content);
+    const rules = findRulesAffectingExtensions(declarations, 'ZWE1', [7590]);
+    expect(rules).to.have.length(1);
+    expect(rules[0].name).to.equal('WideOff');
+    expect(rules[0].ttlsEnabled).to.be.false;
+  });
+
+  it('resolves LocalPortGroupRef — excludes rules whose PortGroup does not cover the extension port', function () {
+    // TN3270-style rule: LocalPortGroupRef covers only 992, 3270, 23, etc.
+    // Extension is on port 7590 — none of those match; rule should be excluded.
+    const content = [
+      'TTLSGroupAction OnGrp\n{\n  TTLSEnabled On\n}',
+      'PortGroup TN3270_ports\n{\n  PortRange\n  {\n    Port 992\n  }\n  PortRange\n  {\n    Port 3270\n  }\n  PortRange\n  {\n    Port 23\n  }\n}',
+      'TTLSRule TN3270Rule\n{\n  LocalAddr ALL\n  RemoteAddr ALL\n  LocalPortGroupRef TN3270_ports\n  Jobname ZWE1*\n  Direction Inbound\n  Priority 255\n  TTLSGroupActionRef OnGrp\n}',
+    ].join('\n');
+    const { declarations } = parseAttlsFile(content);
+    const rules = findRulesAffectingExtensions(declarations, 'ZWE1', [7590]);
+    // TN3270 ports (992, 3270, 23) do not include 7590 → should be excluded
+    expect(rules.map(r => r.name)).to.not.include('TN3270Rule');
+  });
+
+  it('resolves LocalPortGroupRef — includes rules whose PortGroup covers the extension port', function () {
+    const content = [
+      'TTLSGroupAction OnGrp\n{\n  TTLSEnabled On\n}',
+      'PortGroup ExtPorts\n{\n  PortRange\n  {\n    Port 7580-7600\n  }\n}',
+      'TTLSRule ExtRule\n{\n  LocalAddr ALL\n  LocalPortGroupRef ExtPorts\n  Jobname ZWE1*\n  Direction Inbound\n  Priority 100\n  TTLSGroupActionRef OnGrp\n}',
+    ].join('\n');
+    const { declarations } = parseAttlsFile(content);
+    const rules = findRulesAffectingExtensions(declarations, 'ZWE1', [7590]);
+    expect(rules.map(r => r.name)).to.include('ExtRule');
+    // localPortRange should show the resolved ports, not 'all'
+    expect(rules[0].localPortRange).to.equal('7580-7600');
+  });
+
+  it('shows resolved port ranges in localPortRange field (not raw "all" for group refs)', function () {
+    const content = [
+      'TTLSGroupAction OnGrp\n{\n  TTLSEnabled On\n}',
+      'PortRange MyRange\n{\n  Port 7590\n}',
+      'TTLSRule RefRule\n{\n  LocalPortRangeRef MyRange\n  Jobname ZWE1*\n  Direction Inbound\n  Priority 100\n  TTLSGroupActionRef OnGrp\n}',
+    ].join('\n');
+    const { declarations } = parseAttlsFile(content);
+    const rules = findRulesAffectingExtensions(declarations, 'ZWE1', [7590]);
+    expect(rules).to.have.length(1);
+    expect(rules[0].localPortRange).to.equal('7590');
+  });
+
+  it('includes direction and localPortRange fields', function () {
+    const { declarations } = parseAttlsFile(loadAttls('attls-good-complete.txt'));
+    const rules = findRulesAffectingExtensions(declarations, 'ZWE1', EXT_PORTS);
+    const outbound = rules.find(r => r.name === 'ZoweOutboundInternal');
+    expect(outbound).to.exist;
+    expect(outbound.direction).to.equal('Outbound');
+  });
+
+  it('works with a different jobPrefix (ZPRD)', function () {
+    const { declarations } = parseAttlsFile(loadAttls('attls-good-complete.txt'));
+    const rules = findRulesAffectingExtensions(declarations, 'ZPRD', EXT_PORTS);
+    expect(rules).to.have.length(0);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// buildRequiredConnections
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('buildRequiredConnections', function () {
+  it('returns empty array when both attls flags are false', function () {
+    const cfg = parseZoweYaml(loadYaml('zowe-attls-disabled.yaml'));
+    expect(buildRequiredConnections(cfg)).to.have.length(0);
+  });
+
+  it('generates outbound entries even when the (deprecated) client.attls=false, because server.attls=true wins', function () {
+    const cfg = parseZoweYaml(loadYaml('zowe-server-attls-only.yaml'));
+    const required = buildRequiredConnections(cfg);
+    // server.attls=true means ALL components have attls=true — outbound is required
+    const outbound = required.filter(r => r.direction === 'Outbound');
+    expect(outbound.length).to.be.greaterThan(0);
+    // A mismatch should be recorded
+    expect(cfg.clientAttlsMismatches).to.have.length.greaterThan(0);
+  });
+
+  it('returns both inbound and outbound entries for fully-enabled config', function () {
+    const cfg = parseZoweYaml(loadYaml('zowe-full-attls.yaml'));
+    const required = buildRequiredConnections(cfg);
+    const inbound  = required.filter(r => r.direction === 'Inbound');
+    const outbound = required.filter(r => r.direction === 'Outbound');
+    expect(inbound.length).to.be.greaterThan(0);
+    expect(outbound.length).to.be.greaterThan(0);
+  });
+
+  it('includes infinispan inbound entries when infinispan ports are configured', function () {
+    const cfg = parseZoweYaml(loadYaml('zowe-full-attls.yaml'));
+    const required = buildRequiredConnections(cfg);
+    const infPorts = required.filter(r => r.id.includes('caching-'));
+    expect(infPorts.length).to.be.greaterThan(0);
+  });
+
+  it('does not include infinispan entries when no jgroups ports are configured', function () {
+    // zowe-server-attls-only.yaml has no infinispan ports
+    const cfg = parseZoweYaml(loadYaml('zowe-server-attls-only.yaml'));
+    const required = buildRequiredConnections(cfg);
+    const infPorts = required.filter(r => r.id.includes('caching-jgroups') || r.id.includes('caching-keyExchange'));
+    expect(infPorts).to.have.length(0);
+  });
+
+  it('includes z/OSMF outbound entry for custom port', function () {
+    const cfg = parseZoweYaml(loadYaml('zowe-custom-ports.yaml'));
+    const required = buildRequiredConnections(cfg);
+    const zosmf = required.filter(r => r.id.includes('zosmf'));
+    expect(zosmf.length).to.be.greaterThan(0);
+    expect(zosmf[0].port).to.equal(10443);
+  });
+
+  describe('per-component AT-TLS override: api-catalog disabled', function () {
+    let cfg, required;
+    before(function () {
+      cfg      = parseZoweYaml(loadYaml('zowe-partial-attls.yaml'));
+      required = buildRequiredConnections(cfg);
+    });
+
+    it('omits inbound:api-catalog because api-catalog has attls=false', function () {
+      expect(required.find(r => r.id === 'inbound:api-catalog')).to.be.undefined;
+    });
+
+    it('still includes inbound entries for all other enabled components', function () {
+      const ids = required.map(r => r.id);
+      expect(ids).to.include('inbound:gateway');
+      expect(ids).to.include('inbound:discovery');
+      expect(ids).to.include('inbound:app-server');
+      expect(ids).to.include('inbound:zss');
+      expect(ids).to.include('inbound:zaas');
+      expect(ids).to.include('inbound:caching-service');
+    });
+
+    it('still includes outbound entries (all non-api-catalog sources have attls=true)', function () {
+      const outbound = required.filter(r => r.direction === 'Outbound');
+      expect(outbound.length).to.be.greaterThan(0);
+    });
+
+    it('excludes api-catalog from the discovery registrants list (no outbound:ZWE1AC→discovery)', function () {
+      // api-catalog has attls=false so it is not a registrant that needs an AT-TLS outbound rule
+      expect(required.find(r => r.id === 'outbound:ZWE1AC→discovery')).to.be.undefined;
+    });
+  });
+
+  describe('single-service mode (components.apiml.enabled: true)', function () {
+    let cfg, required;
+    before(function () {
+      cfg      = parseZoweYaml(loadYaml('zowe-apiml-single-service.yaml'));
+      required = buildRequiredConnections(cfg);
+    });
+
+    it('generates no inbound entry for api-catalog, caching-service, or zaas', function () {
+      const ids = required.map(r => r.id);
+      expect(ids).to.not.include('inbound:api-catalog');
+      expect(ids).to.not.include('inbound:caching-service');
+      expect(ids).to.not.include('inbound:zaas');
+    });
+
+    it('generates inbound entries for discovery and gateway (both ZWE1AG)', function () {
+      const disc = required.find(r => r.id === 'inbound:discovery');
+      const gw   = required.find(r => r.id === 'inbound:gateway');
+      expect(disc).to.exist;
+      expect(disc.candidates[0]).to.equal('ZWE1AG');
+      expect(gw).to.exist;
+      expect(gw.candidates[0]).to.equal('ZWE1AG');
+    });
+
+    it('generates inbound entries for app-server (ZWE1SV in cluster mode) and zss (ZWE1SZ)', function () {
+      const app = required.find(r => r.id === 'inbound:app-server');
+      const zss = required.find(r => r.id === 'inbound:zss');
+      expect(app).to.exist;
+      // zowe-apiml-single-service.yaml has no ZLUX_NO_CLUSTER — cluster mode is
+      // enabled by default, so the STC (ZWE1SV) holds the inbound socket.
+      expect(app.candidates[0]).to.equal('ZWE1SV');
+      expect(zss).to.exist;
+      expect(zss.candidates[0]).to.equal('ZWE1SZ');
+    });
+
+    it('generates inbound entries for infinispan ports (ZWE1AG)', function () {
+      const inf = required.filter(r => r.id.startsWith('inbound:caching-'));
+      expect(inf).to.have.length(2);
+      expect(inf[0].candidates[0]).to.equal('ZWE1AG');
+    });
+
+    it('generates no cross-APIML outbound entries (gw→zaas, zaas→gw, →caching)', function () {
+      const ids = required.map(r => r.id);
+      // No cross-service APIML calls — they are all in-process in single-service mode
+      expect(ids).to.not.include('outbound:gw→zaas');
+      expect(ids).to.not.include('outbound:zaas→gw');
+      expect(ids.some(id => id.includes('→caching'))).to.be.false;
+    });
+
+    it('generates outbound entries for discovery, app-server, zss, z/OSMF, infinispan', function () {
+      const ids = required.map(r => r.id);
+      expect(ids).to.include('outbound:ag→discovery');
+      expect(ids).to.include('outbound:ag→appserver');
+      expect(ids).to.include('outbound:ag→zss');
+      expect(ids).to.include('outbound:gw/zaas→zosmf');
+      expect(ids.some(id => id.startsWith('outbound:caching-'))).to.be.true;
+    });
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// _internal.findBestRule
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('_internal.findBestRule', function () {
+  const { findBestRule } = _internal;
+
+  it('finds enabled rule for matching port + jobname', function () {
+    const { declarations } = parseAttlsFile(loadAttls('attls-good-complete.txt'));
+    const r = findBestRule(declarations, 'Inbound', 7554, 'ZWE1AG');
+    expect(r.covered).to.be.true;
+    expect(r.warn).to.be.false;
+    expect(r.shadower).to.be.null;
+  });
+
+  it('returns covered=false when no rule matches', function () {
+    const { declarations } = parseAttlsFile(loadAttls('attls-bad-empty.txt'));
+    const r = findBestRule(declarations, 'Inbound', 7554, 'ZWE1AG');
+    expect(r.covered).to.be.false;
+  });
+
+  it('detects shadowing: high-priority Off rule over lower-priority On rule', function () {
+    const { declarations } = parseAttlsFile(loadAttls('attls-bad-priority-shadow.txt'));
+    // GatewayShadow (priority 200, Off) shadows ZoweInboundMain (priority 100, On) for port 7554
+    const r = findBestRule(declarations, 'Inbound', 7554, 'ZWE1AG');
+    expect(r.covered).to.be.false;
+    expect(r.warn).to.be.true;
+    expect(r.shadower).to.exist;
+    expect(r.shadower.name).to.equal('GatewayShadow');
+  });
+
+  it('does not flag shadowing when Off rule has lower priority than On rule', function () {
+    // Build a synthetic scenario: On at priority 200, Off at priority 100
+    const content = [
+      'TTLSGroupAction OnGroup\n{\n  TTLSEnabled On\n}',
+      'TTLSGroupAction OffGroup\n{\n  TTLSEnabled Off\n}',
+      'TTLSRule HighPriorityOn\n{\n  LocalPortRange 7554\n  Jobname ZWE1AG\n  Direction Inbound\n  Priority 200\n  TTLSGroupActionRef OnGroup\n}',
+      'TTLSRule LowPriorityOff\n{\n  LocalPortRange 7554\n  Jobname ZWE1AG\n  Direction Inbound\n  Priority 100\n  TTLSGroupActionRef OffGroup\n}',
+    ].join('\n');
+    const { declarations } = parseAttlsFile(content);
+    const r = findBestRule(declarations, 'Inbound', 7554, 'ZWE1AG');
+    expect(r.covered).to.be.true;
+    expect(r.warn).to.be.false;
+  });
+
+  it('returns covered=false when only rule has wrong direction', function () {
+    const content = [
+      'TTLSGroupAction Grp\n{\n  TTLSEnabled On\n}',
+      'TTLSRule OutRule\n{\n  LocalPortRange 7554\n  Direction Outbound\n  Priority 100\n  TTLSGroupActionRef Grp\n}',
+    ].join('\n');
+    const { declarations } = parseAttlsFile(content);
+    const r = findBestRule(declarations, 'Inbound', 7554, 'ZWE1AG');
+    expect(r.covered).to.be.false;
+  });
+
+  it('outbound: skips rule whose LocalPortRange excludes ephemeral ports', function () {
+    // A rule with LocalPortRange 1245 only makes sense for a server that
+    // listens on port 1245.  Zowe processes connect OUTBOUND using ephemeral
+    // source ports (~1024+), so this rule can never apply and must be ignored.
+    const content = [
+      'TTLSGroupAction Grp\n{\n  TTLSEnabled On\n}',
+      // This rule restricts source port to 1245 — cannot match ephemeral source
+      'TTLSRule ServerRule\n{\n  LocalPortRange 1245\n  RemotePortRange 1024-65535\n  Direction Both\n  Priority 249\n  TTLSGroupActionRef Grp\n}',
+    ].join('\n');
+    const { declarations } = parseAttlsFile(content);
+    const r = findBestRule(declarations, 'Outbound', 7553, 'ZWE1AG');
+    expect(r.covered).to.be.false;
+  });
+
+  it('outbound: prefers specific ZWE* rule over generic lower-priority rule with restricted LocalPort', function () {
+    // Simulates the real-world scenario where a broad "Both" direction rule
+    // has a lower priority than a correct ZWE*-specific outbound rule, but
+    // the broad rule also restricts LocalPort to non-ephemeral values.
+    const content = [
+      'TTLSGroupAction Grp\n{\n  TTLSEnabled On\n}',
+      // Lower priority, LocalPort restricted to 1245 — must be excluded from outbound
+      'TTLSRule BroadBothRule\n{\n  LocalPortRange 1245\n  RemotePortRange 1024-65535\n  Direction Both\n  Priority 249\n  TTLSGroupActionRef Grp\n}',
+      // Higher priority, correct ZWE* outbound rule with no LocalPort restriction
+      'TTLSRule ZweOutboundRule\n{\n  RemotePortRange 1024-65535\n  Jobname ZWE*\n  Direction Outbound\n  Priority 250\n  TTLSGroupActionRef Grp\n}',
+    ].join('\n');
+    const { declarations } = parseAttlsFile(content);
+    const r = findBestRule(declarations, 'Outbound', 7553, 'ZWE1AG');
+    expect(r.covered).to.be.true;
+    expect(r.rule.name).to.equal('ZweOutboundRule');
+  });
+
+  it('outbound: unconstrained LocalPortRange (0-65535) passes ephemeral check', function () {
+    const content = [
+      'TTLSGroupAction Grp\n{\n  TTLSEnabled On\n}',
+      'TTLSRule OpenRule\n{\n  LocalPortRange 0-65535\n  RemotePortRange 7553\n  Jobname ZWE*\n  Direction Outbound\n  Priority 100\n  TTLSGroupActionRef Grp\n}',
+    ].join('\n');
+    const { declarations } = parseAttlsFile(content);
+    const r = findBestRule(declarations, 'Outbound', 7553, 'ZWE1AG');
+    expect(r.covered).to.be.true;
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// _internal.normalizeZoweKeyring
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('_internal.normalizeZoweKeyring', function () {
+  const { normalizeZoweKeyring } = _internal;
+
+  it('normalizes safkeyring://OWNER/RING to OWNER/RING (upper-cased)', function () {
+    expect(normalizeZoweKeyring('safkeyring://ZWESVUSR/ZWERING')).to.equal('ZWESVUSR/ZWERING');
+  });
+
+  it('normalizes lower-case URI and upper-cases result', function () {
+    expect(normalizeZoweKeyring('safkeyring://zowe/zowe_ring')).to.equal('ZOWE/ZOWE_RING');
+  });
+
+  it('handles double-slash form safkeyring:////OWNER/RING', function () {
+    expect(normalizeZoweKeyring('safkeyring:////ZWESVUSR/ZWERING')).to.equal('ZWESVUSR/ZWERING');
+  });
+
+  it('returns null for a PKCS12 path', function () {
+    expect(normalizeZoweKeyring('/var/zowe/keystore/zowe.p12')).to.be.null;
+  });
+
+  it('returns null for empty string', function () {
+    expect(normalizeZoweKeyring('')).to.be.null;
+  });
+
+  it('returns null for null/undefined', function () {
+    expect(normalizeZoweKeyring(null)).to.be.null;
+    expect(normalizeZoweKeyring(undefined)).to.be.null;
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// _internal.resolveKeyringForRule
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('_internal.resolveKeyringForRule', function () {
+  const { resolveKeyringForRule } = _internal;
+
+  it('resolves keyring via full chain: rule → env action → keyring parms', function () {
+    const { declarations } = parseAttlsFile(loadAttls('attls-good-complete.txt'));
+    const ruleDecl = declarations.get('ZoweInboundMain');
+    expect(ruleDecl).to.exist;
+    const keyring = resolveKeyringForRule(declarations, ruleDecl);
+    expect(keyring).to.equal('ZOWE/ZOWE_RING');
+  });
+
+  it('resolves wrong keyring in attls-bad-wrong-keyring.txt', function () {
+    const { declarations } = parseAttlsFile(loadAttls('attls-bad-wrong-keyring.txt'));
+    const ruleDecl = declarations.get('ZoweInboundMain');
+    expect(ruleDecl).to.exist;
+    const keyring = resolveKeyringForRule(declarations, ruleDecl);
+    expect(keyring).to.equal('WRONG/KEYRING');
+  });
+
+  it('returns null when rule has no TTLSEnvironmentActionRef', function () {
+    const content = [
+      'TTLSGroupAction Grp\n{\n  TTLSEnabled On\n}',
+      'TTLSRule NoEnvRule\n{\n  LocalPortRange 7554\n  Direction Inbound\n  TTLSGroupActionRef Grp\n}',
+    ].join('\n');
+    const { declarations } = parseAttlsFile(content);
+    const ruleDecl = declarations.get('NoEnvRule');
+    expect(resolveKeyringForRule(declarations, ruleDecl)).to.be.null;
+  });
+
+  it('returns null when the referenced env action has no TTLSKeyringParmsRef', function () {
+    const content = [
+      'TTLSGroupAction Grp\n{\n  TTLSEnabled On\n}',
+      'TTLSEnvironmentAction EnvNoKeyring\n{\n  HandshakeRole Server\n}',
+      'TTLSRule RuleNoKeyring\n{\n  LocalPortRange 7554\n  Direction Inbound\n  TTLSGroupActionRef Grp\n  TTLSEnvironmentActionRef EnvNoKeyring\n}',
+    ].join('\n');
+    const { declarations } = parseAttlsFile(content);
+    const ruleDecl = declarations.get('RuleNoKeyring');
+    expect(resolveKeyringForRule(declarations, ruleDecl)).to.be.null;
+  });
+
+  it('returns null for null ruleDecl', function () {
+    const { declarations } = parseAttlsFile('');
+    expect(resolveKeyringForRule(declarations, null)).to.be.null;
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// _internal.keyringMatches
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('_internal.keyringMatches', function () {
+  const { keyringMatches } = _internal;
+
+  it('matches when both are identical fully-qualified values', function () {
+    expect(keyringMatches('ZOWE/ZOWE_RING', 'ZOWE/ZOWE_RING')).to.be.true;
+  });
+
+  it('matches when rule uses ring-only (no owner) and names are equal', function () {
+    expect(keyringMatches('ZOWE_RING', 'ZOWE/ZOWE_RING')).to.be.true;
+  });
+
+  it('matches when ring-only value equals ring portion of a multi-segment zoweKeyring', function () {
+    expect(keyringMatches('ZOWESSL', 'ZWESTCU/ZOWESSL')).to.be.true;
+  });
+
+  it('does not match when ring names differ', function () {
+    expect(keyringMatches('WRONG_RING', 'ZOWE/ZOWE_RING')).to.be.false;
+  });
+
+  it('does not match when fully-qualified values differ', function () {
+    expect(keyringMatches('OTHER/ZOWE_RING', 'ZOWE/ZOWE_RING')).to.be.false;
+  });
+
+  it('does not match when owner differs even if ring name is same', function () {
+    expect(keyringMatches('BADOWNER/ZOWE_RING', 'ZOWE/ZOWE_RING')).to.be.false;
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// checkCoverage + summariseResults — scenario-level tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('checkCoverage scenarios', function () {
+
+  // Helper to run a scenario end-to-end
+  function run(attlsFile, yamlFile) {
+    const { declarations } = parseAttlsFile(loadAttls(attlsFile));
+    const zoweConfig        = parseZoweYaml(loadYaml(yamlFile));
+    const results           = checkCoverage(declarations, zoweConfig);
+    return { results, summary: summariseResults(results) };
+  }
+
+  // ── AT-TLS disabled ─────────────────────────────────────────────────────────
+
+  describe('AT-TLS disabled in zowe.yaml', function () {
+    it('reports zero required connections when attls is disabled', function () {
+      const { summary } = run('attls-good-complete.txt', 'zowe-attls-disabled.yaml');
+      expect(summary.total).to.equal(0);
+      expect(summary.miss).to.equal(0);
+    });
+  });
+
+  // ── Good scenarios ──────────────────────────────────────────────────────────
+
+  describe('Good: complete coverage (inline port ranges)', function () {
+    it('has no misses and no warnings', function () {
+      const { summary } = run('attls-good-complete.txt', 'zowe-full-attls.yaml');
+      expect(summary.miss).to.equal(0);
+      expect(summary.warn).to.equal(0);
+      expect(summary.ok).to.equal(summary.total);
+    });
+  });
+
+  describe('Good: complete coverage via PortRange references', function () {
+    it('resolves PortRange refs and finds no misses', function () {
+      const { summary } = run('attls-good-portref.txt', 'zowe-full-attls.yaml');
+      expect(summary.miss).to.equal(0);
+      expect(summary.warn).to.equal(0);
+    });
+  });
+
+  describe('Good: inbound-only policy with server-only zowe.yaml', function () {
+    it('covers inbound requirements (outbound also required since server.attls=true→all components attls=true)', function () {
+      // With the new model, client.attls is deprecated and server.attls drives
+      // both inbound and outbound AT-TLS.  zowe-server-attls-only.yaml has
+      // server.attls=true so outbound rules are still needed.
+      // attls-good-inbound-only.txt only has inbound rules so outbound will miss.
+      const { summary, results } = run('attls-good-inbound-only.txt', 'zowe-server-attls-only.yaml');
+      const inboundMisses = results.filter(r => r.direction === 'Inbound' && r.status === 'miss');
+      expect(inboundMisses).to.have.length(0);
+      // Some outbound connections will miss (no client.attls workaround anymore)
+      const outboundMisses = results.filter(r => r.direction === 'Outbound' && r.status === 'miss');
+      expect(outboundMisses.length).to.be.greaterThan(0);
+    });
+  });
+
+  describe('Good: custom port prefix and ports', function () {
+    it('covers all ZPRD* requirements on custom ports', function () {
+      const { summary } = run('attls-good-custom-ports.txt', 'zowe-custom-ports.yaml');
+      expect(summary.miss).to.equal(0);
+      expect(summary.warn).to.equal(0);
+    });
+  });
+
+  // ── Bad scenarios ───────────────────────────────────────────────────────────
+
+  describe('Bad: missing inbound rules for most components', function () {
+    it('reports misses for uncovered inbound connections', function () {
+      const { summary } = run('attls-bad-missing-inbound.txt', 'zowe-full-attls.yaml');
+      expect(summary.miss).to.be.greaterThan(0);
+      // discovery(7553), caching(7555), app-server(7556), zss(7557), zaas(7558),
+      // infinispan(7600), infinispan(7601) should all be missed inbound
+      expect(summary.missed.some(id => id.startsWith('inbound:'))).to.be.true;
+    });
+
+    it('does not report misses for the two covered inbound ports (7552, 7554)', function () {
+      const { results } = run('attls-bad-missing-inbound.txt', 'zowe-full-attls.yaml');
+      const apiCatalogInbound = results.find(r => r.id === 'inbound:api-catalog');
+      const gatewayInbound    = results.find(r => r.id === 'inbound:gateway');
+      expect(apiCatalogInbound && apiCatalogInbound.status).to.equal('ok');
+      expect(gatewayInbound    && gatewayInbound.status   ).to.equal('ok');
+    });
+  });
+
+  describe('Bad: no outbound rules', function () {
+    it('reports misses for all outbound connections', function () {
+      const { summary } = run('attls-bad-missing-outbound.txt', 'zowe-full-attls.yaml');
+      expect(summary.miss).to.be.greaterThan(0);
+      expect(summary.missed.every(id => id.startsWith('outbound:'))).to.be.true;
+    });
+
+    it('has no inbound misses (inbound rules are complete)', function () {
+      const { results } = run('attls-bad-missing-outbound.txt', 'zowe-full-attls.yaml');
+      const inboundMisses = results.filter(r => r.id.startsWith('inbound:') && r.status === 'miss');
+      expect(inboundMisses).to.have.length(0);
+    });
+  });
+
+  describe('Bad: priority shadowing disables AT-TLS for gateway', function () {
+    it('produces a warn entry for the gateway inbound connection', function () {
+      const { summary, results } = run('attls-bad-priority-shadow.txt', 'zowe-full-attls.yaml');
+      expect(summary.warn).to.be.greaterThan(0);
+      const gwInbound = results.find(r => r.id === 'inbound:gateway');
+      expect(gwInbound).to.exist;
+      expect(gwInbound.status).to.equal('warn');
+      expect(gwInbound.shadower).to.exist;
+    });
+
+    it('still marks other inbound connections as ok', function () {
+      const { results } = run('attls-bad-priority-shadow.txt', 'zowe-full-attls.yaml');
+      const apiCatalog = results.find(r => r.id === 'inbound:api-catalog');
+      expect(apiCatalog && apiCatalog.status).to.equal('ok');
+    });
+  });
+
+  describe('Bad: broad low-priority On rule partially overridden by specific high-priority Off rule', function () {
+    // This is the "I thought my broad rule covered everything" mistake.
+    // A broad On rule at priority 100 covers all Zowe ports, but a specific Off
+    // rule at priority 200 punches holes in it for gateway (7554), app-server
+    // (7556), and ZAAS (7558).  Ports NOT covered by the Off rule (api-catalog,
+    // discovery, caching-service, zss) remain ok.
+    let results;
+    before(function () {
+      results = run('attls-bad-partial-shadow.txt', 'zowe-full-attls.yaml').results;
+    });
+
+    it('reports warn for gateway inbound (7554) — Off rule at priority 200 shadows On rule', function () {
+      const r = results.find(r => r.id === 'inbound:gateway');
+      expect(r).to.exist;
+      expect(r.status).to.equal('warn');
+      expect(r.warnReasons).to.include('shadow');
+      expect(r.shadower).to.exist;
+      expect(r.shadower.name).to.equal('ZoweOffGatewayZaasAppServer');
+    });
+
+    it('reports warn for app-server inbound (7556) — Off rule matches ZWE1SV (cluster STC)', function () {
+      const r = results.find(r => r.id === 'inbound:app-server');
+      expect(r).to.exist;
+      expect(r.status).to.equal('warn');
+      expect(r.warnReasons).to.include('shadow');
+    });
+
+    it('reports warn for zaas inbound (7558) — Off rule at priority 200 shadows On rule', function () {
+      const r = results.find(r => r.id === 'inbound:zaas');
+      expect(r).to.exist;
+      expect(r.status).to.equal('warn');
+      expect(r.warnReasons).to.include('shadow');
+    });
+
+    it('reports ok for api-catalog, discovery, caching-service, and zss (broad On rule still applies)', function () {
+      const unaffected = ['inbound:api-catalog', 'inbound:discovery',
+                          'inbound:caching-service', 'inbound:zss'];
+      for (const id of unaffected) {
+        const r = results.find(r => r.id === id);
+        expect(r, `${id} should exist`).to.exist;
+        expect(r.status, `${id} should be ok`).to.equal('ok');
+      }
+    });
+
+    it('reports ok for all outbound connections (Off rule only targeted inbound)', function () {
+      const outboundMisses = results.filter(r => r.direction === 'Outbound' && r.status !== 'ok');
+      expect(outboundMisses).to.have.length(0);
+    });
+  });
+
+  describe('Bad: rules exist but jobname does not match Zowe', function () {
+    it('reports all connections as missed', function () {
+      const { summary } = run('attls-bad-wrong-jobname.txt', 'zowe-full-attls.yaml');
+      expect(summary.miss).to.equal(summary.total);
+      expect(summary.ok).to.equal(0);
+      expect(summary.warn).to.equal(0);
+    });
+  });
+
+  describe('Bad: empty policy (no TTLSRule declarations)', function () {
+    it('reports all connections as missed', function () {
+      const { summary } = run('attls-bad-empty.txt', 'zowe-full-attls.yaml');
+      expect(summary.miss).to.equal(summary.total);
+      expect(summary.ok).to.equal(0);
+    });
+  });
+
+  describe('Bad: wrong keyring for Zowe-to-Zowe connections', function () {
+    it('warns for every covered Zowe-to-Zowe connection', function () {
+      const { summary } = run('attls-bad-wrong-keyring.txt', 'zowe-full-attls.yaml');
+      expect(summary.miss).to.equal(0);         // all connections are covered
+      expect(summary.warn).to.be.greaterThan(0); // but all have keyring mismatches
+      expect(summary.keyringWarnings.length).to.equal(summary.warn);
+    });
+
+    it('includes "keyring" in warnReasons for every covered non-zosmf connection', function () {
+      const { results } = run('attls-bad-wrong-keyring.txt', 'zowe-full-attls.yaml');
+      const covered = results.filter(r => r.status !== 'miss');
+      const zosmfConn = covered.find(r => r.id === 'outbound:gw/zaas\u2192zosmf');
+      const nonZosmf  = covered.filter(r => r.id !== 'outbound:gw/zaas\u2192zosmf');
+
+      // Every non-z/OSMF covered connection should flag keyring mismatch
+      for (const r of nonZosmf) {
+        expect(r.warnReasons, `${r.id} should have keyring warnReason`).to.include('keyring');
+        expect(r.keyringUsed).to.equal('WRONG/KEYRING');
+      }
+    });
+
+    it('exempts the z/OSMF outbound connection from keyring check', function () {
+      const { results } = run('attls-bad-wrong-keyring.txt', 'zowe-full-attls.yaml');
+      const zosmfConn = results.find(r => r.id === 'outbound:gw/zaas\u2192zosmf');
+      expect(zosmfConn).to.exist;
+      // z/OSMF is exempt: status should be 'ok' even though the keyring is wrong
+      expect(zosmfConn.status).to.equal('ok');
+      expect(zosmfConn.warnReasons).to.not.include('keyring');
+    });
+
+    it('reports keyringUsed in each warn result', function () {
+      const { results } = run('attls-bad-wrong-keyring.txt', 'zowe-full-attls.yaml');
+      const keyringWarns = results.filter(r => r.warnReasons && r.warnReasons.includes('keyring'));
+      for (const r of keyringWarns) {
+        expect(r.keyringUsed).to.be.a('string').and.not.be.empty;
+      }
+    });
+
+    it('does not warn when zowe.yaml has no SAF keyring (PKCS12 config)', function () {
+      // Build a minimal yaml with PKCS12 keystore (no safkeyring:// prefix)
+      const pkcs12Yaml = loadYaml('zowe-full-attls.yaml').replace(
+        /file:\s*"safkeyring:\/\/ZOWE\/ZOWE_RING"/g,
+        'file: "/var/zowe/keystore/zowe.p12"'
+      );
+      const zoweConfig       = parseZoweYaml(pkcs12Yaml);
+      expect(zoweConfig.zoweKeyring).to.be.null;
+
+      const { declarations } = parseAttlsFile(loadAttls('attls-bad-wrong-keyring.txt'));
+      const results          = checkCoverage(declarations, zoweConfig);
+      const summary          = summariseResults(results);
+
+      // No keyring warnings when zoweKeyring is null
+      expect(summary.keyringWarnings).to.have.length(0);
+      expect(summary.warn).to.equal(0);
+    });
+  });
+
+  // ── Single-service mode ────────────────────────────────────────────────────
+
+  describe('Single-service: good complete coverage', function () {
+    it('reports no misses and no warnings', function () {
+      const { summary } = run('attls-good-single-service.txt', 'zowe-apiml-single-service.yaml');
+      expect(summary.miss).to.equal(0);
+      expect(summary.warn).to.equal(0);
+      expect(summary.ok).to.equal(summary.total);
+    });
+  });
+
+  describe('Single-service: multi-service rules also satisfy single-service requirements', function () {
+    it('broad ZWE1* rules from attls-good-complete.txt cover non-infinispan single-service connections', function () {
+      // attls-good-complete.txt uses ZWE1* and covers all standard ports.
+      // It will cover the narrower single-service requirements EXCEPT infinispan
+      // inbound, because its ZoweInboundInfinispan rule uses Jobname ZWE1CS
+      // (multi-service caching-service job) which does not match the single-
+      // service infinispan candidates (ZWE1AG).
+      const { results, summary } = run('attls-good-complete.txt', 'zowe-apiml-single-service.yaml');
+      // Only infinispan inbound entries should be missed
+      const missed = summary.missed;
+      expect(missed.every(id => id.startsWith('inbound:caching-'))).to.be.true;
+      // Everything else should be covered
+      const nonInfMisses = results.filter(
+        r => r.status === 'miss' && !r.id.startsWith('inbound:caching-')
+      );
+      expect(nonInfMisses).to.have.length(0);
+    });
+  });
+
+  describe('Single-service: missing inbound rules for gateway', function () {
+    it('misses the gateway inbound but not incorrectly missed api-catalog/caching/zaas', function () {
+      // attls-bad-missing-inbound.txt only covers api-catalog (7552) and gateway (7554).
+      // In single-service mode there is no inbound:api-catalog requirement, only discovery+gateway.
+      // Gateway (7554) IS covered; discovery (7553) is NOT.
+      const { results } = run('attls-bad-missing-inbound.txt', 'zowe-apiml-single-service.yaml');
+
+      // gateway inbound (7554) covered
+      const gwInbound = results.find(r => r.id === 'inbound:gateway');
+      expect(gwInbound && gwInbound.status).to.equal('ok');
+
+      // discovery inbound (7553) NOT covered
+      const discInbound = results.find(r => r.id === 'inbound:discovery');
+      expect(discInbound && discInbound.status).to.equal('miss');
+
+      // No entry for api-catalog, caching-service, zaas inbound
+      // (they are not required in single-service mode)
+      expect(results.find(r => r.id === 'inbound:api-catalog')).to.be.undefined;
+      expect(results.find(r => r.id === 'inbound:caching-service')).to.be.undefined;
+      expect(results.find(r => r.id === 'inbound:zaas')).to.be.undefined;
+    });
+  });
+
+  describe('Single-service: empty policy', function () {
+    it('reports all connections as missed', function () {
+      const { summary } = run('attls-bad-empty.txt', 'zowe-apiml-single-service.yaml');
+      expect(summary.miss).to.equal(summary.total);
+      expect(summary.ok).to.equal(0);
+    });
+  });
+});

--- a/utils/attlsChecker.js
+++ b/utils/attlsChecker.js
@@ -1,0 +1,1074 @@
+/*
+  This program and the accompanying materials are
+  made available under the terms of the Eclipse Public License v2.0 which accompanies
+  this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
+
+  SPDX-License-Identifier: EPL-2.0
+
+  Copyright Contributors to the Zowe Project.
+*/
+
+/**
+ * attlsChecker.js
+ *
+ * Pure-logic module (no file I/O, no process.exit) for validating that an
+ * AT-TLS Policy Agent configuration file provides adequate coverage for Zowe
+ * components described in a zowe.yaml file.
+ *
+ * The companion CLI script check-zowe-attls.js handles I/O and the exit code.
+ */
+
+'use strict';
+
+const yaml = require('yaml');
+
+// ─────────────────────────────────────────────────────────────────────────────
+// AT-TLS policy file parser
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Parses an AT-TLS Policy Agent file and returns { declarations }
+ * where declarations is a Map<itemName, { typeName, name, props, startLine }>.
+ *
+ * Only well-formed declarations (non-indented TypeKeyword Name followed by a
+ * lone '{' on the next non-blank line) are included.  All properties inside the
+ * block are captured in a key→value/array map.
+ *
+ * The first declaration for a given name wins when duplicates exist (mirrors
+ * the Policy Agent's own behaviour of using the first match).
+ */
+function parseAttlsFile(content) {
+  // Strip comments and preserve line structure
+  const lines = content.split(/\r?\n/).map(l => {
+    // Only treat '#' as a comment when it appears at the start of the line
+    // or immediately after whitespace.  A '#' embedded in a word (e.g. a
+    // rule name like "zowe#3_Client") must be kept intact.
+    const ci = l.search(/(?:^|\s)#/);
+    return ci >= 0 ? l.slice(0, ci) : l;
+  });
+
+  const declarations  = new Map();
+  const parseWarnings = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    const line    = lines[i];
+    const trimmed = line.trim();
+
+    // Top-level declaration: optional leading whitespace, TypeKeyword  ItemName  (nothing else)
+    // Leading whitespace is explicitly allowed: some sites indent their policy stanzas.
+    const declMatch = /^\s*([A-Za-z]\w*)\s+(\S+)\s*$/.exec(line);
+    if (!declMatch) {
+      // Warn about non-blank lines outside blocks that don't look like AT-TLS syntax.
+      // Skip pure structural tokens ({, }) and truly blank lines.
+      if (trimmed && trimmed !== '{' && trimmed !== '}') {
+        parseWarnings.push({
+          type:    'unexpected-syntax',
+          lineNum: i + 1,
+          content: trimmed.length > 80 ? trimmed.slice(0, 80) + '…' : trimmed,
+          message: `Unexpected content on line ${i + 1} (outside a declaration block): "${trimmed.length > 80 ? trimmed.slice(0, 80) + '…' : trimmed}"`,
+        });
+      }
+      continue;
+    }
+
+    const typeName = declMatch[1];
+    const itemName = declMatch[2];
+
+    // Find opening brace on the next non-blank line
+    let braceIdx = i + 1;
+    while (braceIdx < lines.length && lines[braceIdx].trim() === '') braceIdx++;
+    if (braceIdx >= lines.length || lines[braceIdx].trim() !== '{') continue;
+
+    // Walk forward to the matching closing brace, tracking nested depth
+    let depth = 1;
+    let closeIdx = braceIdx + 1;
+    while (closeIdx < lines.length && depth > 0) {
+      const t = lines[closeIdx].trim();
+      if (t === '{') depth++;
+      else if (t === '}') depth--;
+      if (depth > 0) closeIdx++;
+    }
+
+    const bodyLines = lines.slice(braceIdx + 1, closeIdx);
+    const props     = parseBlockProps(bodyLines);
+
+    // First declaration wins (deduplicate by name)
+    if (!declarations.has(itemName)) {
+      declarations.set(itemName, { typeName, name: itemName, props, startLine: i + 1 });
+    }
+
+    i = closeIdx; // skip to end of block
+  }
+
+  // ── Post-parse semantic validation ──────────────────────────────────────────
+  // Validate Jobname patterns in TTLSRule declarations.  AT-TLS only permits
+  // letters, digits, @, #, $, and a single trailing '*' wildcard.  Other
+  // characters (like '.' from regex/glob notation) make a rule effectively dead
+  // because no real z/OS job name will ever match the pattern.
+  for (const [, decl] of declarations) {
+    if (decl.typeName !== 'TTLSRule') continue;
+    const jobPatterns = decl.props['Jobname']
+      ? (Array.isArray(decl.props['Jobname']) ? decl.props['Jobname'] : [decl.props['Jobname']])
+      : [];
+    for (const pat of jobPatterns) {
+      // Valid: letters, digits, @, #, $, trailing *
+      if (/[^A-Za-z0-9@#$*]/.test(pat)) {
+        parseWarnings.push({
+          type:    'invalid-jobname',
+          lineNum: decl.startLine,
+          rule:    decl.name,
+          jobname: pat,
+          message: `TTLSRule "${decl.name}" has Jobname pattern "${pat}" containing characters not valid in ` +
+                   `z/OS job names (only A-Z, 0-9, @, #, $, and trailing * are allowed). ` +
+                   `This rule will never match any z/OS job.`,
+        });
+      }
+    }
+  }
+
+  return { declarations, parseWarnings };
+}
+
+/**
+ * Parses property lines from inside an AT-TLS block body.
+ * Keys that appear more than once are collected into an array.
+ */
+function parseBlockProps(bodyLines) {
+  const props = {};
+  for (const line of bodyLines) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed === '{' || trimmed === '}') continue;
+    const m = /^([\w.]+)\s+(.+)$/.exec(trimmed);
+    if (!m) continue;
+    const key   = m[1];
+    const value = m[2].trim();
+    if (key in props) {
+      if (!Array.isArray(props[key])) props[key] = [props[key]];
+      props[key].push(value);
+    } else {
+      props[key] = value;
+    }
+  }
+  return props;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Port range utilities
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Returns true if portStr covers port.
+ * Accepted forms: "7554", "7552-7558", "1024-65535", "ALL".
+ */
+function portRangeCoversPort(portStr, port) {
+  if (!portStr) return false;
+  const s = portStr.trim();
+  if (s.toUpperCase() === 'ALL') return true;
+  const dash = s.indexOf('-');
+  if (dash >= 0) {
+    return port >= parseInt(s.slice(0, dash), 10) &&
+           port <= parseInt(s.slice(dash + 1), 10);
+  }
+  return parseInt(s, 10) === port;
+}
+
+/**
+ * Resolves the port range(s) for a TTLSRule to an array of range strings.
+ * Handles both inline values (LocalPortRange 7552-7558) and Ref-based values
+ * (LocalPortRangeRef portR1 → PortRange portR1 { Port 7552-7558 }).
+ * Returns ['0-65535'] when no port restriction is specified.
+ */
+function resolveRulePortRange(declarations, props, forLocalPort) {
+  const inlineKey   = forLocalPort ? 'LocalPortRange'    : 'RemotePortRange';
+  const refKey      = forLocalPort ? 'LocalPortRangeRef' : 'RemotePortRangeRef';
+  const groupRefKey = forLocalPort ? 'LocalPortGroupRef' : 'RemotePortGroupRef';
+
+  if (props[inlineKey]) {
+    const v = props[inlineKey];
+    return Array.isArray(v) ? v : [v];
+  }
+
+  // PortRange declaration: TTLSRule … LocalPortRangeRef portR4
+  //   → PortRange portR4 { Port 7552 }
+  if (props[refKey]) {
+    const refNames = Array.isArray(props[refKey]) ? props[refKey] : [props[refKey]];
+    const ranges = [];
+    for (const refName of refNames) {
+      const portDecl = declarations.get(refName);
+      if (portDecl && portDecl.props['Port']) {
+        const pv = portDecl.props['Port'];
+        if (Array.isArray(pv)) ranges.push(...pv);
+        else ranges.push(pv);
+      }
+    }
+    if (ranges.length > 0) return ranges;
+  }
+
+  // PortGroup declaration: TTLSRule … LocalPortGroupRef TN3270_ports
+  //   → PortGroup TN3270_ports { PortRange { Port 992 } PortRange { Port 923 } … }
+  // parseBlockProps flattens all Port values from nested PortRange sub-blocks
+  // into the same props['Port'] array as a regular PortRange declaration.
+  if (props[groupRefKey]) {
+    const groupNames = Array.isArray(props[groupRefKey]) ? props[groupRefKey] : [props[groupRefKey]];
+    const ranges = [];
+    for (const groupName of groupNames) {
+      const groupDecl = declarations.get(groupName);
+      if (groupDecl && groupDecl.props['Port']) {
+        const pv = groupDecl.props['Port'];
+        if (Array.isArray(pv)) ranges.push(...pv);
+        else ranges.push(pv);
+      }
+    }
+    if (ranges.length > 0) return ranges;
+  }
+
+  return ['0-65535']; // unconstrained
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Keyring utilities
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Normalises a zowe.yaml keystore file value to a comparable keyring identifier.
+ * SAF keyring URIs of the form safkeyring://OWNER/RING (or safkeyring:////OWNER/RING)
+ * are reduced to "OWNER/RING" (upper-cased).
+ * Returns null for PKCS12 paths or any non-SAF keyring (skip the check).
+ */
+function normalizeZoweKeyring(keystoreFile) {
+  if (!keystoreFile) return null;
+  const m = /^safkeyring:\/+(.+)/i.exec(String(keystoreFile));
+  if (!m) return null;
+  // Strip any additional leading slashes (safkeyring:////OWNER/RING)
+  return m[1].replace(/^\/+/, '').toUpperCase();
+}
+
+/**
+ * Returns true if a TTLSKeyringParms Keyring value matches the expected Zowe
+ * keyring (in "OWNER/RING" form from zowe.yaml).
+ *
+ * AT-TLS allows the Keyring value to be specified as:
+ *   - "OWNER/RING"  — fully qualified; compare as-is
+ *   - "RING"        — owner is implied (the job's current user); we can only
+ *                     compare the ring name since we don't know the runtime
+ *                     user here.  If the ring names match we treat it as ok.
+ */
+function keyringMatches(ruleKeyring, zoweKeyring) {
+  if (ruleKeyring === zoweKeyring) return true;
+  // If the rule omits the owner, compare only the ring name portion
+  if (!ruleKeyring.includes('/')) {
+    const ringName = zoweKeyring.includes('/') ? zoweKeyring.split('/').slice(1).join('/') : zoweKeyring;
+    return ruleKeyring === ringName;
+  }
+  return false;
+}
+
+/**
+ * Traces a TTLSRule declaration through its environment action to the keyring
+ * value it uses.
+ *
+ * Chain: TTLSRule.TTLSEnvironmentActionRef
+ *          → TTLSEnvironmentAction.TTLSKeyringParmsRef
+ *            → TTLSKeyringParms.Keyring
+ *
+ * Returns the Keyring string value (upper-cased) or null if the chain is broken.
+ */
+function resolveKeyringForRule(declarations, ruleDecl) {
+  if (!ruleDecl) return null;
+  const envRef = ruleDecl.props['TTLSEnvironmentActionRef'];
+  if (!envRef) return null;
+  const envName = Array.isArray(envRef) ? envRef[0] : envRef;
+  const envDecl = declarations.get(envName);
+  if (!envDecl) return null;
+  const kpRef = envDecl.props['TTLSKeyringParmsRef'];
+  if (!kpRef) return null;
+  const kpName = Array.isArray(kpRef) ? kpRef[0] : kpRef;
+  const kpDecl = declarations.get(kpName);
+  if (!kpDecl) return null;
+  const kv = kpDecl.props['Keyring'];
+  const raw = Array.isArray(kv) ? kv[0] : kv;
+  return raw ? raw.trim().toUpperCase() : null;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Jobname matching
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Returns true if AT-TLS Jobname pattern matches job.
+ * AT-TLS supports a single trailing '*' wildcard.
+ * An absent/empty pattern matches all jobs.
+ */
+function jobnameMatches(pattern, job) {
+  if (!pattern || !pattern.trim()) return true;
+  const p = pattern.trim().toUpperCase();
+  const j = job.trim().toUpperCase();
+  if (p.endsWith('*')) return j.startsWith(p.slice(0, -1));
+  return p === j;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Rule matching
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Returns the highest-priority TTLSRule that actively enables AT-TLS for the
+ * connection described by (direction, port, jobName), along with metadata about
+ * whether a higher-priority disabled rule shadows it.
+ *
+ * @returns {{ covered: boolean, rule: object|null, warn: boolean, shadower: object|null }}
+ */
+function findBestRule(declarations, direction, port, jobName) {
+  const enabled  = [];
+  const disabled = [];
+
+  for (const [, decl] of declarations) {
+    if (decl.typeName !== 'TTLSRule') continue;
+
+    const p        = decl.props;
+    const ruleDir  = (p['Direction'] || 'Both').toUpperCase();
+    if (ruleDir !== 'BOTH' && ruleDir !== direction.toUpperCase()) continue;
+
+    // Jobname filter
+    const jobPatterns = p['Jobname']
+      ? (Array.isArray(p['Jobname']) ? p['Jobname'] : [p['Jobname']])
+      : [];
+    if (jobPatterns.length > 0 &&
+        !jobPatterns.some(pat => jobnameMatches(pat, jobName))) continue;
+
+    // Port filter
+    const isInbound = direction.toUpperCase() === 'INBOUND';
+    const ranges    = resolveRulePortRange(declarations, p, isInbound);
+    if (!ranges.some(r => portRangeCoversPort(r, port))) continue;
+
+    // For outbound connections Zowe uses an ephemeral source port (e.g. 1024).
+    // If a rule constrains its LocalPortRange to specific non-ephemeral values
+    // (e.g. LocalPortGroupRef PortB_Zowe = 1234/1337/9999) it cannot
+    // actually match a Zowe connection, so skip it.
+    if (!isInbound) {
+      const localRanges = resolveRulePortRange(declarations, p, true);
+      const unconstrained = localRanges.length === 1 && localRanges[0] === '0-65535';
+      if (!unconstrained && !localRanges.some(r => portRangeCoversPort(r, 1024))) continue;
+    }
+
+    const priority = parseInt(p['Priority'] || '0', 10);
+
+    // Check whether the GroupAction actually enables AT-TLS
+    const groupRef = p['TTLSGroupActionRef'];
+    if (!groupRef) continue;
+    const refName  = Array.isArray(groupRef) ? groupRef[0] : groupRef;
+    const ga       = declarations.get(refName);
+    const ttlsOn   = ga
+      ? (ga.props['TTLSEnabled'] || 'On').trim().toUpperCase() === 'ON'
+      : false;
+
+    if (ttlsOn) enabled.push({ decl, priority });
+    else        disabled.push({ decl, priority });
+  }
+
+  enabled.sort( (a, b) => b.priority - a.priority);
+  disabled.sort((a, b) => b.priority - a.priority);
+
+  const bestEnabled  = enabled[0]  || null;
+  const bestDisabled = disabled[0] || null;
+  const shadowed     = bestEnabled && bestDisabled &&
+                       bestDisabled.priority > bestEnabled.priority;
+
+  return {
+    covered:  bestEnabled !== null && !shadowed,
+    rule:     bestEnabled  ? bestEnabled.decl  : null,
+    shadower: shadowed      ? bestDisabled.decl : null,
+    warn:     !!shadowed,
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Zowe YAML parser
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Well-known Zowe component metadata.
+ * suffix  = address-space name suffix appended to zowe.job.prefix
+ * defaultPort = port used when none is specified in components.<id>.port
+ */
+const COMPONENT_META = {
+  'api-catalog':     { suffix: 'AC', defaultPort: 7552, desc: 'API Catalog'       },
+  'discovery':       { suffix: 'AD', defaultPort: 7553, desc: 'Discovery Service' },
+  'gateway':         { suffix: 'AG', defaultPort: 7554, desc: 'API Gateway'       },
+  'caching-service': { suffix: 'CS', defaultPort: 7555, desc: 'Caching Service'   },
+  'app-server':      { suffix: 'DS', defaultPort: 7556, desc: 'App Server'        },
+  'zss':             { suffix: 'SZ', defaultPort: 7557, desc: 'ZSS'               },
+  'zaas':            { suffix: 'AZ', defaultPort: 7558, desc: 'ZAAS'              },
+};
+
+/** Safely traverses nested object keys; returns undefined if any level is missing. */
+function dig(obj, ...keys) {
+  return keys.reduce((cur, k) => (cur != null ? cur[k] : undefined), obj);
+}
+
+/**
+ * Parses a zowe.yaml string and extracts AT-TLS-relevant configuration.
+ *
+ * @returns {{
+ *   serverAttls: boolean,
+ *   clientAttlsMismatches: Array<{context: string, serverAttls: boolean, clientAttls: boolean}>,
+ *   jobPrefix: string,
+ *   jobName: string,
+ *   enabledComponents: Array,
+ *   infinispanPorts: Array,
+ *   zosmf: { host: string|undefined, port: number }
+ * }}
+ */
+function parseZoweYaml(content) {
+  let doc;
+  try { doc = yaml.parse(content); }
+  catch (e) { throw new Error(`YAML parse error: ${e.message}`); }
+
+  const zowe = doc.zowe || {};
+  const job  = zowe.job || {};
+
+  const jobPrefix   = job.prefix || 'ZWE1';
+  const jobName     = job.name   || `${jobPrefix}SV`;
+
+  // Global server AT-TLS flag — default for all components unless overridden per-component at
+  // components.<id>.zowe.network.server.tls.attls.  The client AT-TLS setting is deprecated;
+  // server attls determines both inbound and outbound AT-TLS behaviour.
+  const serverAttls = !!(dig(zowe, 'network', 'server', 'tls', 'attls'));
+
+  // Detect global client/server mismatch.  If explicitly set and differing from server attls,
+  // record it so the CLI can surface it as a configuration error to the user.
+  const globalClientAttls = dig(zowe, 'network', 'client', 'tls', 'attls');
+  const clientAttlsMismatches = [];
+  if (globalClientAttls !== undefined && !!globalClientAttls !== serverAttls) {
+    clientAttlsMismatches.push({
+      context: 'global (zowe.network)',
+      serverAttls,
+      clientAttls: !!globalClientAttls,
+    });
+  }
+
+  const components = doc.components || {};
+
+  // Whether the API ML is running in single-service deployment mode
+  // (components.apiml.enabled: true).  When true, the api-catalog, discovery,
+  // gateway, caching-service, and zaas components are all merged into one job
+  // (${prefix}AG).  Their individual enabled flags are ignored.
+  // app-server (${prefix}DS) and zss (${prefix}SZ) are unaffected.
+  const apimlSingleService = !!(dig(components, 'apiml', 'enabled'));
+
+  // APIML component IDs that are absorbed into the single-service job
+  const APIML_BUNDLED = new Set(['api-catalog', 'discovery', 'gateway', 'caching-service', 'zaas']);
+
+  // Components that use the pre-v2.18.4 legacy AT-TLS indicator
+  // (components.<id>.server.ssl.enabled: false) instead of the current
+  // zowe.network.server.tls.attls property.
+  const legacyAttlsComponents = [];
+
+  const enabledComponents = [];
+  for (const [id, meta] of Object.entries(COMPONENT_META)) {
+    const comp = components[id];
+    if (apimlSingleService && APIML_BUNDLED.has(id)) {
+      // Always included; all run under the single ${prefix}AG job
+      const rawSA = comp ? dig(comp, 'zowe', 'network', 'server', 'tls', 'attls') : undefined;
+      // Legacy AT-TLS signal: components.<id>.server.ssl.enabled: false
+      const legacySsl = comp ? dig(comp, 'server', 'ssl', 'enabled') : undefined;
+      if (legacySsl === false) legacyAttlsComponents.push(id);
+      const compAttls = rawSA !== undefined ? !!rawSA : (legacySsl === false ? true : serverAttls);
+      const rawCA = comp ? dig(comp, 'zowe', 'network', 'client', 'tls', 'attls') : undefined;
+      if (rawCA !== undefined && !!rawCA !== compAttls) {
+        clientAttlsMismatches.push({ context: `components.${id}`, serverAttls: compAttls, clientAttls: !!rawCA });
+      }
+      enabledComponents.push({
+        id,
+        desc:    meta.desc,
+        jobName: `${jobPrefix}AG`,
+        port:    (comp && comp.port) || meta.defaultPort,
+        attls:   compAttls,
+        raw:     comp || {},
+      });
+    } else {
+      // Multi-service, or non-apiml components: respect the enabled flag
+      if (!comp || comp.enabled === false) continue;
+      const rawSA = dig(comp, 'zowe', 'network', 'server', 'tls', 'attls');
+      // Legacy AT-TLS signal: components.<id>.server.ssl.enabled: false
+      const legacySsl = dig(comp, 'server', 'ssl', 'enabled');
+      if (legacySsl === false) legacyAttlsComponents.push(id);
+      const compAttls = rawSA !== undefined ? !!rawSA : (legacySsl === false ? true : serverAttls);
+      const rawCA = dig(comp, 'zowe', 'network', 'client', 'tls', 'attls');
+      if (rawCA !== undefined && !!rawCA !== compAttls) {
+        clientAttlsMismatches.push({ context: `components.${id}`, serverAttls: compAttls, clientAttls: !!rawCA });
+      }
+      enabledComponents.push({
+        id,
+        desc:    meta.desc,
+        jobName: `${jobPrefix}${meta.suffix}`,
+        port:    comp.port || meta.defaultPort,
+        attls:   compAttls,
+        raw:     comp,
+      });
+    }
+  }
+
+  // Caching Service infinispan cluster-communication ports.
+  // In single-service mode caching is always part of the apiml job, so we
+  // look for infinispan config regardless of the caching-service.enabled flag.
+  const cachingCompRaw  = components['caching-service'];
+  const infinispanPorts = [];
+  const cachingActive   = apimlSingleService
+    ? !!cachingCompRaw
+    : !!(cachingCompRaw && cachingCompRaw.enabled !== false);
+  if (cachingActive) {
+    const jg = dig(cachingCompRaw, 'storage', 'infinispan', 'jgroups') || {};
+    if (jg.port)                 infinispanPorts.push({ port: jg.port, label: 'jgroups' });
+    if (jg.keyExchange && jg.keyExchange.port)
+      infinispanPorts.push({ port: jg.keyExchange.port, label: 'keyExchange' });
+  }
+
+  const zosmfSection = doc.zOSMF || doc.zosmf || {};
+
+  // Detect whether app-server cluster mode is enabled.
+  // When ZLUX_NO_CLUSTER is 1/'1'/true the app-server runs as a single process
+  // under ${prefix}DS, which is both the port listener and the only worker.
+  // Otherwise (default) the parent STC job (zowe.job.name, e.g. ZWE1SV) holds
+  // the listening socket, while worker processes run as ${prefix}DS.
+  //
+  // This matters for AT-TLS INBOUND rules: the rule must match the job that
+  // owns the listening socket (the local port owner), not the workers.
+  const zwedNoCluster = dig(zowe, 'environments', 'ZLUX_NO_CLUSTER');
+  const appServerClustered = !(zwedNoCluster === 1 || zwedNoCluster === '1' || zwedNoCluster === true);
+
+  // Extract the Zowe SAF keyring from zowe.certificate.keystore.file.
+  // Only SAF keyrings (safkeyring://OWNER/RING) are checked; PKCS12 paths return null.
+  const keystoreFile = dig(zowe, 'certificate', 'keystore', 'file') || '';
+  const zoweKeyring  = normalizeZoweKeyring(keystoreFile);
+
+  // Collect enabled components that are not in COMPONENT_META.  Zowe extensions
+  // add components with arbitrary IDs; the checker cannot validate their AT-TLS
+  // coverage but can at least surface their presence and highlight relevant rules.
+  // 'apiml' is a deployment-mode flag, not a real component — skip it.
+  const unknownComponents = [];
+  for (const [id, comp] of Object.entries(components)) {
+    if (id === 'apiml') continue;
+    if (COMPONENT_META[id]) continue;
+    if (!comp || comp.enabled === false) continue;
+    if (!comp.port) continue;  // no port — cannot be AT-TLS relevant
+    unknownComponents.push({ id, port: comp.port, raw: comp });
+  }
+
+  return {
+    serverAttls,
+    clientAttlsMismatches,
+    legacyAttlsComponents,
+    jobPrefix,
+    jobName,
+    apimlSingleService,
+    appServerClustered,
+    enabledComponents,
+    unknownComponents,
+    infinispanPorts,
+    zosmf:      { host: zosmfSection.host, port: zosmfSection.port || 443 },
+    zoweKeyring,
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Extension-component rule finder
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Returns AT-TLS rules that could potentially match Zowe extension component
+ * jobs.  Extension components (Zowe plugins) follow the naming convention
+ * ${prefix}X<suffix> for their address spaces, e.g. ZWE1XABC.
+ *
+ * Only rules whose LocalPortRange covers at least one of the supplied
+ * extensionPorts are returned.  Rules that target entirely unrelated ports
+ * (e.g. a non-Zowe application on a different port) are excluded even if their
+ * Jobname pattern would otherwise match.
+ *
+ * @param {Map}      declarations    parsed AT-TLS declarations map
+ * @param {string}   jobPrefix       e.g. 'ZWE1'
+ * @param {number[]} extensionPorts  ports of the unknown extension components
+ * @returns {Array<{
+ *   name: string,
+ *   direction: string,
+ *   localPortRange: string,
+ *   jobname: string,
+ *   ttlsEnabled: boolean,
+ *   priority: number,
+ * }>}
+ */
+function findRulesAffectingExtensions(declarations, jobPrefix, extensionPorts) {
+  if (!extensionPorts || extensionPorts.length === 0) return [];
+  const probeJob = `${jobPrefix}XEXT`;
+  const results  = [];
+
+  for (const [, decl] of declarations) {
+    if (decl.typeName !== 'TTLSRule') continue;
+    const p = decl.props;
+
+    // Jobname check: does this rule's pattern match the extension probe job?
+    const jobPatterns = p['Jobname']
+      ? (Array.isArray(p['Jobname']) ? p['Jobname'] : [p['Jobname']])
+      : [];
+    const coversExtensions = jobPatterns.length === 0 ||
+      jobPatterns.some(pat => jobnameMatches(pat, probeJob));
+    if (!coversExtensions) continue;
+
+    // Port check: the rule's LocalPortRange must cover at least one extension port.
+    const isInbound = (p['Direction'] || 'Both').toUpperCase() !== 'OUTBOUND';
+    const ranges    = resolveRulePortRange(declarations, p, isInbound);
+    const coversAPort = extensionPorts.some(port =>
+      ranges.some(r => portRangeCoversPort(r, port))
+    );
+    if (!coversAPort) continue;
+
+    // Resolve TTLSEnabled from the group action
+    const groupRef = p['TTLSGroupActionRef'];
+    let ttlsEnabled = false;
+    if (groupRef) {
+      const refName = Array.isArray(groupRef) ? groupRef[0] : groupRef;
+      const ga = declarations.get(refName);
+      ttlsEnabled = ga
+        ? (ga.props['TTLSEnabled'] || 'On').trim().toUpperCase() === 'ON'
+        : false;
+    }
+
+    // Display the resolved port range (not just the raw inline value) so that
+    // rules using LocalPortGroupRef / LocalPortRangeRef show actual ports.
+    const resolvedRanges = ranges[0] === '0-65535' && ranges.length === 1
+      ? 'all'
+      : ranges.join(', ');
+
+    results.push({
+      name:          decl.name,
+      direction:     p['Direction'] || 'Both',
+      localPortRange: resolvedRanges,
+      jobname:       jobPatterns.length > 0 ? jobPatterns.join(', ') : '(any)',
+      ttlsEnabled,
+      priority:      parseInt(p['Priority'] || '0', 10),
+    });
+  }
+
+  return results;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Required-connection builder
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Builds the list of (direction, port, jobName) tuples that must be covered by
+ * active AT-TLS rules given the Zowe configuration.
+ *
+ * Branches automatically on zoweConfig.apimlSingleService:
+ *   true  → single-service mode (api-catalog/discovery/gateway/caching/zaas
+ *             all run in one ${prefix}AG job; only discovery+gateway inbound
+ *             ports are externally exposed).
+ *   false → multi-service mode (each component has its own job and port).
+ */
+function buildRequiredConnections(zoweConfig) {
+  if (zoweConfig.apimlSingleService) {
+    return _buildRequiredConnectionsSingleService(zoweConfig);
+  }
+  return _buildRequiredConnectionsMultiService(zoweConfig);
+}
+
+/** Multi-service connection requirements (one job per component). */
+function _buildRequiredConnectionsMultiService(zoweConfig) {
+  const req = [];
+  const px  = zoweConfig.jobPrefix;
+
+  const comp = (id) => zoweConfig.enabledComponents.find(c => c.id === id);
+
+  // ── Inbound ────────────────────────────────────────────────────────────────
+  // Per-component AT-TLS gate: each component carries an .attls flag derived
+  // from zowe.network.server.tls.attls overridden by
+  // components.<id>.zowe.network.server.tls.attls when present.
+  for (const c of zoweConfig.enabledComponents) {
+    if (!c.attls) continue;
+      // App-server has a dual-jobname complication: when Node.js clustering is
+      // enabled (default), the parent STC job (zowe.job.name, e.g. ZWE1SV)
+      // holds the listening socket, so AT-TLS inbound rules must match THAT
+      // job.  Worker processes run as ${prefix}DS but do not own the port.
+      // When clustering is disabled (ZLUX_NO_CLUSTER=1), ${prefix}DS is both
+      // the listener and the worker, so the rule must match ${prefix}DS.
+      let candidates;
+      let effectiveJob;
+      if (c.id === 'app-server') {
+        if (zoweConfig.appServerClustered) {
+          effectiveJob = zoweConfig.jobName;  // e.g. ZWE1SV
+          candidates   = [zoweConfig.jobName, `${px}*`];
+        } else {
+          effectiveJob = c.jobName;           // e.g. ZWE1DS
+          candidates   = [c.jobName, `${px}*`];
+        }
+      } else {
+        effectiveJob = c.jobName;
+        candidates   = [c.jobName, `${px}*`, `${px}`];
+      }
+      req.push({
+        id:         `inbound:${c.id}`,
+        label:      `Inbound: ${c.desc} (job ${effectiveJob}, port ${c.port})`,
+        direction:  'Inbound',
+        port:       c.port,
+        candidates,
+      });
+    }
+
+  // Caching Service infinispan ports (only when caching has AT-TLS enabled)
+  if (comp('caching-service')?.attls) {
+    for (const { port, label } of zoweConfig.infinispanPorts) {
+      req.push({
+        id:         `inbound:caching-${label}`,
+        label:      `Inbound: Caching infinispan ${label} (job ${px}CS, port ${port})`,
+        direction:  'Inbound',
+        port,
+        candidates: [`${px}CS`, `${px}*`],
+      });
+    }
+  }
+
+  // ── Outbound ───────────────────────────────────────────────────────────────
+  // Each outbound connection is gated on the source component's .attls flag.
+  {
+    const gw   = comp('gateway');
+    const zaas = comp('zaas');
+    const disc = comp('discovery');
+    const cs   = comp('caching-service');
+    const app  = comp('app-server');
+    const zss  = comp('zss');
+
+    // API Gateway → ZAAS (X.509 client cert required)
+    if (gw && gw.attls && zaas) {
+      req.push({
+        id: 'outbound:gw→zaas', label: `Outbound: Gateway (${px}AG) → ZAAS port ${zaas.port}`,
+        direction: 'Outbound', port: zaas.port,
+        candidates: [`${px}AG`, `${px}A*`, `${px}*`],
+      });
+    }
+
+    // ZAAS → Gateway
+    if (zaas && zaas.attls && gw) {
+      req.push({
+        id: 'outbound:zaas→gw', label: `Outbound: ZAAS (${px}AZ) → Gateway port ${gw.port}`,
+        direction: 'Outbound', port: gw.port,
+        candidates: [`${px}AZ`, `${px}A*`, `${px}*`],
+      });
+    }
+
+    // All registrants → Discovery (X.509 client cert for onboarding)
+    if (disc) {
+      const registrants = [
+        gw   && gw.attls   && `${px}AG`,
+        zaas && zaas.attls && `${px}AZ`,
+        comp('api-catalog') && comp('api-catalog').attls && `${px}AC`,
+        cs   && cs.attls   && `${px}CS`,
+      ].filter(Boolean);
+
+      for (const jobName of registrants) {
+        req.push({
+          id: `outbound:${jobName}→discovery`,
+          label: `Outbound: ${jobName} → Discovery port ${disc.port}`,
+          direction: 'Outbound', port: disc.port,
+          candidates: [jobName, `${px}*`],
+        });
+      }
+    }
+
+    // Core services → Caching Service (X.509 client cert required)
+    if (cs) {
+      const users = [gw && gw.attls && `${px}AG`, zaas && zaas.attls && `${px}AZ`, disc && disc.attls && `${px}AD`].filter(Boolean);
+      for (const jobName of users) {
+        req.push({
+          id: `outbound:${jobName}→caching`,
+          label: `Outbound: ${jobName} → Caching Service port ${cs.port}`,
+          direction: 'Outbound', port: cs.port,
+          candidates: [jobName, `${px}*`],
+        });
+      }
+    }
+
+    if (app && (gw?.attls || zaas?.attls)) {
+      req.push({
+        id: 'outbound:any→appserver',
+        label: `Outbound: Zowe services → App Server port ${app.port}`,
+        direction: 'Outbound', port: app.port,
+        candidates: [`${px}AG`, `${px}DS`, `${px}*`],
+      });
+    }
+
+    if (zss && app?.attls) {
+      req.push({
+        id: 'outbound:any→zss',
+        label: `Outbound: Zowe services → ZSS port ${zss.port}`,
+        direction: 'Outbound', port: zss.port,
+        candidates: [`${px}DS`, `${px}AG`, `${px}*`],
+      });
+    }
+
+    // Gateway / ZAAS → z/OSMF (no X.509 client cert on this rule)
+    if ((gw?.attls || zaas?.attls) && zoweConfig.zosmf.port) {
+      req.push({
+        id: 'outbound:gw/zaas→zosmf',
+        label: `Outbound: Gateway/ZAAS → z/OSMF port ${zoweConfig.zosmf.port}`,
+        direction: 'Outbound', port: zoweConfig.zosmf.port,
+        candidates: [`${px}AG`, `${px}AZ`, `${px}A*`, `${px}*`],
+      });
+    }
+
+    // Caching Service infinispan outbound
+    if (cs && cs.attls) {
+      for (const { port, label } of zoweConfig.infinispanPorts) {
+        req.push({
+          id: `outbound:caching-${label}`,
+          label: `Outbound: Caching infinispan ${label} (${px}CS, port ${port})`,
+          direction: 'Outbound', port,
+          candidates: [`${px}CS`, `${px}*`],
+        });
+      }
+    }
+  }
+
+  return req;
+}
+
+/**
+ * Single-service connection requirements (components.apiml.enabled: true).
+ *
+ * api-catalog, discovery, gateway, caching-service, and zaas all run inside
+ * the single ${prefix}AG job.  Only the discovery and gateway ports are
+ * externally exposed as inbound; the others (api-catalog/caching/zaas) are
+ * internal to the process and require no AT-TLS inbound rule.
+ *
+ * app-server (${prefix}DS) and zss (${prefix}SZ) are unaffected and still
+ * have their own inbound rules.
+ *
+ * Outbound: there are no cross-APIML-component connections (all in-process).
+ * Required outbound rules are: ${prefix}AG → discovery (HA replica),
+ * ${prefix}AG → app-server, ${prefix}AG → zss, ${prefix}AG → z/OSMF,
+ * and ${prefix}AG → infinispan.
+ */
+function _buildRequiredConnectionsSingleService(zoweConfig) {
+  const req = [];
+  const px  = zoweConfig.jobPrefix;
+  const comp = (id) => zoweConfig.enabledComponents.find(c => c.id === id);
+
+  const disc = comp('discovery');
+  const gw   = comp('gateway');
+  const app  = comp('app-server');
+  const zss  = comp('zss');
+
+  // Effective AT-TLS state for the bundled ${prefix}AG job.  In single-service
+  // mode all APIML components run in one process; AT-TLS is on for the job if
+  // any of the bundled components has it enabled.
+  const agAttls = [disc, gw, comp('api-catalog'), comp('caching-service'), comp('zaas')]
+    .some(c => c && c.attls);
+
+  // ── Inbound ────────────────────────────────────────────────────────────────
+  {
+    // Discovery and gateway are the only externally-exposed inbound ports.
+    // All APIML components run under ${prefix}AG.
+    if (disc && agAttls) {
+      req.push({
+        id: 'inbound:discovery', direction: 'Inbound', port: disc.port,
+        label: `Inbound: Discovery Service (job ${px}AG, port ${disc.port})`,
+        candidates: [`${px}AG`, `${px}*`],
+      });
+    }
+    if (gw && agAttls) {
+      req.push({
+        id: 'inbound:gateway', direction: 'Inbound', port: gw.port,
+        label: `Inbound: API Gateway (job ${px}AG, port ${gw.port})`,
+        candidates: [`${px}AG`, `${px}*`],
+      });
+    }
+
+    // app-server and zss remain as separate jobs
+    if (app && app.attls) {
+      // Same clustering logic as multi-service: in cluster mode the STC
+      // (zowe.job.name) holds the inbound socket; workers are ${prefix}DS.
+      const appJob = zoweConfig.appServerClustered ? zoweConfig.jobName : `${px}DS`;
+      const appCandidates = zoweConfig.appServerClustered
+        ? [zoweConfig.jobName, `${px}*`]
+        : [`${px}DS`, `${px}*`];
+      req.push({
+        id: 'inbound:app-server', direction: 'Inbound', port: app.port,
+        label: `Inbound: App Server (job ${appJob}, port ${app.port})`,
+        candidates: appCandidates,
+      });
+    }
+    if (zss && zss.attls) {
+      req.push({
+        id: 'inbound:zss', direction: 'Inbound', port: zss.port,
+        label: `Inbound: ZSS (job ${px}SZ, port ${zss.port})`,
+        candidates: [`${px}SZ`, `${px}*`],
+      });
+    }
+
+    // Infinispan (caching runs inside the apiml single-service job)
+    if (agAttls) {
+      for (const { port, label } of zoweConfig.infinispanPorts) {
+        req.push({
+          id: `inbound:caching-${label}`, direction: 'Inbound', port,
+          label: `Inbound: Caching infinispan ${label} (job ${px}AG, port ${port})`,
+          candidates: [`${px}AG`, `${px}*`],
+        });
+      }
+    }
+  }
+
+  // ── Outbound ───────────────────────────────────────────────────────────────
+  // ${prefix}AG is the source for all outbound connections in single-service mode.
+  // Only emit outbound requirements when the AG job has AT-TLS enabled.
+  if (agAttls) {
+    // ${prefix}AG → discovery (for HA replica between instances)
+    if (disc) {
+      req.push({
+        id: 'outbound:ag→discovery', direction: 'Outbound', port: disc.port,
+        label: `Outbound: APIML (${px}AG) → Discovery port ${disc.port}`,
+        candidates: [`${px}AG`, `${px}*`],
+      });
+    }
+
+    // ${prefix}AG → app-server (gateway routing)
+    if (app) {
+      req.push({
+        id: 'outbound:ag→appserver', direction: 'Outbound', port: app.port,
+        label: `Outbound: APIML (${px}AG) → App Server port ${app.port}`,
+        candidates: [`${px}AG`, `${px}*`],
+      });
+    }
+
+    // ${prefix}AG → zss (app-server / desktop routing through gateway)
+    if (zss) {
+      req.push({
+        id: 'outbound:ag→zss', direction: 'Outbound', port: zss.port,
+        label: `Outbound: APIML (${px}AG) → ZSS port ${zss.port}`,
+        candidates: [`${px}AG`, `${px}*`],
+      });
+    }
+
+    // ${prefix}AG → z/OSMF (user authentication — exempt from keyring check)
+    if (zoweConfig.zosmf.port) {
+      req.push({
+        id: 'outbound:gw/zaas→zosmf', direction: 'Outbound', port: zoweConfig.zosmf.port,
+        label: `Outbound: Gateway → z/OSMF port ${zoweConfig.zosmf.port}`,
+        candidates: [`${px}AG`, `${px}A*`, `${px}*`],
+      });
+    }
+
+    // ${prefix}AG → infinispan (caching replication)
+    for (const { port, label } of zoweConfig.infinispanPorts) {
+      req.push({
+        id: `outbound:caching-${label}`, direction: 'Outbound', port,
+        label: `Outbound: Caching infinispan ${label} (${px}AG, port ${port})`,
+        candidates: [`${px}AG`, `${px}*`],
+      });
+    }
+  }
+
+  return req;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Coverage checker
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Tests each required connection against the AT-TLS declarations map and
+ * returns an array of result objects with status 'ok' | 'warn' | 'miss'.
+ *
+ * Each result carries:
+ *   warnReasons: string[]  — reasons for a 'warn' status:
+ *     'shadow'  — a higher-priority TTLSEnabled Off rule shadows the match
+ *     'keyring' — the matched rule uses a TTLSKeyringParms whose Keyring value
+ *                 does not match zowe.yaml's SAF keyring (Zowe-to-Zowe only;
+ *                 z/OSMF outbound is exempt).
+ *   keyringUsed: string|null — the keyring value found in the matched rule.
+ */
+function checkCoverage(declarations, zoweConfig) {
+  const required = buildRequiredConnections(zoweConfig);
+  return required.map(req => {
+    // Deduplicate candidates while preserving order
+    const seen = new Set();
+    const candidates = req.candidates.filter(j => !seen.has(j) && seen.add(j));
+
+    for (const jobName of candidates) {
+      const { covered, rule, warn, shadower } = findBestRule(
+        declarations, req.direction, req.port, jobName
+      );
+      if (covered || warn) {
+        const warnReasons = warn ? ['shadow'] : [];
+        let keyringUsed = null;
+
+        // Keyring check: skip z/OSMF outbound (may legitimately use a different
+        // CA-only keyring) and skip when zowe.yaml has no SAF keyring configured.
+        const isZosmfConn = req.id === 'outbound:gw/zaas→zosmf';
+        if (!isZosmfConn && zoweConfig.zoweKeyring && rule) {
+          keyringUsed = resolveKeyringForRule(declarations, rule);
+          if (keyringUsed && !keyringMatches(keyringUsed, zoweConfig.zoweKeyring)) {
+            warnReasons.push('keyring');
+          }
+        }
+
+        return {
+          ...req,
+          status:      warnReasons.length > 0 ? 'warn' : 'ok',
+          rule,
+          shadower,
+          matchedJob:  jobName,
+          warnReasons,
+          keyringUsed,
+        };
+      }
+    }
+    return { ...req, status: 'miss', rule: null, warnReasons: [], keyringUsed: null };
+  });
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Summary helper (used by report builder and tests)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Returns a plain object summarising the coverage results.
+ * Suitable for programmatic consumption (tests, JSON output, etc.).
+ */
+function summariseResults(results) {
+  const total           = results.length;
+  const ok              = results.filter(r => r.status === 'ok').length;
+  const warn            = results.filter(r => r.status === 'warn').length;
+  const miss            = results.filter(r => r.status === 'miss').length;
+  const missed          = results.filter(r => r.status === 'miss').map(r => r.id);
+  const warnings        = results.filter(r => r.status === 'warn').map(r => r.id);
+  const keyringWarnings = results
+    .filter(r => r.warnReasons && r.warnReasons.includes('keyring'))
+    .map(r => r.id);
+
+  return { total, ok, warn, miss, missed, warnings, keyringWarnings };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Exports
+// ─────────────────────────────────────────────────────────────────────────────
+
+module.exports = {
+  parseAttlsFile,
+  parseZoweYaml,
+  buildRequiredConnections,
+  checkCoverage,
+  summariseResults,
+  findRulesAffectingExtensions,
+  // Exported for unit testing
+  _internal: {
+    parseBlockProps,
+    portRangeCoversPort,
+    resolveRulePortRange,
+    jobnameMatches,
+    findBestRule,
+    normalizeZoweKeyring,
+    resolveKeyringForRule,
+    keyringMatches,
+    findRulesAffectingExtensions,
+  },
+};

--- a/utils/check-zowe-attls.js
+++ b/utils/check-zowe-attls.js
@@ -1,0 +1,258 @@
+#!/usr/bin/env node
+/*
+  This program and the accompanying materials are
+  made available under the terms of the Eclipse Public License v2.0 which accompanies
+  this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
+
+  SPDX-License-Identifier: EPL-2.0
+
+  Copyright Contributors to the Zowe Project.
+*/
+
+/**
+ * check-zowe-attls.js
+ *
+ * CLI entry point for the Zowe AT-TLS coverage checker.
+ *
+ * Usage:
+ *   node utils/check-zowe-attls.js <attls-policy-file> <zowe.yaml>
+ *
+ * Exit codes:
+ *   0  – all required connections are covered, or AT-TLS is disabled in zowe.yaml
+ *   1  – one or more required connections are missing or have priority conflicts
+ *   2  – usage / parse error
+ */
+
+'use strict';
+
+const fs      = require('fs');
+const checker = require('./attlsChecker');
+
+// ─── ANSI colour helpers ──────────────────────────────────────────────────────
+const C = { reset:'\x1b[0m', bold:'\x1b[1m', red:'\x1b[31m', green:'\x1b[32m',
+            yellow:'\x1b[33m', cyan:'\x1b[36m', gray:'\x1b[90m' };
+const col  = (c, t) => `${C[c]}${t}${C.reset}`;
+const bold = (t) => `${C.bold}${t}${C.reset}`;
+
+// ─── Report printer ───────────────────────────────────────────────────────────
+function printReport(zoweConfig, results, declarations) {
+  const { serverAttls, clientAttlsMismatches, legacyAttlsComponents, jobPrefix, jobName,
+          enabledComponents, infinispanPorts, zosmf } = zoweConfig;
+
+  console.log(`\n${bold('═══════════════════════════════════════════')}`);
+  console.log(`${bold('  Zowe AT-TLS Coverage Report')}`);
+  console.log(`${bold('═══════════════════════════════════════════')}\n`);
+
+  console.log(bold('Zowe configuration (from zowe.yaml):'));
+  console.log(`  Job prefix: ${col('cyan', jobPrefix)}    Job name: ${col('cyan', jobName)}`);
+  console.log(`  zowe.network.server.tls.attls : ${serverAttls
+    ? col('green', 'true  ← AT-TLS required')
+    : col('yellow', 'false — AT-TLS disabled globally')}`);
+
+  // Show per-component AT-TLS overrides (only components that differ from global)
+  for (const c of enabledComponents) {
+    if (c.attls !== serverAttls) {
+      console.log(`  components.${c.id.padEnd(18)} : ${
+        c.attls ? col('green', 'true  (override: AT-TLS ON)')
+                : col('yellow', 'false (override: AT-TLS OFF)')}`);
+    }
+  }
+
+  // Surface client/server attls mismatches as errors
+  if (clientAttlsMismatches && clientAttlsMismatches.length > 0) {
+    console.log();
+    for (const m of clientAttlsMismatches) {
+      console.log(`  ${col('red', '✗')} Configuration error at ${col('cyan', m.context)}: ` +
+        `zowe.network.client.tls.attls=${m.clientAttls} but server AT-TLS is ${m.serverAttls}. ` +
+        `Client AT-TLS is deprecated — set it to match server AT-TLS or remove it.`);
+    }
+  }
+
+  // ── Legacy AT-TLS configuration warning ──────────────────────────────────
+  // Pre-v2.18.4 Zowe used components.<id>.server.ssl.enabled: false instead of
+  // zowe.network.server.tls.attls: true.  That era of Zowe had serious AT-TLS
+  // bugs; the user must be warned to upgrade regardless of policy correctness.
+  if (legacyAttlsComponents && legacyAttlsComponents.length > 0) {
+    console.log();
+    console.log(`  ${col('red', bold('╔══════════════════════════════════════════════════════════════╗'))}`);
+    console.log(`  ${col('red', bold('║  ⚠  LEGACY AT-TLS CONFIGURATION DETECTED                    ║'))}`);
+    console.log(`  ${col('red', bold('╚══════════════════════════════════════════════════════════════╝'))}`);
+    console.log();
+    console.log(`  ${col('red', bold('The following component(s) use the old-style AT-TLS indicator:'))}`);
+    for (const id of legacyAttlsComponents) {
+      console.log(`    ${col('red', '•')} ${col('cyan', `components.${id}.server.ssl.enabled: false`)}`);
+    }
+    console.log();
+    console.log(`  This property was used in Zowe versions ${col('red', 'prior to v2.18.4')} and implies`);
+    console.log(`  you are running a vintage of Zowe that contained ${col('red', 'significant AT-TLS bugs')}.`);
+    console.log(`  Even if the AT-TLS policy rules shown below appear correct, Zowe's`);
+    console.log(`  behaviour with this configuration ${col('red', 'is unreliable')} and errors are expected.`);
+    console.log();
+    console.log(`  ${col('yellow', bold('Action required:'))}`);
+    console.log(`    1. Upgrade Zowe to ${bold('v2.18.4')} or later.`);
+    console.log(`    2. Replace the legacy property with:`);
+    console.log(`       ${col('cyan', 'zowe.network.server.tls.attls: true')}`);
+    console.log(`       (and remove the per-component server.ssl.enabled settings)`);
+    console.log(`    3. See ${col('cyan', 'https://docs.zowe.org')} for the current AT-TLS configuration guide.`);
+    console.log();
+    console.log(`  Continuing analysis, treating legacy components as AT-TLS-enabled...`);
+    console.log();
+  }
+
+  const anyAttls = enabledComponents.some(c => c.attls);
+  if (!anyAttls) {
+    console.log(`\n${col('yellow', '⚠  AT-TLS is disabled for all components in zowe.yaml.')}`);
+    console.log(`  Set zowe.network.server.tls.attls: true to enable AT-TLS with Zowe.\n`);
+    return clientAttlsMismatches && clientAttlsMismatches.length > 0 ? 1 : 0;
+  }
+
+  console.log(`\n${bold('Enabled components:')}`);
+  for (const c of enabledComponents) {
+    console.log(`  ${col('cyan', c.desc.padEnd(22))}  port ${String(c.port).padStart(5)}  job ${c.jobName}`);
+  }
+  if (zosmf.host) {
+    console.log(`  ${'z/OSMF (external)'.padEnd(22)}  port ${String(zosmf.port).padStart(5)}  host ${zosmf.host}`);
+  }
+  if (infinispanPorts.length) {
+    console.log(`  ${'Caching infinispan'.padEnd(22)}  ports ${infinispanPorts.map(p => p.port).join(', ')}  job ${jobPrefix}CS`);
+  }
+
+  if (zoweConfig.zoweKeyring) {
+    console.log(`\n${bold('Zowe SAF keyring:')} ${col('cyan', zoweConfig.zoweKeyring)}`);
+  }
+
+  // ── Extension / unknown components ──────────────────────────────────────────
+  if (zoweConfig.unknownComponents && zoweConfig.unknownComponents.length > 0) {
+    console.log(`\n${bold('Unknown extension components (cannot validate AT-TLS coverage):')}`)
+    for (const c of zoweConfig.unknownComponents) {
+      console.log(`  ${col('yellow', '⚠')} ${col('cyan', c.id.padEnd(20))} port ${c.port}`);
+      console.log(`      Extension jobs use pattern ${col('cyan', `${zoweConfig.jobPrefix}X*`)} — AT-TLS coverage cannot be validated.`);
+    }
+    if (declarations) {
+      const extPorts = zoweConfig.unknownComponents.map(c => c.port);
+      const extRules = checker.findRulesAffectingExtensions(declarations, zoweConfig.jobPrefix, extPorts);
+      if (extRules.length > 0) {
+        console.log(`\n  ${bold(`AT-TLS rules matching ${zoweConfig.jobPrefix}X* extension jobs:`)}`)
+        for (const r of extRules) {
+          const onOff = r.ttlsEnabled ? col('green', 'On ') : col('red', 'Off');
+          const dir   = r.direction.padEnd(8);
+          const ports = r.localPortRange.length <= 20
+            ? r.localPortRange.padEnd(20)
+            : r.localPortRange;
+          console.log(`    [${onOff}] priority ${String(r.priority).padStart(3)}  ${dir}  ports ${ports}  job ${r.jobname}  → ${r.name}`);
+        }
+      } else {
+        console.log(`\n  ${col('yellow', `No AT-TLS rules found matching ${zoweConfig.jobPrefix}X* — extension components may be unprotected.`)}`);
+      }
+    }
+  }
+
+  const inbound  = results.filter(r => r.direction === 'Inbound');
+  const outbound = results.filter(r => r.direction === 'Outbound');
+  let issues = 0, warnings = 0;
+
+  function printSection(title, items) {
+    if (!items.length) return;
+    console.log(`\n${bold(title)}`);
+    for (const item of items) {
+      if (item.status === 'ok') {
+        console.log(`  ${col('green','✓')} ${item.label}`);
+        console.log(`      ${col('gray', `→ TTLSRule ${item.rule.name}  (job matched: ${item.matchedJob})`)}`);
+      } else if (item.status === 'warn') {
+        warnings++;
+        console.log(`  ${col('yellow','⚠')} ${item.label}`);
+        if (item.warnReasons.includes('shadow')) {
+          console.log(`      ${col('yellow',`Covered by TTLSRule ${item.rule.name}, BUT`)}`);
+          console.log(`      ${col('yellow',`TTLSRule ${item.shadower.name} has higher priority with TTLSEnabled Off — may disable AT-TLS!`)}`);
+        }
+        if (item.warnReasons.includes('keyring')) {
+          console.log(`      ${col('yellow',`Covered by TTLSRule ${item.rule.name}, BUT`)}`);
+          console.log(`      ${col('yellow',`Keyring mismatch: rule uses "${item.keyringUsed}" — expected Zowe keyring "${zoweConfig.zoweKeyring}"`)}`);
+        }
+      } else {
+        issues++;
+        console.log(`  ${col('red','✗')} ${item.label}`);
+        console.log(`      ${col('red','NOT COVERED')} — no active TTLSRule matches this connection.`);
+      }
+    }
+  }
+
+  printSection('Inbound rule coverage:', inbound);
+  printSection('Outbound rule coverage:', outbound);
+
+  const sum = checker.summariseResults(results);
+  console.log(`\n${bold('─────────────────────────────────────────────')}`);
+
+  if (issues === 0 && warnings === 0) {
+    console.log(`${col('green', bold(`✓ All ${sum.total} required connections are covered.`))}\n`);
+    return 0;
+  }
+  if (issues === 0) {
+    const kwCount = sum.keyringWarnings ? sum.keyringWarnings.length : 0;
+    const msgs = [];
+    if (warnings - kwCount > 0)
+      msgs.push(`${warnings - kwCount} with priority conflict${warnings - kwCount === 1 ? '' : 's'}`);
+    if (kwCount > 0)
+      msgs.push(`${kwCount} with keyring mismatch${kwCount === 1 ? '' : 'es'}`);
+    console.log(`${col('yellow', `⚠ ${sum.ok}/${sum.total} connections covered, ${msgs.join(', ')}.`)}\n`);
+    return 1;
+  }
+  console.log(col('red', bold(`✗ ${issues} of ${sum.total} required connection${issues === 1 ? '' : 's'} not covered.`)));
+  if (warnings) console.log(col('yellow', `  Additionally, ${warnings} covered connection${warnings === 1 ? '' : 's'} have priority-conflict warnings.`));
+  console.log(`  Check jobname patterns, port ranges, and TTLSEnabled settings.\n`);
+  return 1;
+}
+
+// ─── Main ─────────────────────────────────────────────────────────────────────
+function main() {
+  const args = process.argv.slice(2);
+  if (args.length !== 2) {
+    process.stderr.write(
+      `Usage: node utils/check-zowe-attls.js <attls-policy-file> <zowe.yaml>\n\n` +
+      `  attls-policy-file  AT-TLS Policy Agent configuration file\n` +
+      `  zowe.yaml          Zowe instance configuration file\n`
+    );
+    process.exit(2);
+  }
+
+  const [attlsPath, zowePath] = args;
+
+  let attlsContent, zoweContent;
+  try { attlsContent = fs.readFileSync(attlsPath, 'utf8'); }
+  catch (e) { process.stderr.write(`Cannot read AT-TLS file: ${e.message}\n`); process.exit(2); }
+  try { zoweContent  = fs.readFileSync(zowePath,  'utf8'); }
+  catch (e) { process.stderr.write(`Cannot read zowe.yaml: ${e.message}\n`); process.exit(2); }
+
+  let policy, zoweConfig;
+  try { policy     = checker.parseAttlsFile(attlsContent); }
+  catch (e) { process.stderr.write(`AT-TLS parse error: ${e.message}\n`); process.exit(2); }
+  try { zoweConfig = checker.parseZoweYaml(zoweContent); }
+  catch (e) { process.stderr.write(`zowe.yaml parse error: ${e.message}\n`); process.exit(2); }
+
+  const ruleCount = [...policy.declarations.values()].filter(d => d.typeName === 'TTLSRule').length;
+  console.log(`Parsed ${policy.declarations.size} AT-TLS declarations (${ruleCount} TTLSRules) from ${attlsPath}`);
+  console.log(`Parsed zowe.yaml from ${zowePath}`);
+
+  // ── Surface parser / semantic warnings from the AT-TLS file ─────────────────
+  if (policy.parseWarnings && policy.parseWarnings.length > 0) {
+    console.log(`\n${bold('AT-TLS policy file warnings:')}`);
+    for (const w of policy.parseWarnings) {
+      if (w.type === 'invalid-jobname') {
+        console.log(`  ${col('red', '✗')} ${col('yellow', `[invalid-jobname]`)} ${w.message}`);
+        console.log(`      ${col('gray', 'Hint: only A-Z 0-9 @#$ and a trailing * are valid in z/OS job names.')}`);
+        console.log(`      ${col('gray', `      This rule will NEVER match — it should be corrected or removed.`)}`);
+      } else {
+        // unexpected-syntax or anything else
+        console.log(`  ${col('yellow', '⚠')} ${col('yellow', `[unexpected-syntax line ${w.lineNum}]`)} ${w.message}`);
+        console.log(`      ${col('gray', 'Hint: this may be a truncated export, an editor artefact, or unsupported syntax.')}`);
+      }
+    }
+    console.log();
+  }
+
+  const results  = checker.checkCoverage(policy.declarations, zoweConfig);
+  const exitCode = printReport(zoweConfig, results, policy.declarations);
+  process.exit(exitCode);
+}
+
+main();


### PR DESCRIPTION
Added a tool you can use with nodejs in the utils folder, run as ./check-zowe-attls.js <path_to_pagent_attls_rules.txt> <path_to_zowe.yaml> and it will give a summary of whether it thinks your attls rules are compatible with zowe's requirements or not.


## Using
If you wish to use this tool without a full zowe install, simply clone this repo, run `npm install`, and then you can use `node utils/check-zowe-attls.js <path_to_pagent_attls_rules.txt> <path_to_zowe.yaml>`

## Testing

There's around 150 tests included, so it handles quite a bit of scenarios, but given the complexity of the situation, I can't say its perfect and any issues you find let me know so we can make it even better.
<img width="1160" height="2070" alt="image" src="https://github.com/user-attachments/assets/57ae07eb-9f50-4242-a106-bcd4240f62cb" />
