### PR TITLE
Set specific versions and enforce it in workflow

### DIFF
--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -136,7 +136,13 @@ jobs:
     needs: check-permission
     steps:
 
-      - name: '[Prep 1] Cache node modules'
+      - name: '[Prep 1] Checkout'
+        uses: actions/checkout@v2
+
+      - name: '[Prep 2] Validate package.json'
+        uses: zowe-actions/shared-actions/validate-package-json@main
+
+      - name: '[Prep 3] Cache node modules'
         uses: actions/cache@v4
         with:
           # npm cache files are stored in `~/.npm` on Linux/macOS
@@ -147,18 +153,18 @@ jobs:
           key: ${{ runner.os }}-build-cache-node-modules-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-build-cache-node-modules-
-      
-      - name: '[Prep 2] Setup Node'
+
+      - name: '[Prep 4] Setup Node'
         uses: actions/setup-node@v3
         with:
           node-version: 18
 
-      - name: '[Prep 3] Setup jFrog CLI'
+      - name: '[Prep 5] Setup jFrog CLI'
         uses: jfrog/setup-jfrog-cli@v2
         env:
           JF_ARTIFACTORY_1: ${{ secrets.JF_ARTIFACTORY_TOKEN }}
 
-      - name: '[Prep 4] prepare workflow'
+      - name: '[Prep 6] prepare workflow'
         uses: zowe-actions/zlux-builds/core/prepare@v3.x/main
         with:
           github-user: ${{ secrets.ZOWE_ROBOT_USER }}
@@ -167,7 +173,7 @@ jobs:
           github-branch: ${{ github.event.inputs.BRANCH_NAME }}
           default-base: ${{ github.event.inputs.DEFAULT_BRANCH }}
 
-      - name: '[Prep 5] build'
+      - name: '[Prep 7] build'
         uses: zowe-actions/zlux-builds/core/build@v3.x/main
         with:
           zlux-app-manager: ${{ github.event.inputs.ZLUX_APP_MANAGER }}
@@ -177,13 +183,13 @@ jobs:
           zlux-server-framework: ${{ github.event.inputs.ZLUX_SERVER_FRAMEWORK }}
           zlux-shared: ${{ github.event.inputs.ZLUX_SHARED }}
 
-      - name: '[Prep 6] packaging'
+      - name: '[Prep 8] packaging'
         uses: zowe-actions/zlux-builds/core/package@v3.x/main
         with:
           pax-ssh-username: ${{ secrets.SSH_MARIST_USERNAME }}
           pax-ssh-password: ${{ secrets.SSH_MARIST_RACF_PASSWORD }}
           pax-name: zlux-core
           
-      - name: '[Prep 7] deploy'
+      - name: '[Prep 9] deploy'
         uses: zowe-actions/zlux-builds/core/deploy@v3.x/main
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,38 +10,38 @@
       "license": "EPL-2.0",
       "dependencies": {
         "@apidevtools/swagger-parser": "12.1.0",
-        "@rocketsoftware/eureka-js-client": "^4.5.9",
-        "@rocketsoftware/express-ws": "^5.0.1",
-        "accept-language-parser": "~1.5.0",
+        "@rocketsoftware/eureka-js-client": "4.5.9",
+        "@rocketsoftware/express-ws": "5.0.1",
+        "accept-language-parser": "1.5.0",
         "bluebird": "3.7.2",
-        "body-parser": "~1.20.3",
-        "cookie-parser": "~1.4.6",
-        "express": "^4.21.2",
-        "express-session": "~1.18.0",
-        "express-static-gzip": "~2.1.7",
-        "graceful-fs": "~4.2.11",
-        "ipaddr.js": "~2.1.0",
+        "body-parser": "1.20.3",
+        "cookie-parser": "1.4.7",
+        "express": "4.21.2",
+        "express-session": "1.18.2",
+        "express-static-gzip": "2.1.7",
+        "graceful-fs": "4.2.11",
+        "ipaddr.js": "2.1.0",
         "node-forge": "1.4.0",
-        "semver": "~7.6.0",
+        "semver": "7.6.2",
         "undici": "6.24.1",
-        "ws": "^6.2.3",
-        "yaml": "~2.4.1",
-        "yauzl": "~3.1.2"
+        "ws": "6.2.3",
+        "yaml": "2.4.5",
+        "yauzl": "3.1.3"
       },
       "devDependencies": {
         "@types/connect": "3.4.35",
         "@types/express": "4.17.17",
         "@types/express-serve-static-core": "4.17.35",
         "@types/mime": "3.0.1",
-        "@types/node": "~16.18.0",
+        "@types/node": "16.18.98",
         "@types/qs": "6.9.3",
-        "chai": "~4.2.0",
-        "mocha": "^11.2.2",
-        "typescript": "~5.0.0"
+        "chai": "4.2.0",
+        "mocha": "11.2.2",
+        "typescript": "5.0.4"
       },
       "optionalDependencies": {
-        "fsevents": "~2.3.2",
-        "keyring_js": "~1.1.0"
+        "fsevents": "2.3.3",
+        "keyring_js": "1.1.0"
       }
     },
     "node_modules/@apidevtools/json-schema-ref-parser": {

--- a/package.json
+++ b/package.json
@@ -38,38 +38,38 @@
   },
   "dependencies": {
     "@apidevtools/swagger-parser": "12.1.0",
-    "@rocketsoftware/eureka-js-client": "^4.5.9",
-    "@rocketsoftware/express-ws": "^5.0.1",
-    "accept-language-parser": "~1.5.0",
+    "@rocketsoftware/eureka-js-client": "4.5.9",
+    "@rocketsoftware/express-ws": "5.0.1",
+    "accept-language-parser": "1.5.0",
     "bluebird": "3.7.2",
-    "body-parser": "~1.20.3",
-    "cookie-parser": "~1.4.6",
-    "express": "^4.21.2",
-    "express-session": "~1.18.0",
-    "express-static-gzip": "~2.1.7",
-    "graceful-fs": "~4.2.11",
-    "ipaddr.js": "~2.1.0",
+    "body-parser": "1.20.3",
+    "cookie-parser": "1.4.7",
+    "express": "4.21.2",
+    "express-session": "1.18.2",
+    "express-static-gzip": "2.1.7",
+    "graceful-fs": "4.2.11",
+    "ipaddr.js": "2.1.0",
     "node-forge": "1.4.0",
-    "semver": "~7.6.0",
+    "semver": "7.6.2",
     "undici": "6.24.1",
-    "ws": "^6.2.3",
-    "yaml": "~2.4.1",
-    "yauzl": "~3.1.2"
+    "ws": "6.2.3",
+    "yaml": "2.4.5",
+    "yauzl": "3.1.3"
   },
   "devDependencies": {
     "@types/connect": "3.4.35",
     "@types/express": "4.17.17",
     "@types/express-serve-static-core": "4.17.35",
     "@types/mime": "3.0.1",
-    "@types/node": "~16.18.0",
+    "@types/node": "16.18.98",
     "@types/qs": "6.9.3",
-    "chai": "~4.2.0",
-    "mocha": "^11.2.2",
-    "typescript": "~5.0.0"
+    "chai": "4.2.0",
+    "mocha": "11.2.2",
+    "typescript": "5.0.4"
   },
   "optionalDependencies": {
-    "fsevents": "~2.3.2",
-    "keyring_js": "~1.1.0"
+    "fsevents": "2.3.3",
+    "keyring_js": "1.1.0"
   },
   "overrides": {
     "@rocketsoftware/eureka-js-client": {


### PR DESCRIPTION
This PR sets all package.json versions to what was found in package-lock.json to set a baseline for specific versions rather than relying on version ranges.

Next, I've added the workflow action zowe-actions/shared-actions/validate-package-json@main
enforces this and also enforces that packages are at least a week old.