### PR TITLE
Cleanup - use native fetch instead of chai http

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,6 @@
         "@types/node": "~16.18.0",
         "@types/qs": "6.9.3",
         "chai": "~4.2.0",
-        "chai-http": "~4.2.0",
         "mocha": "^11.2.2",
         "typescript": "~5.0.0"
       },
@@ -201,12 +200,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/chai": {
-      "version": "4.3.16",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.16.tgz",
-      "integrity": "sha512-PatH4iOdyh3MyWtmHVFXLWCCIhUbopaltqddG9BzB+gMIzee2MJrvd+jouii9Z3wzQJruGWAm7WOMjgfG8hQlQ==",
-      "dev": true
-    },
     "node_modules/@types/connect": {
       "version": "3.4.35",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
@@ -215,12 +208,6 @@
       "dependencies": {
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/cookiejar": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.5.tgz",
-      "integrity": "sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==",
-      "dev": true
     },
     "node_modules/@types/express": {
       "version": "4.17.17",
@@ -306,16 +293,6 @@
         "@types/http-errors": "*",
         "@types/node": "*",
         "@types/send": "*"
-      }
-    },
-    "node_modules/@types/superagent": {
-      "version": "3.8.7",
-      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-3.8.7.tgz",
-      "integrity": "sha512-9KhCkyXv268A2nZ1Wvu7rQWM+BmdYUVkycFeNnYrUL5Zwu7o8wPQ3wBfW59dDP+wuoxw0ww8YKgTNv8j/cgscA==",
-      "dev": true,
-      "dependencies": {
-        "@types/cookiejar": "*",
-        "@types/node": "*"
       }
     },
     "node_modules/accept-language-parser": {
@@ -605,24 +582,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/chai-http": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/chai-http/-/chai-http-4.2.1.tgz",
-      "integrity": "sha512-S2Ezy5uSVuOYleeXppfUKtTU/xbHCZyKkwjheNJ/76SGFTUPDpDkkpVdPNgC3sAO1Ap5J5LJ+/rXdLG8EGhCDA==",
-      "dev": true,
-      "dependencies": {
-        "@types/chai": "4",
-        "@types/superagent": "^3.8.3",
-        "cookiejar": "^2.1.1",
-        "is-ip": "^2.0.0",
-        "methods": "^1.1.2",
-        "qs": "^6.5.1",
-        "superagent": "^3.7.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -786,15 +745,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/component-emitter": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
-      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
-      "dev": true,
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/content-disposition": {
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
@@ -840,18 +790,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
-    },
-    "node_modules/cookiejar": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
-      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
-      "dev": true
-    },
-    "node_modules/core-util-is": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-      "dev": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -1296,16 +1234,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/formidable": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.6.tgz",
-      "integrity": "sha512-KcpbcpuLNOwrEjnbpMC0gS+X8ciDoZE1kkqzat4a8vrprf+s9pKNQ/QIwWfbfs4ltgmFl3MD177SNTkve3BwGQ==",
-      "deprecated": "Please upgrade to latest, formidable@v2 or formidable@v3! Check these notes: https://bit.ly/2ZEqIau",
-      "dev": true,
-      "funding": {
-        "url": "https://ko-fi.com/tunnckoCore/commissions"
-      }
-    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -1563,15 +1491,6 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
-    "node_modules/ip-regex": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
-      "integrity": "sha512-58yWmlHpp7VYfcdTwMTvwMmqx/Elfxjd9RXTDyMsbL7lLWmhMylLEqiYVLKuLzOZqVgiWXD9MfR62Vv89VRxkw==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/ipaddr.js": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.1.0.tgz",
@@ -1588,18 +1507,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/is-ip": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-2.0.0.tgz",
-      "integrity": "sha512-9MTn0dteHETtyUx8pxqMwg5hMBi3pvlyglJ+b79KOCca0po23337LbVV2Hl4xmMvfw++ljnO0/+5G6G+0Szh6g==",
-      "dev": true,
-      "dependencies": {
-        "ip-regex": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/is-plain-obj": {
@@ -1627,12 +1534,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "dev": true
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -2115,12 +2016,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true
-    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -2194,27 +2089,6 @@
       "engines": {
         "node": ">= 0.8"
       }
-    },
-    "node_modules/readable-stream": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-      "dev": true,
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/readable-stream/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
     },
     "node_modules/readdirp": {
       "version": "4.1.2",
@@ -2498,21 +2372,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
-    "node_modules/string_decoder/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
-    },
     "node_modules/string-width": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
@@ -2628,43 +2487,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/superagent": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.3.tgz",
-      "integrity": "sha512-GLQtLMCoEIK4eDv6OGtkOoSMt3D+oq0y3dsxMuYuDvaNUvuT8eFBuLmfR0iYYzHC1e8hpzC6ZsxbuP6DIalMFA==",
-      "deprecated": "Please upgrade to v9.0.0+ as we have fixed a public vulnerability with formidable dependency. Note that v9.0.0+ requires Node.js v14.18.0+. See https://github.com/ladjs/superagent/pull/1800 for insight. This project is supported and maintained by the team at Forward Email @ https://forwardemail.net",
-      "dev": true,
-      "dependencies": {
-        "component-emitter": "^1.2.0",
-        "cookiejar": "^2.1.0",
-        "debug": "^3.1.0",
-        "extend": "^3.0.0",
-        "form-data": "^2.3.1",
-        "formidable": "^1.2.0",
-        "methods": "^1.1.1",
-        "mime": "^1.4.1",
-        "qs": "^6.5.1",
-        "readable-stream": "^2.3.5"
-      },
-      "engines": {
-        "node": ">= 4.0"
-      }
-    },
-    "node_modules/superagent/node_modules/debug": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-      "dev": true,
-      "dependencies": {
-        "ms": "^2.1.1"
-      }
-    },
-    "node_modules/superagent/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true
     },
     "node_modules/supports-color": {
       "version": "8.1.1",
@@ -2797,12 +2619,6 @@
       "engines": {
         "node": ">= 0.8"
       }
-    },
-    "node_modules/util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "@types/node": "~16.18.0",
     "@types/qs": "6.9.3",
     "chai": "~4.2.0",
-    "chai-http": "~4.2.0",
     "mocha": "^11.2.2",
     "typescript": "~5.0.0"
   },
@@ -76,11 +75,6 @@
   "overrides": {
     "@rocketsoftware/eureka-js-client": {
       "@cypress/request": "^3.0.9"
-    },
-    "chai-http": {
-      "superagent": {
-        "form-data": "4.0.4"
-      }
     },
     "express": {
       "path-to-regexp": "0.1.13"

--- a/test/webapp/agent-connectivity.js
+++ b/test/webapp/agent-connectivity.js
@@ -19,10 +19,6 @@ const assert = require('assert')
 const path = require('path');
 const http = require('http');
 const https = require('https');
-const chai = require('chai');
-const chaiHttp = require('chai-http');
-chai.use(chaiHttp);
-const should = chai.should();
 const PluginLoader = require('../../lib/plugin-loader')
 const makePlugin = PluginLoader.makePlugin
 const makeWebApp = require('../../lib/webapp').makeWebApp;
@@ -93,11 +89,9 @@ describe('Agent', function() {
     
     it('should be able to get plugins over HTTP', function() {
       const url = '/plugins?type=all';
-      return chai.request(server)
-        .get(url)
+      return fetch(`http://localhost:${webAppOptions.httpPort}${url}`)
         .then(function (res) {
-          res.should.have.status(200);
-          res.body.should.be.a('object');
+          assert.strictEqual(res.status, 200);
         });
     })
   })
@@ -131,11 +125,9 @@ describe('Agent', function() {
     
     it('should be able to get plugins over HTTPS (ATTLS)', function() {
       const url = '/plugins?type=all';
-      return chai.request(server)
-        .get(url)
+      return fetch(`http://localhost:${webAppOptions.httpPort}${url}`)
         .then(function (res) {
-          res.should.have.status(200);
-          res.body.should.be.a('object');
+          assert.strictEqual(res.status, 200);
         });
     })
   })
@@ -168,11 +160,9 @@ describe('Agent', function() {
     
     it('should be able to get plugins over HTTPS', function() {
       const url = '/plugins?type=all';
-      return chai.request(server)
-        .get(url)
+      return fetch(`http://localhost:${webAppOptions.httpPort}${url}`)
         .then(function (res) {
-          res.should.have.status(200);
-          res.body.should.be.a('object');
+          assert.strictEqual(res.status, 200);
         });
     })
 

--- a/test/webapp/webapp.js
+++ b/test/webapp/webapp.js
@@ -11,10 +11,6 @@
 const assert = require('assert')
 const path = require('path');
 const http = require('http');
-const chai = require('chai');
-const chaiHttp = require('chai-http');
-chai.use(chaiHttp);
-const should = chai.should();
 const PluginLoader = require('../../lib/plugin-loader')
 const makePlugin = PluginLoader.makePlugin
 const makeWebApp = require('../../lib/webapp').makeWebApp;
@@ -85,18 +81,23 @@ describe('WebApp', function() {
         done(e);
       }
     })
+
+    afterEach(function(done) {
+      server.close(done);
+    })
     
     describe('versioning', function() {
       it('should install test-service v1.3.0', function()  {
         const url = '/XXX/plugins/org.zowe.testplugin'
             + '/services/test-service/1.3.0'
-        return chai.request(server)
-          .get(url)
+        return fetch(`http://localhost:${webAppOptions.httpPort}${url}`)
           .then(function (res) {
             //console.log(res)
-            res.should.have.status(200);
-            res.body.should.be.a('object');
-            res.body.should.deep.equal(
+            assert.strictEqual(res.status, 200);
+            return res.json();
+          })
+          .then(function (body) {
+            assert.deepStrictEqual(body,
               {
                 "plugin": "org.zowe.testplugin",
                 "service": "test-service",
@@ -108,13 +109,14 @@ describe('WebApp', function() {
      it('should install test-service v2.1.0', function()  {
         const url = '/XXX/plugins/org.zowe.testplugin'
             + '/services/test-service/2.1.0'
-        return chai.request(server)
-          .get(url)
+        return fetch(`http://localhost:${webAppOptions.httpPort}${url}`)
           .then(function (res) {
-            res.should.have.status(200);
-            res.body.should.be.a('object');
-            console.log(res.body)
-            res.body.should.deep.equal(
+            assert.strictEqual(res.status, 200);
+            return res.json();
+          })
+          .then(function (body) {
+            console.log(body)
+            assert.deepStrictEqual(body,
               {
                 "plugin": "org.zowe.testplugin",
                 "service": "test-service",
@@ -126,13 +128,14 @@ describe('WebApp', function() {
       it('should point the _current version of test-service to v2.1.0', function()  {
         const url = '/XXX/plugins/org.zowe.testplugin'
             + '/services/test-service/_current'
-        return chai.request(server)
-          .get(url)
+        return fetch(`http://localhost:${webAppOptions.httpPort}${url}`)
           .then(function (res) {
-            res.should.have.status(200);
-            res.body.should.be.a('object');
-            console.log(res.body)
-            res.body.should.deep.equal(
+            assert.strictEqual(res.status, 200);
+            return res.json();
+          })
+          .then(function (body) {
+            console.log(body)
+            assert.deepStrictEqual(body,
               {
                 "plugin": "org.zowe.testplugin",
                 "service": "test-service",
@@ -144,12 +147,14 @@ describe('WebApp', function() {
       it('should call the highest version by default', function()  {
         const url = '/XXX/plugins/org.zowe.testplugin'
             + '/services/caller/_current'
-        const req = chai.request(server).get(url)
-        return req.then(function (res) {
-            res.should.have.status(200);
-            res.body.should.be.a('object');
-            console.log(res.body)
-            res.body.should.deep.equal({
+        return fetch(`http://localhost:${webAppOptions.httpPort}${url}`)
+          .then(function (res) {
+            assert.strictEqual(res.status, 200);
+            return res.json();
+          })
+          .then(function (body) {
+            console.log(body)
+            assert.deepStrictEqual(body, {
                 "plugin": "org.zowe.testplugin",
                 "service": "caller",
                 "test-service response": {
@@ -158,19 +163,21 @@ describe('WebApp', function() {
                   "version": "2.1.0"
                 }
               });
-          })//.catch(e => console.log(e))
+          })
       })
       
       it('should respect local service version requirements', function()  {
         const url = '/XXX/plugins/org.zowe.testplugin'
             + '/services/caller-with-requirements/_current'
-        const req = chai.request(server).get(url)
-        //console.log(req)
-        return req.then(function (res) {
-            res.should.have.status(200);
-            res.body.should.be.a('object');
-            console.log(res.body)
-            res.body.should.deep.equal({
+        //console.log(url)
+        return fetch(`http://localhost:${webAppOptions.httpPort}${url}`)
+          .then(function (res) {
+            assert.strictEqual(res.status, 200);
+            return res.json();
+          })
+          .then(function (body) {
+            console.log(body)
+            assert.deepStrictEqual(body, {
                 "plugin": "org.zowe.testplugin",
                 "service": "caller",
                 "test-service response": {


### PR DESCRIPTION
This PR just removes chai-http from the tests to instead prefer fetch.
It has no runtime implication, but is being done to lighten the dependency list.