### PR TITLE
Enforce authentication on Referer-based proxy fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to the Zlux Server Framework package will be documented in t
 This repo is part of the app-server Zowe Component, and the change logs here may appear on Zowe.org in that section.
 
 ## 3.6.0
+- Security: The Referer-based proxy fallback in the catch-all error handler now enforces authentication before forwarding a request to an external-type plugin proxy. Previously a request with a forged Referer header could reach a registered external proxy without passing through the authentication middleware.
 - Enhancement: The `/server/environment` response now includes `agent.host`. This allows plugins to retrieve the agent hostname through the authenticated `ZoweZLUX.environment.getAgentHost()` API. [(#703)](https://github.com/zowe/zlux-server-framework/pull/703) 
 - Bugfix: Removed the unauthenticated `/server/proxies` endpoint, which has been replaced with the `/server/environment` values. [(#703)](https://github.com/zowe/zlux-server-framework/pull/703) 
 - Moved `trivial-auth` and `internal-auth` authentication plugins to `devPlugins/` directory. These plugins are development/troubleshooting tools that should not ship in production distributions. [(#700)](https://github.com/zowe/zlux-server-framework/pull/700) 

--- a/lib/webapp.js
+++ b/lib/webapp.js
@@ -2035,8 +2035,12 @@ WebApp.prototype = {
             req.url = fullUrl;
             if (myProxy != undefined) {
               utilLog.debug("ZWED0201I"); //utilLog.debug("About to call myProxy");
-              myProxy(req, res);
-              utilLog.debug("ZWED0202I"); //utilLog.debug("After myProxy call");
+              //Authenticate before proxying. The auth middleware sends its own
+              //401/403 response on failure, so myProxy only runs once authorized.
+              this.auth.middleware(req, res, () => {
+                myProxy(req, res);
+                utilLog.debug("ZWED0202I"); //utilLog.debug("After myProxy call");
+              });
             } else {
               utilLog.debug("ZWED0203I", referrer); //utilLog.debug(`Referrer proxying miss. Resource not found, sending`
                   //+ ` 404 because referrer (${referrer}) didn't match an existing proxy service`);


### PR DESCRIPTION
## Proposed changes

The catch-all error handler in `lib/webapp.js` (`installErrorHanders`) implements a Referer-based proxy fallback: for any request that matched no route, it parses the `Referer` header, and if it matches `^http.+//<productCode>/plugins/.+` it extracts `pluginID:serviceName`, looks up the entry in `proxyMap`, and calls the proxy directly.


This PR addresses Issue: N/A

This PR depends upon the following PRs: None

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## PR Checklist

- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zlux/blob/master/CONTRIBUTING.md))
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Relevant update to `CHANGELOG.md`
- [x] My changes generate no new warnings

## Testing

1. Register a plugin with an `external`-type service so an entry is added to `proxyMap`.
2. Without authenticating, send a request to a non-existent path with a forged header `Referer: https://<host>/<productCode>/plugins/<pluginID>/services/<serviceName>/`.
3. Before this change, the request was forwarded to the external host/port. After this change, the request is rejected with 401/403 by the auth middleware.
4. Confirm that an authenticated request through the normal plugin service URL still proxies successfully.

## Further comments

The fix reuses the existing `this.auth.middleware` rather than adding a bespoke check, keeping the authentication logic consistent with the normal proxy install path in `_makeRouter`.