### PR TITLE
Fix WebSocket RBAC bypass in ZSS auth handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to the Zlux Server Framework package will be documented in t
 This repo is part of the app-server Zowe Component, and the change logs here may appear on Zowe.org in that section.
 
 ## 3.6.0
+- Security: Fixed a WebSocket authorization bypass in the ZSS auth handler. When RBAC was enabled, WebSocket dataservice requests skipped the SAF authorization check and were granted to any authenticated user regardless of their SAF profile permissions. The SAF check is now enforced for WebSocket requests.
 - Enhancement: The `/server/environment` response now includes `agent.host`, exposing the effective ZSS/agent hostname (the same value previously returned by the `/server/proxies` endpoint, including the APIML gateway hostname override when agent mediation layer is enabled). This allows plugins to retrieve the agent host through the authenticated `ZoweZLUX.environment.getAgentHost()` API.
 - Bugfix: Removed the unauthenticated `/server/proxies` endpoint. Its only consumers (the TN3270 and VT terminal apps) have been updated to use `ZoweZLUX.environment.getAgentHost()` instead.
 - Moved `trivial-auth` and `internal-auth` authentication plugins to `devPlugins/` directory. These plugins are development/troubleshooting tools that should not ship in production distributions. [(#700)](https://github.com/zowe/zlux-server-framework/pull/700) 

--- a/plugins/sso-auth/lib/zssHandler.js
+++ b/plugins/sso-auth/lib/zssHandler.js
@@ -32,7 +32,6 @@ class ZssHandler {
       const result = { authenticated: false, authorized: false };
       options = options || {};
       try {
-        const { syncOnly } = options;
         let bypassUrls = [
           '/login',
           '/logout',
@@ -76,16 +75,6 @@ class ZssHandler {
         }
         const resourceName = this._makeProfileName(request.originalUrl, 
                                                    request.method);
-        if (syncOnly) {
-          // can't do anything further: the user is authenticated but we can't 
-          // make an actual RBAC check
-          this.logger.info(`Can't make a call to the OS agent for access check. ` +
-                   `Allowing ${sessionState.username} access to ${resourceName} ` +
-                   'unconditinally');
-          result.authorized = true;
-          this.setCookieFromRequest(request, sessionState);
-          return result;
-        }
         this.logger.debug(`Sending isAuthorized request for ${sessionState.username}`);
         const httpResponse = yield this._callAgent(request.zluxData, 
                                                    sessionState.username,  resourceName);

--- a/test/lib/sso-auth/zssHandler-test.js
+++ b/test/lib/sso-auth/zssHandler-test.js
@@ -1,0 +1,76 @@
+/*
+  This program and the accompanying materials are
+  made available under the terms of the Eclipse Public License v2.0 which accompanies
+  this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
+
+  SPDX-License-Identifier: EPL-2.0
+
+  Copyright Contributors to the Zowe Project.
+*/
+
+const assert = require('assert');
+const makeZssHandler = require('../../../plugins/sso-auth/lib/zssHandler.js');
+
+function makeHandler() {
+  const noop = () => {};
+  const context = { logger: { debug: noop, info: noop, warn: noop, error: noop } };
+  const serverConf = {
+    instanceID: '1',
+    cookieIdentifier: 'test',
+    agent: { https: { port: 12345 } }
+  };
+  return makeZssHandler({}, {}, serverConf, context);
+}
+
+// A plugin-service WebSocket URL. req.url would end in ".websocket", which is
+// what used to trigger the fail-open syncOnly branch.
+const WS_URL =
+  '/ZLUX/plugins/org.zowe.terminal.proxy/services/tn3270data/_current/index.websocket';
+
+describe('ZssHandler.authorized (WebSocket RBAC)', function() {
+  it('runs the SAF check for a .websocket URL when RBAC is enabled', async function() {
+    const handler = makeHandler();
+    let agentCalled = false;
+    handler._callAgent = async function() {
+      agentCalled = true;
+      // Simulate a user WITHOUT READ access to the profile.
+      return { statusCode: 200, body: JSON.stringify({ authorized: false, message: 'no access' }) };
+    };
+    const request = { originalUrl: WS_URL, method: 'GET', zluxData: {} };
+    const sessionState = { authenticated: true, username: 'BADUSER' };
+    // syncOnly:true is what the auth middleware passes for a ".websocket" URL.
+    // This is the exact input that used to hit the fail-open branch.
+    const result = await handler.authorized(request, sessionState,
+      { syncOnly: true, bypassAuthorizatonCheck: false });
+
+    assert.strictEqual(agentCalled, true, 'SAF /saf-auth check must run for WebSocket requests');
+    assert.strictEqual(result.authenticated, true);
+    assert.strictEqual(result.authorized, false, 'denied user must NOT be authorized (this is the bug fix)');
+  });
+
+  it('authorizes a .websocket URL when the user has SAF access', async function() {
+    const handler = makeHandler();
+    handler._callAgent = async function() {
+      return { statusCode: 200, body: JSON.stringify({ authorized: true }) };
+    };
+    const request = { originalUrl: WS_URL, method: 'GET', zluxData: {} };
+    const sessionState = { authenticated: true, username: 'GOODUSER' };
+    const result = await handler.authorized(request, sessionState,
+      { syncOnly: true, bypassAuthorizatonCheck: false });
+
+    assert.strictEqual(result.authorized, true);
+  });
+
+  it('short-circuits (no SAF call) when RBAC is disabled', async function() {
+    const handler = makeHandler();
+    let agentCalled = false;
+    handler._callAgent = async function() { agentCalled = true; return {}; };
+    handler.setCookieFromRequest = () => {};
+    const request = { originalUrl: WS_URL, method: 'GET', zluxData: {} };
+    const sessionState = { authenticated: true, username: 'ANYUSER' };
+    const result = await handler.authorized(request, sessionState, { bypassAuthorizatonCheck: true });
+
+    assert.strictEqual(agentCalled, false, 'RBAC disabled must not call the agent');
+    assert.strictEqual(result.authorized, true);
+  });
+});


### PR DESCRIPTION
<!-- Thank you for submitting a PR to Zowe! To help us understand, test, and give feedback on your code, please fill in the details below. -->

## Proposed changes

This PR fixes a WebSocket authorization bypass in the ZSS (`sso-auth`) handler.

`webauth.middleware` sets `syncOnly = req.url.endsWith(".websocket")`. When ZSS is the active auth handler and RBAC is enabled, `ZssHandler.authorized()` reached the `syncOnly` branch and unconditionally set `result.authorized = true` for any authenticated user, skipping the `/saf-auth` SAF check entirely. As a result, every WebSocket-based dataservice (terminal-proxy, ws proxies, plugin ws routers) was reachable by any authenticated user regardless of their SAF profile permissions.

Because `authorized()` is an async coroutine that is `yield`ed (awaited) by the auth middleware, and `_callAgent()` returns a promise, the real SAF authorization check can be performed for WebSocket requests too. This PR removes the fail-open `syncOnly` branch so the code proceeds to the actual `/saf-auth` check, and removes the now-unused `syncOnly` destructuring. Any error in the surrounding `try/catch` now fails closed (`authorized = false`).

CVSS 3.1 - 8.1 :: AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:N

This PR addresses Issue: [*Link to Github issue within https://github.com/zowe/zlux/issues* if any]

This PR depends upon the following PRs: N/A

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

## PR Checklist
Please delete options that are not relevant.
- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zlux/blob/master/CONTRIBUTING.md))
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
- [ ] Relevant update to CHANGELOG.md
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works, or describe a test method below

## Testing

With `components.app-server.dataserviceAuthentication.rbac: true` and the ZSS/`sso-auth` handler active:

1. Log in as a user who does NOT have the SAF profile READ access for a WebSocket-backed dataservice (e.g. terminal-proxy).
2. Attempt to open the WebSocket connection (URL ending in `.websocket`).
   - Before this fix: the connection is authorized (bypass) despite lacking SAF access.
   - After this fix: the `/saf-auth` check runs; the request is rejected (403) when the user lacks the profile.
3. Log in as a user who DOES have READ access to the profile and confirm the WebSocket connection is authorized.
4. With `rbac: false` (default), confirm WebSocket dataservices still work unchanged (authorization is short-circuited earlier via `bypassAuthorizatonCheck`).

## Further comments

The `syncOnly` flag was originally used to skip the RBAC check on the assumption that an async agent call could not be made during WebSocket handling. That assumption is not accurate here: the auth middleware already awaits `authorized()`, so the SAF call completes correctly for WebSocket requests. The fix keeps behavior identical when RBAC is disabled and only changes the RBAC-enabled WebSocket path from failing open to enforcing the SAF check.