### PR TITLE
Remove unused normalize-url package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,6 @@
         "graceful-fs": "~4.2.11",
         "ipaddr.js": "~2.1.0",
         "node-forge": "1.4.0",
-        "normalize-url": "~7.0.0",
         "require-from-string": "~2.0.2",
         "semver": "~7.6.0",
         "undici": "6.24.1",
@@ -1963,17 +1962,6 @@
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
         "node-gyp-build-test": "build-test.js"
-      }
-    },
-    "node_modules/normalize-url": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-7.0.3.tgz",
-      "integrity": "sha512-RiCOdwdPnzvwcBFJE4iI1ss3dMVRIrEzFpn8ftje6iBfzBInqlnRrNhxcLwBEKjPPXQKzm1Ptlxtaiv9wdcj5w==",
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/object-inspect": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "graceful-fs": "~4.2.11",
     "ipaddr.js": "~2.1.0",
     "node-forge": "1.4.0",
-    "normalize-url": "~7.0.0",
     "require-from-string": "~2.0.2",
     "semver": "~7.6.0",
     "undici": "6.24.1",
@@ -84,7 +83,7 @@
       }
     },
     "express": {
-        "path-to-regexp": "0.1.13"
+      "path-to-regexp": "0.1.13"
     },
     "qs": "6.14.2"
   }


### PR DESCRIPTION
I checked on this library and found no users of it - nothing builtin nor dataservices, so it seems appropriate to remove it.