### PR TITLE
Add missing reference for client tlsoptions

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -207,6 +207,7 @@ Server.prototype = {
       auth: WebAuth(this.authManager, this.componentConfig.cookieIdentifier, util.isServerHttps(this.zoweConfig)),
       pluginLoader: this.pluginLoader,
       langManagers: this.langManagers,
+      clientTlsOptions: this.tlsOptions,
       tlsOptions: this.tlsOptions
     };
 


### PR DESCRIPTION
Code in https://github.com/zowe/zlux-server-framework/pull/674 was simplified to use `clientTlsOptions` instead of `clientTlsOptions | tlsOptions` but there was a place identified that didn't have both, and didn't have `clientTlsOptions`, so it was failing. This is now corrected.