### PR TITLE
Remove full process.env exposure from /server/environment endpoint

### DIFF
--- a/lib/webapp.js
+++ b/lib/webapp.js
@@ -236,17 +236,21 @@ function getUserEnv(rbac, zoweConfig){
     const serverConfig = zoweConfig.components['app-server'];
     const nodeConfig = serverConfig.node;
     if (rbac) {
+      const filteredEnv = {};
+      Object.keys(process.env).forEach(key => {
+        if (key.startsWith('ZWE_') || key.startsWith('ZWED_')) {
+          filteredEnv[key] = process.env[key];
+        }
+      });
       resolve({
         "timestamp": date.toUTCString(),
-        "args": process.argv,
-        "nodeArgs": process.execArgv,
         "platform": process.platform,
         "arch": arch,
         "osRelease": release,
         "cpus": cpus,
         "freeMemory": os.freemem(),
         "hostname": hostname,
-        "userEnvironment": process.env,
+        "userEnvironment": filteredEnv,
         // Flag to show or hide 'Change Password' option in Personalization Panel.
         "enablePasswordChange": serverConfig.enablePasswordChange ?? true,
         "agent": {


### PR DESCRIPTION
When RBAC is enabled, [/server/environment](vscode-file://vscode-app/c:/Users/jstruga/AppData/Local/Programs/Microsoft%20VS%20Code/4fe60c8b1c/resources/app/out/vs/code/electron-browser/workbench/workbench.html) dumps the entire [process.env](vscode-file://vscode-app/c:/Users/jstruga/AppData/Local/Programs/Microsoft%20VS%20Code/4fe60c8b1c/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and [process.argv](vscode-file://vscode-app/c:/Users/jstruga/AppData/Local/Programs/Microsoft%20VS%20Code/4fe60c8b1c/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to authenticated users. This can expose credentials and internal config.

Now only ZWE_* and ZWED_* env vars are returned, and [process.argv](vscode-file://vscode-app/c:/Users/jstruga/AppData/Local/Programs/Microsoft%20VS%20Code/4fe60c8b1c/resources/app/out/vs/code/electron-browser/workbench/workbench.html)/[process.execArgv](vscode-file://vscode-app/c:/Users/jstruga/AppData/Local/Programs/Microsoft%20VS%20Code/4fe60c8b1c/resources/app/out/vs/code/electron-browser/workbench/workbench.html) are removed.