### PR TITLE
Ensure auth is used in proxying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This repo is part of the app-server Zowe Component, and the change logs here may
 
 ## 3.6.0
 
+- Bugfix: The Referer-based proxy fallback in the catch-all error handler now enforces authentication before forwarding a request to an external-type plugin proxy. [(#715)](https://github.com/zowe/zlux-server-framework/pull/715)
 - Enhancement: RBAC is can now be used on for WebSocket dataservices, which will use the 'GET' method for SAF profiles. [(#710)](https://github.com/zowe/zlux-server-framework/pull/710)
 - Enhancement: Verify RBAC is enabled for instance and site scope plugin configuration updating. [(#704)](https://github.com/zowe/zlux-server-framework/pull/704)
 - Enhancement: The `/server/environment` response now includes `agent.host`. This allows plugins to retrieve the agent hostname through the authenticated `ZoweZLUX.environment.getAgentHost()` API. [(#703)](https://github.com/zowe/zlux-server-framework/pull/703) 

--- a/lib/webapp.js
+++ b/lib/webapp.js
@@ -2037,12 +2037,21 @@ WebApp.prototype = {
             const pluginID = parts[zluxIndex + 2];
             const serviceName = parts[zluxIndex + 4];
             const myProxy = proxyMap.get(pluginID + ":" + serviceName);
+            //find the actual dataservice def so auth can be enforced the same as the normal proxy route
+            const targetPlugin = pluginsArray.find(p => p.identifier === pluginID);
+            const serviceGroup = targetPlugin?.dataServicesGrouped?.[serviceName];
+            const service = serviceGroup?.versions?.[serviceGroup.highestVersion];
             const fullUrl = req.originalUrl;
             req.url = fullUrl;
-            if (myProxy != undefined) {
-              utilLog.debug("ZWED0201I"); //utilLog.debug("About to call myProxy");
-              myProxy(req, res);
-              utilLog.debug("ZWED0202I"); //utilLog.debug("After myProxy call");
+            if (myProxy != undefined && service && service.type === 'external') {
+              const appData = req[`${constants.APP_NAME}Data`];
+              appData.plugin.def = targetPlugin;
+              appData.service.def = service;
+              this.auth.middleware(req, res, () => {
+                utilLog.debug("ZWED0201I"); //utilLog.debug("About to call myProxy");
+                myProxy(req, res);
+                utilLog.debug("ZWED0202I"); //utilLog.debug("After myProxy call");
+              });
             } else {
               utilLog.debug("ZWED0203I", referrer); //utilLog.debug(`Referrer proxying miss. Resource not found, sending`
                   //+ ` 404 because referrer (${referrer}) didn't match an existing proxy service`);

--- a/test/lib/fixtures/webapp-external-proxy-plugin.json
+++ b/test/lib/fixtures/webapp-external-proxy-plugin.json
@@ -1,0 +1,16 @@
+{
+  "identifier": "org.zowe.proxyfallbacktest",
+  "apiVersion": "1.0.0",
+  "pluginVersion": "1.0.0",
+  "pluginType": "application",
+  "dataServices": [
+    {
+      "type": "external",
+      "name": "extsvc",
+      "version": "1.0.0",
+      "host": "127.0.0.1",
+      "port": 0,
+      "urlPrefix": "/"
+    }
+  ]
+}

--- a/test/lib/webapp.js
+++ b/test/lib/webapp.js
@@ -1,4 +1,10 @@
 const assert = require('assert');
+const http = require('http');
+const sinon = require('sinon');
+const { Writable } = require('stream');
+const constants = require('../../lib/unp-constants');
+const PluginLoader = require('../../lib/plugin-loader');
+const externalProxyPluginDef = require('./fixtures/webapp-external-proxy-plugin.json');
 
 describe('webapp', function () {
   let webapp;
@@ -19,5 +25,179 @@ describe('webapp', function () {
   it('should export expected interface', function () {
     const exportType = typeof webapp;
     assert.ok(exportType === 'object' || exportType === 'function', 'should export object or function');
+  });
+
+  describe('installErrorHanders() referer-based proxy fallback', function () {
+    const productCode = 'XXX';
+    const pluginId = externalProxyPluginDef.identifier;
+    const serviceName = externalProxyPluginDef.dataServices[0].name;
+    const appDataKey = `${constants.APP_NAME}Data`;
+
+    let targetServer;
+    let targetRequestCount;
+    let webApp;
+    let fallbackHandler;
+    let authMiddlewareSpy;
+
+    function zoweConfigFor() {
+      return {
+        zowe: {
+          cookieIdentifier: 'test',
+          externalDomains: ['localhost']
+        },
+        components: {
+          'app-server': {
+            productDir: __dirname,
+            checkReferrer: {},
+            dataserviceAuthentication: { rbac: false, defaultAuthentication: 'fallback' },
+            enablePasswordChange: true,
+            node: {
+              productCode: productCode,
+              http: { port: 0, ipAddresses: [] },
+              https: {},
+              checkReferrer: {},
+              mediationLayer: { enabled: false, server: { gatewayPort: 7554, gatewayHostname: 'localhost' } },
+              allowInvalidTLSProxy: true
+            }
+          }
+        }
+      };
+    }
+
+    before(function (done) {
+      targetRequestCount = 0;
+      targetServer = http.createServer(function (req, res) {
+        targetRequestCount++;
+        res.writeHead(200, { 'Content-Type': 'text/plain' });
+        res.end('proxied-ok');
+      });
+      targetServer.listen(0, '127.0.0.1', function () {
+        const targetPort = targetServer.address().port;
+
+        const def = JSON.parse(JSON.stringify(externalProxyPluginDef));
+        def.dataServices[0].port = targetPort;
+        const makePluginContext = { productCode: productCode, config: {}, authManager: {} };
+        const plugin = PluginLoader.makePlugin(def, {}, makePluginContext, false);
+        const pluginContext = {
+          pluginDef: plugin,
+          server: {
+            config: { app: {}, user: { node: { http: { port: 1 } } }, startUp: {} },
+            state: { pluginMap: {} }
+          }
+        };
+
+        authMiddlewareSpy = sinon.stub().callsFake(function (req, res, next) { next(); });
+
+        const makeWebApp = require('../../lib/webapp').makeWebApp;
+        webApp = makeWebApp({
+          zoweConfig: zoweConfigFor(),
+          port: 31390,
+          isHttps: false,
+          proxiedHost: 'localhost',
+          proxiedPort: 1,
+          auth: {
+            doLogin() {}, doPasswordReset() {}, getStatus() {}, doLogout() {}, refreshStatus() {},
+            semiAuthenticatedMiddleware(r, re, next) { next(); },
+            addProxyAuthorizations() {},
+            processProxiedHeaders(req, headers) { return headers; },
+            middleware: authMiddlewareSpy
+          }
+        });
+
+        webApp.installPlugin(pluginContext).then(function () {
+          webApp.installRootServices();
+          webApp.injectPluginRouter();
+
+          // capture the catch-all handler instead of letting it register on the shared expressApp
+          const useStub = sinon.stub(webApp.expressApp, 'use').callsFake(function (fn) {
+            fallbackHandler = fn;
+          });
+          webApp.installErrorHanders();
+          useStub.restore();
+
+          done();
+        }).catch(done);
+      });
+    });
+
+    after(function (done) {
+      targetServer.close(done);
+    });
+
+    beforeEach(function () {
+      authMiddlewareSpy.resetHistory();
+      authMiddlewareSpy.callsFake(function (req, res, next) { next(); });
+      targetRequestCount = 0;
+    });
+
+    function makeReq(referer, url) {
+      const req = {
+        headers: { referer: referer, host: 'localhost' },
+        url: url,
+        originalUrl: url,
+        method: 'GET',
+        protocol: 'http',
+        get(header) { return this.headers[header.toLowerCase()]; }
+      };
+      req[appDataKey] = { plugin: {}, service: {}, webApp: {} };
+      return req;
+    }
+
+    function makeRes(onFinish) {
+      const chunks = [];
+      let statusCode = null;
+      const res = new Writable({
+        write(chunk, encoding, callback) { chunks.push(chunk); callback(); }
+      });
+      res.status = function (code) { statusCode = code; return res; };
+      res.set = function () { return res; };
+      res.json = function (body) { res.end(JSON.stringify(body)); return res; };
+      res.send = function (body) { res.end(body); return res; };
+      res.on('finish', function () { onFinish(statusCode, Buffer.concat(chunks).toString()); });
+      return res;
+    }
+
+    it('runs auth.middleware with the resolved plugin/service before proxying an authorized request', function (done) {
+      const referer = `http://localhost/${productCode}/plugins/${pluginId}/services/${serviceName}/legacy/broken/path`;
+      const req = makeReq(referer, '/legacy/broken/path');
+      const res = makeRes(function (status, body) {
+        assert.strictEqual(authMiddlewareSpy.called, true, 'auth.middleware should have been invoked');
+        const authedReq = authMiddlewareSpy.firstCall.args[0];
+        assert.strictEqual(authedReq[appDataKey].plugin.def.identifier, pluginId);
+        assert.strictEqual(authedReq[appDataKey].service.def.name, serviceName);
+        assert.strictEqual(status, 200);
+        assert.strictEqual(body, 'proxied-ok');
+        assert.strictEqual(targetRequestCount, 1);
+        done();
+      });
+      fallbackHandler(req, res, function () {});
+    });
+
+    it('does not proxy when auth.middleware denies the request', function (done) {
+      authMiddlewareSpy.callsFake(function (req, res, next) {
+        res.status(401).json({ error: 'unauthorized' });
+      });
+      const referer = `http://localhost/${productCode}/plugins/${pluginId}/services/${serviceName}/legacy/broken/path`;
+      const req = makeReq(referer, '/legacy/broken/path');
+      const res = makeRes(function (status, body) {
+        assert.strictEqual(authMiddlewareSpy.called, true);
+        assert.strictEqual(status, 401);
+        assert.strictEqual(targetRequestCount, 0, 'the external target should never have been reached');
+        done();
+      });
+      fallbackHandler(req, res, function () {});
+    });
+
+    it('falls back to 404 without invoking auth when the referer does not match a known plugin/service', function (done) {
+      const referer = `http://localhost/${productCode}/plugins/org.zowe.unknownplugin/services/unknownsvc/legacy/broken/path`;
+      const req = makeReq(referer, '/legacy/broken/path');
+      const res = makeRes(function (status) {
+        assert.strictEqual(authMiddlewareSpy.called, false, 'auth.middleware should not run for an unresolved proxy target');
+        assert.strictEqual(status, 404);
+        assert.strictEqual(targetRequestCount, 0);
+        done();
+      });
+      fallbackHandler(req, res, function () {});
+    });
   });
 });


### PR DESCRIPTION
## Proposed changes
This fixes an issue where the proxy-of-last-resort (for references that would otherwise be 404 if incorrectly proxied) did not handle auth properly.



## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

## PR Checklist
Please delete options that are not relevant.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zlux/blob/master/CONTRIBUTING.md))
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works, or describe a test method below

## Testing
<!-- Describe how this code should be tested. I've you've added an automated or unit test, then describe how to run it. Otherwise, describe how you have tested it and how others should test it. -->

Added `test/lib/webapp.js` coverage for `installErrorHanders()`'s proxy fallback, using a new fixture
`test/lib/fixtures/webapp-external-proxy-plugin.json` (a plugin with one `external`-type dataservice)
and a local stub HTTP server standing in for the proxied backend. `options.auth.middleware` is stubbed
with sinon so the tests can assert on both branches without depending on a real auth plugin/session:

1. **Authorized request is still proxied**: `auth.middleware` calls `next()`; asserts it was invoked
   with the correct `plugin.def`/`service.def` resolved, and that the response is the proxied 200 body
   (no functional regression for the legacy path-breakout workaround).
2. **Denied request is never proxied**: `auth.middleware` responds 401 instead of calling `next()`;
   asserts the response is 401 and the stub backend received zero requests (the core regression test
   for the vulnerability).
3. **Unresolvable plugin/service still 404s without invoking auth**: a referer naming an unknown
   plugin/service; asserts a 404 and that `auth.middleware` was never called.

Manual verification (optional, for a real deployment): configure an `external` dataservice with a
specific `authenticationCategory`, then send a request with no session cookie but a forged
`Referer: https://<host>/ZLUX/plugins/<pluginId>/services/<serviceName>/...` header at an unmapped
path — should now get 401/403 instead of being proxied. Repeat with a valid session to confirm the
request is still proxied as before.
