### PR TITLE
Update webserver.js for ipv4-ipv6 binding fix

### DIFF
--- a/lib/assets/i18n/log/messages_en.json
+++ b/lib/assets/i18n/log/messages_en.json
@@ -310,6 +310,7 @@
   "ZWED0178W":"Skipping authentication plugin %s because it's not HA compatible",
   "ZWED0179W":"Unable to retrieve the list of certificate authorities from the keyring=%s owner=%s Error: %s",
   "ZWED0180W":"Failed to query discovery server (%s:%s) for agent access: %s",
+  "ZWED0181W":"IPv6 address %s is unavailable on this system, retrying with IPv4 fallback %s on port %s",
 
   "ZWED0001E":"RESERVED: Error: %s",
   "ZWED0002E":"Could not stop language manager for types=%s",

--- a/lib/webserver.js
+++ b/lib/webserver.js
@@ -251,7 +251,7 @@ WebServer.prototype = {
   expressWsHttps: [],
   expressWsHttp: [],
 
-  _setErrorLogger(server, type, ipAddress, port) {
+  _setErrorLogger(server, type, ipAddress, port, onAddressNotAvailable) {
     //the server object will not tell the ipAddr & port unless it has successfully connected,
     //making logging poor unless passed
     server.on('error',(e)=> {
@@ -266,8 +266,12 @@ WebServer.prototype = {
         break;
       case 'ENOTFOUND':
       case 'EADDRNOTAVAIL':
-        networkLogger.severe(`ZWED0005E`, ipAddress, port); //networkLogger.severe(`Could not listen on address ${ipAddress}:${port}. Invalid IP for this system.`);
-        process.exit(constants.EXIT_HTTPS_LOAD);
+        if (onAddressNotAvailable) {
+          onAddressNotAvailable();
+        } else {
+          networkLogger.severe(`ZWED0005E`, ipAddress, port); //networkLogger.severe(`Could not listen on address ${ipAddress}:${port}. Invalid IP for this system.`);
+          process.exit(constants.EXIT_HTTPS_LOAD);
+        }
         break;
       default:
         networkLogger.warn(`ZWED0071W`, ipAddress, port, e.message, e.stack); //networkLogger.warn(`Unexpected error on server ${ipAddress}:${port}. E=${e}. Stack trace follows.`);
@@ -451,20 +455,44 @@ WebServer.prototype = {
     }
   },  
 
+  _attachServer(webapp, server, serverList, wsList) {
+    serverList.push(server);
+    webapp.expressWs = expressWs(webapp.expressApp, server, {maxPayload: 50000});
+    wsList.push(webapp.expressWs);
+  },
+
+  _removeServer(webapp, server, serverList, wsList) {
+    const serverIndex = serverList.indexOf(server);
+    if (serverIndex >= 0) { serverList.splice(serverIndex, 1); }
+    const wsIndex = wsList.indexOf(webapp.expressWs);
+    if (wsIndex >= 0) { wsList.splice(wsIndex, 1); }
+  },
+
+  _makeFallbackCallback(webapp, createServer, serverList, wsList, httpMethod, httpMethodLabel, ipAddress, port) {
+    const ipv4FallbackAddress = WebServer.ipv4Fallback(ipAddress);
+    if (!ipv4FallbackAddress) { return null; }
+    const self = this;
+    return function(failedServer) {
+      networkLogger.warn('ZWED0181W', ipAddress, ipv4FallbackAddress, port);
+      self._removeServer(webapp, failedServer, serverList, wsList);
+      const newServer = createServer();
+      self._attachServer(webapp, newServer, serverList, wsList);
+      self._setErrorLogger(newServer, httpMethodLabel, ipv4FallbackAddress, port);
+      self.callListen(newServer, httpMethod, httpMethodLabel, ipv4FallbackAddress, port);
+    };
+  },
+
   startListening: Promise.coroutine(function* (webapp) {
     if (this.config.https && this.config.https.port) {
       const port = this.config.https.port;
+      const httpsOptions = this.getServerTlsOptions();
       for (let ipAddress of this.config.https.ipAddresses) {
         let listening = false;
         let httpsServer;
-        const httpsOptions = this.getServerTlsOptions();
         while (!listening) {
           try {
             httpsServer = https.createServer(httpsOptions, webapp.expressApp);
-            this._setErrorLogger(httpsServer, 'HTTPS', ipAddress, port);
-            this.httpsServers.push(httpsServer);
-            webapp.expressWs = expressWs(webapp.expressApp, httpsServer, {maxPayload: 50000});
-            this.expressWsHttps.push(webapp.expressWs);
+            this._attachServer(webapp, httpsServer, this.httpsServers, this.expressWsHttps);
             listening = true;
           } catch (e) {
             if (e.message == 'mac verify failure') {
@@ -480,6 +508,13 @@ WebServer.prototype = {
             }
           }
         }
+        const ipv4FallbackCallback = this._makeFallbackCallback(webapp,
+          () => https.createServer(httpsOptions, webapp.expressApp),
+          this.httpsServers, this.expressWsHttps, 'https', 'HTTPS', ipAddress, port);
+        const onAddressNotAvailable = ipv4FallbackCallback ? (function(server, callback) {
+          return function() { callback(server); };
+        }(httpsServer, ipv4FallbackCallback)) : null;
+        this._setErrorLogger(httpsServer, 'HTTPS', ipAddress, port, onAddressNotAvailable);
         this.callListen(httpsServer, 'https', 'HTTPS', ipAddress, port);
       }
     }
@@ -487,10 +522,14 @@ WebServer.prototype = {
       const port = this.config.http.port;
       for (let ipAddress of this.config.http.ipAddresses) {
         let httpServer = http.createServer(webapp.expressApp);
-        this._setErrorLogger(httpServer, 'HTTP', ipAddress, port);
-        this.httpServers.push(httpServer);
-        webapp.expressWs = expressWs(webapp.expressApp, httpServer, {maxPayload: 50000});
-        this.expressWsHttp.push(webapp.expressWs);
+        this._attachServer(webapp, httpServer, this.httpServers, this.expressWsHttp);
+        const ipv4FallbackCallback = this._makeFallbackCallback(webapp,
+          () => http.createServer(webapp.expressApp),
+          this.httpServers, this.expressWsHttp, 'http', 'HTTP', ipAddress, port);
+        const onAddressNotAvailable = ipv4FallbackCallback ? (function(server, callback) {
+          return function() { callback(server); };
+        }(httpServer, ipv4FallbackCallback)) : null;
+        this._setErrorLogger(httpServer, 'HTTP', ipAddress, port, onAddressNotAvailable);
         this.callListen(httpServer, 'http', 'HTTP', ipAddress, port);
       }
     }
@@ -526,6 +565,12 @@ WebServer.prototype = {
       server.close();      
     });
   }
+};
+
+WebServer.ipv4Fallback = function(address) {
+  if (address === '::') { return '0.0.0.0'; }
+  const m = address.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/i);
+  return m ? m[1] : null;
 };
 
 module.exports = WebServer;


### PR DESCRIPTION
I found a situation on my system where it appears that although app-server can talk to and bind to ipv6 addresses, the default '0.0.0.0' bind address is interpreted differently on nodejs than other langauges on zos. If other servers wish to talk to :ffff:0.0.0.0, this can fail.

Take a situation where zss needs to talk to app-server, for example.

Node.js interprets 0.0.0.0 as AF_INET on z/OS (pure IPv4), creating the listener at 0.0.0.0..7556. ZSS's C HTTP client uses AF_INET6 (it calls getaddrinfo with AI_V4MAPPED, gets ::ffff:<my ipv4>, creates an AF_INET6 socket, and tries to connect). On z/OS, an AF_INET6 socket appears to not be able to connect to an AF_INET listener.

The result, even though both servers are available, they can't talk to each other.

This fixes it by preferring ipv6 binds, but falling back to ipv4.

If a :: or :ffff: ip is given, we bind to that, unless it fails, at which point we retry the ipv4 equivalent.

Utilizes pr https://github.com/zowe/zlux-app-server/pull/374