### PR TITLE
Remove obsolete Referer-based proxy fallback in error handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This repo is part of the app-server Zowe Component, and the change logs here may
 - Bugfix: Removed the unauthenticated `/server/proxies` endpoint, which has been replaced with the `/server/environment` values. [(#703)](https://github.com/zowe/zlux-server-framework/pull/703) 
 - Moved `trivial-auth` and `internal-auth` authentication plugins to `devPlugins/` directory. These plugins are development/troubleshooting tools that should not ship in production distributions. [(#700)](https://github.com/zowe/zlux-server-framework/pull/700) 
 - Security: Remove obsolete 'encryption.js' file which was a thin wrapper for `node:crypto` functions, some of which have already been removed from node starting version 22. Users of this api should migrate to using `node:crypto` directly. [(#705)](https://github.com/zowe/zlux-server-framework/pull/705) 
+- Security: Removed obsolete Referer-based proxy fallback in the catch-all error handler. This path could route unauthenticated requests with a forged Referer header to external plugin proxies. Unmatched requests now consistently return a 404.
 
 ## 3.5.0
 - Enhancement: Improved SSH connection performance restoring use of Node.js built-in diffie-hellman logic. [(#669)](https://github.com/zowe/zlux-server-framework/pull/669) 

--- a/lib/webapp.js
+++ b/lib/webapp.js
@@ -73,7 +73,6 @@ const LOG_LEVEL_MAX = 5;
 const jsonParser = bodyParser.json()
 const urlencodedParser = bodyParser.urlencoded({ extended: false })
 const ZLUX_LOOPBACK_HEADER = 'X-ZLUX-Loopback';
-const proxyMap = new Map();
 const pluginsArray = [];
 
 function DataserviceContext(serviceDefinition, serviceConfiguration, 
@@ -1437,7 +1436,6 @@ WebApp.prototype = {
       allowInvalidTLSProxy: this.options.componentConfig.node.allowInvalidTLSProxy,
       tlsOptions: tlsOptions
     }, pluginID, serviceName);
-    proxyMap.set(pluginID + ":" + serviceName, myProxy);
     r.use(myProxy);
     return r;
   },
@@ -2015,46 +2013,8 @@ WebApp.prototype = {
 
   installErrorHanders() {
     this.expressApp.use((req, res, next) => {
-      const headers = req.headers
-      let referrerPresent = false;
-      for (const header of Object.keys(headers)) {
-        /* Try to find a referer header and try to
-         * redirect to our server,
-         */
-        if (header == 'referer') {
-          referrerPresent = true;
-          let referrer = headers[header];
-          var pattern = new RegExp('^http.+\/'+this.options.componentConfig.node.productCode+'\/plugins\/.+');
-          if (pattern.test(referrer)) {
-            const parts = headers[header].split("/");
-            const zluxIndex = parts.indexOf(this.options.componentConfig.node.productCode);
-            const pluginID = parts[zluxIndex + 2];
-            const serviceName = parts[zluxIndex + 4];
-            const myProxy = proxyMap.get(pluginID + ":" + serviceName);
-            const fullUrl = req.originalUrl;
-            req.url = fullUrl;
-            if (myProxy != undefined) {
-              utilLog.debug("ZWED0201I"); //utilLog.debug("About to call myProxy");
-              myProxy(req, res);
-              utilLog.debug("ZWED0202I"); //utilLog.debug("After myProxy call");
-            } else {
-              utilLog.debug("ZWED0203I", referrer); //utilLog.debug(`Referrer proxying miss. Resource not found, sending`
-                  //+ ` 404 because referrer (${referrer}) didn't match an existing proxy service`);
-              return do404(req.url, res, this.options.componentConfig.node.productCode
-                  + ": unknown resource requested");
-            }
-          } else {
-            utilLog.debug(`ZWED0204I`, referrer); //utilLog.debug(`Referrer proxying miss. Resource not found, sending`
-                  //+ ` 404 because referrer (${referrer}) didn't match a plugin pattern`);               
-            return do404(req.url, res, this.options.componentConfig.node.productCode + ": unknown resource requested");
-          }
-          break;
-        }
-      }
-      if (!referrerPresent) {
-        return do404(req.url, res, this.options.componentConfig.node.productCode
-                     + ": unknown resource requested");
-      }
+      return do404(req.url, res, this.options.componentConfig.node.productCode
+                   + ": unknown resource requested");
     });
   },
 


### PR DESCRIPTION
The catch-all error handler parsed the Referer header and routed matching requests directly to external plugin proxies via proxyMap, bypassing auth middleware. An unauthenticated client with a forged Referer header could reach any external-type plugin proxy. This obsolete code is removed so unmatched requests consistently return a 404.

## Proposed changes

This PR removes the obsolete Referer-based proxy fallback from the catch-all error handler in `lib/webapp.js`. Previously, when a request matched no route, the handler inspected the `Referer` header; if it matched `^http.+//<productCode>/plugins/.+` it extracted a `pluginID:serviceName`, looked the entry up in `proxyMap` (populated by `makeExternalProxy`), and invoked the proxy directly. This path never passed through `this.auth.middleware`, so an unauthenticated client with a forged `Referer` header could reach any registered external-type plugin proxy (host/port defined by the plugin) using the App Server as the origin.

The Referer-based routing is obsolete and has been removed. Unmatched requests now consistently return a 404. The now-unused `proxyMap` map and its population in `makeExternalProxy` were also removed; external proxies continue to work through their existing router registration (`r.use(myProxy)`).


This PR depends upon the following PRs: N/A

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## PR Checklist

- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zlux/blob/master/CONTRIBUTING.md))
- [x] Relevant update to CHANGELOG.md
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Testing

Verify that a request to any unrouted URL that carries a `Referer` header matching `http.../<productCode>/plugins/...` no longer reaches an external plugin proxy and instead receives a 404:

1. Configure an external-type plugin proxy (host/port defined in the plugin).
2. Without authenticating, send a request to a URL that matches no route, with a forged `Referer` header pointing at that plugin's service (e.g. `Referer: https://host/<productCode>/plugins/<pluginID>/services/<serviceName>`).
3. Confirm the response is a 404 and the request is not proxied to the external host.
4. Confirm legitimate authenticated access to the external plugin proxy through its normal route still works.

## Further comments

The fix is a straightforward removal of dead, insecure code. Cookie `SameSite` handling already covers the cross-site scenario this Referer logic was originally intended for, so no replacement behavior is required.